### PR TITLE
Add github action to check that all files are formatted

### DIFF
--- a/.github/actions/clang_format/action.yml
+++ b/.github/actions/clang_format/action.yml
@@ -41,7 +41,7 @@ runs:
           arguments+="-i $sourceFiles "
 
           ERRORS_FILE=${{ inputs.path }}/clang_format_errors.txt
-          clang-format $arguments 2> ${ERRORS_FILE}
+          clang-format $arguments 2>&1 | tee ${ERRORS_FILE}
 
           # Check if there are errors
           if [ -s "${ERRORS_FILE}" ]; then

--- a/.github/actions/clang_format/action.yml
+++ b/.github/actions/clang_format/action.yml
@@ -37,7 +37,7 @@ runs:
           arguments="--dry-run "
 
           # Retrieve all the source files for the desired module
-          sourceFiles=$(find ${{ inputs.path }} -type f \( -name "*.cpp" -o -name "*.hpp" \) | tr '\n' ' ')
+          sourceFiles=$(find ${{ inputs.path }} -type f \( -name '*.[ch]' -o -name "*.cpp" -o -name "*.hpp" \) | tr '\n' ' ')
           arguments+="-i $sourceFiles "
 
           ERRORS_FILE=${{ inputs.path }}/clang_format_errors.txt

--- a/.github/actions/clang_format/action.yml
+++ b/.github/actions/clang_format/action.yml
@@ -12,7 +12,7 @@ inputs:
 
 runs:
   using: "composite"
-  steps:    
+  steps:
       - name: Dependencies for local execution
         if: env.ACT # Only run for local execution
         shell: bash
@@ -22,11 +22,11 @@ runs:
           sudo apt update
 
       # Dependencies for testing:
-      # - clang-format 
+      # - clang-format
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: clang-format 
+          packages: clang-format
           version: 1.0
 
       - name: Check Coding style

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,25 @@
+name: Clang Format Check
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Run Clang Format Check
+      uses: ./.github/actions/clang_format
+      with:
+        path: 'src/'
+        id: 'wazuh-agent'

--- a/src/common/.clang-format
+++ b/src/common/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never

--- a/src/modules/.clang-format
+++ b/src/modules/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never


### PR DESCRIPTION
### Description

This PR introduces a GitHub Action to enforce `clang-format` checks on all C/C++ source and header files, excluding specific directories like `modules` and `common` which bring many legacy files. The action runs on every push and pull request to ensure code consistency and style adherence across the repository.

#### Key Features:
- **Automatic Formatting Checks**: The action runs `clang-format` in dry-run mode with `-Werror` to identify and report formatting issues.
- **Detailed Feedback**: Integrates `clang-tidy` to provide specific rule violations and detailed feedback on formatting issues.

#### Usage Tips:
- **Git Integration**: You can use `git clang-format` to format staged files before committing. This helps to ensure that your changes adhere to the project's formatting rules.
  ```sh
  git clang-format
  ```
- **Ignoring Blocks of Code**: To ignore specific blocks of code from being formatted, you can use `// clang-format off` and `// clang-format on` comments around the code block.
  ```cpp
  // clang-format off
  void unformatted_function() {
      int         x = 0;
      int         y = 0;
      std::cout << "This code block will not be formatted." << std::endl;
  }
  // clang-format on
  ```

This integration will help maintain a consistent code style and improve code readability across the project.
