### PR TITLE
Enhancement/25 communicator module mvp register cli

### DIFF
--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -38,7 +38,7 @@ add_subdirectory(agent_info)
 add_subdirectory(communicator)
 add_subdirectory(configuration_parser)
 
-target_link_libraries(agent PUBLIC ConfigurationParser PRIVATE ${Boost_LIBRARIES} communicator)
+target_link_libraries(agent PUBLIC ConfigurationParser PRIVATE ${Boost_LIBRARIES} communicator AgentInfo)
 
 if(BUILD_TESTS)
     add_subdirectory(tests)

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(Boost REQUIRED COMPONENTS asio)
 target_include_directories(agent PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/communicator/include)
 
 # Add the subdirectory for each child project
+add_subdirectory(agent_info)
 add_subdirectory(communicator)
 add_subdirectory(configuration_parser)
 

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
     src/agent.cpp
     src/message_task.cpp
     src/task_manager.cpp
+    src/register.cpp
 )
 
 set(HEADERS
@@ -23,6 +24,7 @@ set(HEADERS
     include/itask_manager.hpp
     include/task_manager.hpp
     include/message_task.hpp
+    include/register.hpp
 )
 
 add_library(agent ${SOURCES} ${HEADERS})

--- a/src/agent/agent_info/CMakeLists.txt
+++ b/src/agent/agent_info/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.18)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/../../vcpkg/scripts/buildsystems/vcpkg.cmake")
+set(VCPKG_MANIFEST_DIR ${CMAKE_SOURCE_DIR}/../../)
+
+project(AgentInfo)
+
+find_package(SQLiteCpp REQUIRED)
+
+add_library(AgentInfo src/agent_info.cpp src/agent_info_persistance.cpp)
+
+target_include_directories(AgentInfo PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(AgentInfo PRIVATE SQLiteCpp)
+
+if(BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -7,6 +7,10 @@ class AgentInfo
 public:
     AgentInfo();
 
+    std::string GetName() const;
+    std::string GetIP() const;
+    std::string GetUUID() const;
+
 private:
     std::string m_name;
     std::string m_ip;

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -6,6 +6,7 @@ class AgentInfo
 {
 public:
     AgentInfo();
+    AgentInfo(const std::string& name, const std::string& ip, const std::string& uuid);
 
     std::string GetName() const;
     std::string GetIP() const;

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -1,1 +1,14 @@
 #pragma once
+
+#include <string>
+
+class AgentInfo
+{
+public:
+    AgentInfo();
+
+private:
+    std::string m_name;
+    std::string m_ip;
+    std::string m_uuid;
+};

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -11,6 +11,10 @@ public:
     std::string GetIP() const;
     std::string GetUUID() const;
 
+    void SetName(const std::string& name);
+    void SetIP(const std::string& ip);
+    void SetUUID(const std::string& uuid);
+
 private:
     std::string m_name;
     std::string m_ip;

--- a/src/agent/agent_info/include/agent_info_persistance.hpp
+++ b/src/agent/agent_info/include/agent_info_persistance.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/src/agent/agent_info/include/agent_info_persistance.hpp
+++ b/src/agent/agent_info/include/agent_info_persistance.hpp
@@ -21,10 +21,15 @@ public:
     AgentInfoPersistance(AgentInfoPersistance&&) = delete;
     AgentInfoPersistance& operator=(AgentInfoPersistance&&) = delete;
 
+    std::string GetName() const;
+    std::string GetIP() const;
+    std::string GetUUID() const;
+
 private:
     bool AgentInfoTableExists() const;
     void CreateAgentInfoTable();
     void InsertDefaultAgentInfo();
+    std::string GetAgentInfoValue(const std::string& column) const;
 
     std::unique_ptr<SQLite::Database> m_db;
 };

--- a/src/agent/agent_info/include/agent_info_persistance.hpp
+++ b/src/agent/agent_info/include/agent_info_persistance.hpp
@@ -1,1 +1,28 @@
 #pragma once
+
+#include <memory>
+#include <string>
+
+static constexpr char sqlitedb_path[] = "agent_info.db";
+
+namespace SQLite
+{
+    class Database;
+}
+
+class AgentInfoPersistance
+{
+public:
+    explicit AgentInfoPersistance(const std::string& db_path = sqlitedb_path);
+    ~AgentInfoPersistance();
+
+    AgentInfoPersistance(const AgentInfoPersistance&) = delete;
+    AgentInfoPersistance& operator=(const AgentInfoPersistance&) = delete;
+    AgentInfoPersistance(AgentInfoPersistance&&) = delete;
+    AgentInfoPersistance& operator=(AgentInfoPersistance&&) = delete;
+
+private:
+    void CreateAgentInfoTable();
+
+    std::unique_ptr<SQLite::Database> m_db;
+};

--- a/src/agent/agent_info/include/agent_info_persistance.hpp
+++ b/src/agent/agent_info/include/agent_info_persistance.hpp
@@ -24,6 +24,7 @@ public:
 private:
     bool AgentInfoTableExists() const;
     void CreateAgentInfoTable();
+    void InsertDefaultAgentInfo();
 
     std::unique_ptr<SQLite::Database> m_db;
 };

--- a/src/agent/agent_info/include/agent_info_persistance.hpp
+++ b/src/agent/agent_info/include/agent_info_persistance.hpp
@@ -33,6 +33,7 @@ public:
 
 private:
     bool AgentInfoTableExists() const;
+    bool AgentInfoIsEmpty() const;
     void CreateAgentInfoTable();
     void InsertDefaultAgentInfo();
     void SetAgentInfoValue(const std::string& column, const std::string& value);

--- a/src/agent/agent_info/include/agent_info_persistance.hpp
+++ b/src/agent/agent_info/include/agent_info_persistance.hpp
@@ -22,6 +22,7 @@ public:
     AgentInfoPersistance& operator=(AgentInfoPersistance&&) = delete;
 
 private:
+    bool AgentInfoTableExists() const;
     void CreateAgentInfoTable();
 
     std::unique_ptr<SQLite::Database> m_db;

--- a/src/agent/agent_info/include/agent_info_persistance.hpp
+++ b/src/agent/agent_info/include/agent_info_persistance.hpp
@@ -25,6 +25,8 @@ public:
     std::string GetIP() const;
     std::string GetUUID() const;
 
+    void ResetToDefault();
+
 private:
     bool AgentInfoTableExists() const;
     void CreateAgentInfoTable();

--- a/src/agent/agent_info/include/agent_info_persistance.hpp
+++ b/src/agent/agent_info/include/agent_info_persistance.hpp
@@ -25,12 +25,17 @@ public:
     std::string GetIP() const;
     std::string GetUUID() const;
 
+    void SetName(const std::string& name);
+    void SetIP(const std::string& ip);
+    void SetUUID(const std::string& uuid);
+
     void ResetToDefault();
 
 private:
     bool AgentInfoTableExists() const;
     void CreateAgentInfoTable();
     void InsertDefaultAgentInfo();
+    void SetAgentInfoValue(const std::string& column, const std::string& value);
     std::string GetAgentInfoValue(const std::string& column) const;
 
     std::unique_ptr<SQLite::Database> m_db;

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -22,3 +22,24 @@ std::string AgentInfo::GetUUID() const
 {
     return m_uuid;
 }
+
+void AgentInfo::SetName(const std::string& name)
+{
+    AgentInfoPersistance agentInfoPersistance;
+    agentInfoPersistance.SetName(name);
+    m_name = name;
+}
+
+void AgentInfo::SetIP(const std::string& ip)
+{
+    AgentInfoPersistance agentInfoPersistance;
+    agentInfoPersistance.SetIP(ip);
+    m_ip = ip;
+}
+
+void AgentInfo::SetUUID(const std::string& uuid)
+{
+    AgentInfoPersistance agentInfoPersistance;
+    agentInfoPersistance.SetUUID(uuid);
+    m_uuid = uuid;
+}

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -10,6 +10,17 @@ AgentInfo::AgentInfo()
     m_uuid = agentInfoPersistance.GetUUID();
 }
 
+AgentInfo::AgentInfo(const std::string& name, const std::string& ip, const std::string& uuid)
+    : m_name(name)
+    , m_ip(ip)
+    , m_uuid(uuid)
+{
+    AgentInfoPersistance agentInfoPersistance;
+    agentInfoPersistance.SetName(m_name);
+    agentInfoPersistance.SetIP(m_ip);
+    agentInfoPersistance.SetUUID(m_uuid);
+}
+
 std::string AgentInfo::GetName() const
 {
     return m_name;

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -9,3 +9,16 @@ AgentInfo::AgentInfo()
     m_ip = agentInfoPersistance.GetIP();
     m_uuid = agentInfoPersistance.GetUUID();
 }
+
+std::string AgentInfo::GetName() const
+{
+    return m_name;
+}
+std::string AgentInfo::GetIP() const
+{
+    return m_ip;
+}
+std::string AgentInfo::GetUUID() const
+{
+    return m_uuid;
+}

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -1,1 +1,11 @@
 #include <agent_info.hpp>
+
+#include <agent_info_persistance.hpp>
+
+AgentInfo::AgentInfo()
+{
+    AgentInfoPersistance agentInfoPersistance;
+    m_name = agentInfoPersistance.GetName();
+    m_ip = agentInfoPersistance.GetIP();
+    m_uuid = agentInfoPersistance.GetUUID();
+}

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -1,0 +1,1 @@
+#include <agent_info.hpp>

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -1,3 +1,39 @@
 #include <agent_info_persistance.hpp>
 
 #include <SQLiteCpp/SQLiteCpp.h>
+
+#include <iostream>
+
+AgentInfoPersistance::AgentInfoPersistance(const std::string& db_path)
+{
+    try
+    {
+        m_db = std::make_unique<SQLite::Database>(db_path, SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
+        CreateAgentInfoTable();
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Can't open database: " << e.what() << std::endl;
+        m_db.reset();
+    }
+}
+
+AgentInfoPersistance::~AgentInfoPersistance() = default;
+
+void AgentInfoPersistance::CreateAgentInfoTable()
+{
+    try
+    {
+        m_db->exec("CREATE TABLE IF NOT EXISTS agent_info ("
+                   "id INTEGER PRIMARY KEY, "
+                   "name TEXT, "
+                   "ip TEXT, "
+                   "uuid TEXT"
+                   ");");
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Error creating table: " << e.what() << std::endl;
+    }
+}
+

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -108,3 +108,16 @@ std::string AgentInfoPersistance::GetUUID() const
 {
     return GetAgentInfoValue("uuid");
 }
+
+void AgentInfoPersistance::ResetToDefault()
+{
+    try
+    {
+        m_db->exec("DELETE FROM agent_info;");
+        InsertDefaultAgentInfo();
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Error resetting to default values: " << e.what() << std::endl;
+    }
+}

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -44,7 +44,6 @@ void AgentInfoPersistance::CreateAgentInfoTable()
     try
     {
         m_db->exec("CREATE TABLE IF NOT EXISTS agent_info ("
-                   "id INTEGER PRIMARY KEY, "
                    "name TEXT, "
                    "ip TEXT, "
                    "uuid TEXT"
@@ -80,7 +79,7 @@ void AgentInfoPersistance::SetAgentInfoValue(const std::string& column, const st
 {
     try
     {
-        SQLite::Statement query(*m_db, "UPDATE agent_info SET " + column + " = ? WHERE id = 1;");
+        SQLite::Statement query(*m_db, "UPDATE agent_info SET " + column + " = ?;");
         query.bind(1, value);
         query.exec();
     }
@@ -95,7 +94,7 @@ std::string AgentInfoPersistance::GetAgentInfoValue(const std::string& column) c
     std::string value;
     try
     {
-        SQLite::Statement query(*m_db, "SELECT " + column + " FROM agent_info WHERE id = 1;");
+        SQLite::Statement query(*m_db, "SELECT " + column + " FROM agent_info LIMIT 1;");
         if (query.executeStep())
         {
             value = query.getColumn(0).getText();

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -1,0 +1,3 @@
+#include <agent_info_persistance.hpp>
+
+#include <SQLiteCpp/SQLiteCpp.h>

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -13,6 +13,7 @@ AgentInfoPersistance::AgentInfoPersistance(const std::string& db_path)
         if (!AgentInfoTableExists())
         {
             CreateAgentInfoTable();
+            InsertDefaultAgentInfo();
         }
     }
     catch (const std::exception& e)
@@ -55,3 +56,22 @@ void AgentInfoPersistance::CreateAgentInfoTable()
     }
 }
 
+void AgentInfoPersistance::InsertDefaultAgentInfo()
+{
+    try
+    {
+        SQLite::Statement query(*m_db, "SELECT COUNT(*) FROM agent_info;");
+        query.executeStep();
+        const auto count = query.getColumn(0).getInt();
+
+        if (count == 0)
+        {
+            SQLite::Statement insert(*m_db, "INSERT INTO agent_info (name, ip, uuid) VALUES (?, ?, ?);");
+            insert.exec();
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Error inserting default agent info: " << e.what() << std::endl;
+    }
+}

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -75,3 +75,36 @@ void AgentInfoPersistance::InsertDefaultAgentInfo()
         std::cerr << "Error inserting default agent info: " << e.what() << std::endl;
     }
 }
+
+std::string AgentInfoPersistance::GetAgentInfoValue(const std::string& column) const
+{
+    std::string value;
+    try
+    {
+        SQLite::Statement query(*m_db, "SELECT " + column + " FROM agent_info WHERE id = 1;");
+        if (query.executeStep())
+        {
+            value = query.getColumn(0).getText();
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Error fetching " << column << ": " << e.what() << std::endl;
+    }
+    return value;
+}
+
+std::string AgentInfoPersistance::GetName() const
+{
+    return GetAgentInfoValue("name");
+}
+
+std::string AgentInfoPersistance::GetIP() const
+{
+    return GetAgentInfoValue("ip");
+}
+
+std::string AgentInfoPersistance::GetUUID() const
+{
+    return GetAgentInfoValue("uuid");
+}

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -76,6 +76,20 @@ void AgentInfoPersistance::InsertDefaultAgentInfo()
     }
 }
 
+void AgentInfoPersistance::SetAgentInfoValue(const std::string& column, const std::string& value)
+{
+    try
+    {
+        SQLite::Statement query(*m_db, "UPDATE agent_info SET " + column + " = ? WHERE id = 1;");
+        query.bind(1, value);
+        query.exec();
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Error updating " << column << ": " << e.what() << std::endl;
+    }
+}
+
 std::string AgentInfoPersistance::GetAgentInfoValue(const std::string& column) const
 {
     std::string value;
@@ -107,6 +121,21 @@ std::string AgentInfoPersistance::GetIP() const
 std::string AgentInfoPersistance::GetUUID() const
 {
     return GetAgentInfoValue("uuid");
+}
+
+void AgentInfoPersistance::SetName(const std::string& name)
+{
+    SetAgentInfoValue("name", name);
+}
+
+void AgentInfoPersistance::SetIP(const std::string& ip)
+{
+    SetAgentInfoValue("ip", ip);
+}
+
+void AgentInfoPersistance::SetUUID(const std::string& uuid)
+{
+    SetAgentInfoValue("uuid", uuid);
 }
 
 void AgentInfoPersistance::ResetToDefault()

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -13,6 +13,10 @@ AgentInfoPersistance::AgentInfoPersistance(const std::string& db_path)
         if (!AgentInfoTableExists())
         {
             CreateAgentInfoTable();
+        }
+
+        if (AgentInfoIsEmpty())
+        {
             InsertDefaultAgentInfo();
         }
     }
@@ -37,6 +41,23 @@ bool AgentInfoPersistance::AgentInfoTableExists() const
         std::cerr << "Failed to check if table exists: " << e.what() << std::endl;
         return false;
     }
+}
+
+bool AgentInfoPersistance::AgentInfoIsEmpty() const
+{
+    try
+    {
+        SQLite::Statement query(*m_db, "SELECT COUNT(*) FROM agent_info;");
+        query.executeStep();
+        const auto count = query.getColumn(0).getInt();
+        return count == 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Error fetching: " << e.what() << std::endl;
+    }
+
+    return false;
 }
 
 void AgentInfoPersistance::CreateAgentInfoTable()

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -9,7 +9,11 @@ AgentInfoPersistance::AgentInfoPersistance(const std::string& db_path)
     try
     {
         m_db = std::make_unique<SQLite::Database>(db_path, SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
-        CreateAgentInfoTable();
+
+        if (!AgentInfoTableExists())
+        {
+            CreateAgentInfoTable();
+        }
     }
     catch (const std::exception& e)
     {
@@ -19,6 +23,20 @@ AgentInfoPersistance::AgentInfoPersistance(const std::string& db_path)
 }
 
 AgentInfoPersistance::~AgentInfoPersistance() = default;
+
+bool AgentInfoPersistance::AgentInfoTableExists() const
+{
+    try
+    {
+        SQLite::Statement query(*m_db, "SELECT name FROM sqlite_master WHERE type='table' AND name='agent_info';");
+        return query.executeStep();
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Failed to check if table exists: " << e.what() << std::endl;
+        return false;
+    }
+}
 
 void AgentInfoPersistance::CreateAgentInfoTable()
 {

--- a/src/agent/agent_info/tests/CMakeLists.txt
+++ b/src/agent/agent_info/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+find_package(GTest CONFIG REQUIRED)
+
+set(TEST_SOURCES
+    agent_info_test.cpp
+    agent_info_persistance_test.cpp
+)
+
+add_executable(agent_info_test agent_info_test.cpp)
+target_include_directories(agent_info_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_link_libraries(agent_info_test PRIVATE AgentInfo GTest::gtest)
+add_test(NAME AgentInfoTest COMMAND agent_info_test)
+
+add_executable(agent_info_persistance_test agent_info_persistance_test.cpp)
+target_include_directories(agent_info_persistance_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_link_libraries(agent_info_persistance_test PRIVATE AgentInfo GTest::gtest)
+add_test(NAME AgentInfoPersistanceTest COMMAND agent_info_persistance_test)

--- a/src/agent/agent_info/tests/agent_info_persistance_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_persistance_test.cpp
@@ -11,6 +11,7 @@ protected:
     void SetUp() override
     {
         persistance = std::make_unique<AgentInfoPersistance>("agent_info_test.db");
+        persistance->ResetToDefault();
     }
 
     std::unique_ptr<AgentInfoPersistance> persistance;

--- a/src/agent/agent_info/tests/agent_info_persistance_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_persistance_test.cpp
@@ -2,6 +2,25 @@
 
 #include <agent_info_persistance.hpp>
 
+#include <memory>
+#include <string>
+
+class AgentInfoPersistanceTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        persistance = std::make_unique<AgentInfoPersistance>("agent_info_test.db");
+    }
+
+    std::unique_ptr<AgentInfoPersistance> persistance;
+};
+
+TEST_F(AgentInfoPersistanceTest, TestConstruction)
+{
+    EXPECT_NE(persistance, nullptr);
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/src/agent/agent_info/tests/agent_info_persistance_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_persistance_test.cpp
@@ -29,6 +29,39 @@ TEST_F(AgentInfoPersistanceTest, TestDefaultValues)
     EXPECT_EQ(persistance->GetUUID(), "");
 }
 
+TEST_F(AgentInfoPersistanceTest, TestSetName)
+{
+    const std::string newName = "new_name";
+    persistance->SetName(newName);
+    EXPECT_EQ(persistance->GetName(), newName);
+}
+
+TEST_F(AgentInfoPersistanceTest, TestSetIP)
+{
+    const std::string newIP = "192.168.1.1";
+    persistance->SetIP(newIP);
+    EXPECT_EQ(persistance->GetIP(), newIP);
+}
+
+TEST_F(AgentInfoPersistanceTest, TestSetUUID)
+{
+    const std::string newUUID = "new_uuid";
+    persistance->SetUUID(newUUID);
+    EXPECT_EQ(persistance->GetUUID(), newUUID);
+}
+
+TEST_F(AgentInfoPersistanceTest, TestResetToDefault)
+{
+    const std::string newName = "new_name";
+    persistance->SetName(newName);
+    EXPECT_EQ(persistance->GetName(), newName);
+
+    persistance->ResetToDefault();
+    EXPECT_EQ(persistance->GetName(), "");
+    EXPECT_EQ(persistance->GetIP(), "");
+    EXPECT_EQ(persistance->GetUUID(), "");
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/src/agent/agent_info/tests/agent_info_persistance_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_persistance_test.cpp
@@ -21,6 +21,13 @@ TEST_F(AgentInfoPersistanceTest, TestConstruction)
     EXPECT_NE(persistance, nullptr);
 }
 
+TEST_F(AgentInfoPersistanceTest, TestDefaultValues)
+{
+    EXPECT_EQ(persistance->GetName(), "");
+    EXPECT_EQ(persistance->GetIP(), "");
+    EXPECT_EQ(persistance->GetUUID(), "");
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/src/agent/agent_info/tests/agent_info_persistance_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_persistance_test.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+#include <agent_info_persistance.hpp>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+#include <agent_info.hpp>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -1,12 +1,16 @@
 #include <gtest/gtest.h>
 
 #include <agent_info.hpp>
+#include <agent_info_persistance.hpp>
 
 class AgentInfoTest : public ::testing::Test
 {
 protected:
     void SetUp() override
     {
+        // We need to reset the database to the default state before each test
+        AgentInfoPersistance agentInfoPersistance;
+        agentInfoPersistance.ResetToDefault();
     }
 };
 
@@ -21,6 +25,42 @@ TEST_F(AgentInfoTest, TestDefaultConstructorDefaultValues)
     EXPECT_EQ(agentInfo.GetName(), "");
     EXPECT_EQ(agentInfo.GetIP(), "");
     EXPECT_EQ(agentInfo.GetUUID(), "");
+}
+
+TEST_F(AgentInfoTest, TestSetName)
+{
+    AgentInfo agentInfo;
+    const std::string newName = "new_name";
+
+    agentInfo.SetName(newName);
+    EXPECT_EQ(agentInfo.GetName(), newName);
+
+    const AgentInfo agentInfoReloaded;
+    EXPECT_EQ(agentInfoReloaded.GetName(), newName);
+}
+
+TEST_F(AgentInfoTest, TestSetIP)
+{
+    AgentInfo agentInfo;
+    const std::string newIP = "192.168.1.1";
+
+    agentInfo.SetIP(newIP);
+    EXPECT_EQ(agentInfo.GetIP(), newIP);
+
+    const AgentInfo agentInfoReloaded;
+    EXPECT_EQ(agentInfoReloaded.GetIP(), newIP);
+}
+
+TEST_F(AgentInfoTest, TestSetUUID)
+{
+    AgentInfo agentInfo;
+    const std::string newUUID = "new_uuid";
+
+    agentInfo.SetUUID(newUUID);
+    EXPECT_EQ(agentInfo.GetUUID(), newUUID);
+
+    const AgentInfo agentInfoReloaded;
+    EXPECT_EQ(agentInfoReloaded.GetUUID(), newUUID);
 }
 
 int main(int argc, char** argv)

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -27,6 +27,27 @@ TEST_F(AgentInfoTest, TestDefaultConstructorDefaultValues)
     EXPECT_EQ(agentInfo.GetUUID(), "");
 }
 
+TEST_F(AgentInfoTest, TestParameterizedConstructor)
+{
+    const std::string name = "new_name";
+    const std::string ip = "192.168.1.1";
+    const std::string uuid = "new_uuid";
+
+    const AgentInfo agentInfo(name, ip, uuid);
+    EXPECT_EQ(agentInfo.GetName(), name);
+    EXPECT_EQ(agentInfo.GetIP(), ip);
+    EXPECT_EQ(agentInfo.GetUUID(), uuid);
+}
+
+TEST_F(AgentInfoTest, TestPersistedValues)
+{
+    const AgentInfo agentInfo("test_name", "test_ip", "test_uuid");
+    const AgentInfo agentInfoReloaded;
+    EXPECT_EQ(agentInfoReloaded.GetName(), "test_name");
+    EXPECT_EQ(agentInfoReloaded.GetIP(), "test_ip");
+    EXPECT_EQ(agentInfoReloaded.GetUUID(), "test_uuid");
+}
+
 TEST_F(AgentInfoTest, TestSetName)
 {
     AgentInfo agentInfo;

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -15,6 +15,14 @@ TEST_F(AgentInfoTest, TestDefaultConstructor)
     EXPECT_NO_THROW(AgentInfo {});
 }
 
+TEST_F(AgentInfoTest, TestDefaultConstructorDefaultValues)
+{
+    const AgentInfo agentInfo;
+    EXPECT_EQ(agentInfo.GetName(), "");
+    EXPECT_EQ(agentInfo.GetIP(), "");
+    EXPECT_EQ(agentInfo.GetUUID(), "");
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -2,6 +2,19 @@
 
 #include <agent_info.hpp>
 
+class AgentInfoTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+};
+
+TEST_F(AgentInfoTest, TestDefaultConstructor)
+{
+    EXPECT_NO_THROW(AgentInfo {});
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/src/agent/configuration_parser/include/configuration_parser.hpp
+++ b/src/agent/configuration_parser/include/configuration_parser.hpp
@@ -18,7 +18,7 @@ namespace configuration
         ConfigurationParser(std::string stringToParse);
 
         template<typename T, typename... Ks>
-        auto GetConfig(Ks... ks)
+        auto GetConfig(Ks... ks) const
         {
             try
             {

--- a/src/agent/include/register.hpp
+++ b/src/agent/include/register.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+bool RegisterAgent(const std::string& user,
+                   const std::string& password,
+                   const std::optional<std::string>& name,
+                   const std::optional<std::string>& ip);

--- a/src/agent/src/main.cpp
+++ b/src/agent/src/main.cpp
@@ -1,8 +1,47 @@
-#include "agent.hpp"
-#include <iostream>
+#include <agent.hpp>
+#include <cmd_ln_parser.hpp>
+#include <register.hpp>
 
-int main()
+#include <iostream>
+#include <optional>
+
+int main(int argc, char* argv[])
 {
+    CommandlineParser cmdParser(argc, argv);
+
+    if (cmdParser.OptionExists("--register"))
+    {
+        std::cout << "Starting registration process" << std::endl;
+
+        if (cmdParser.OptionExists("--user") && cmdParser.OptionExists("--password"))
+        {
+            const auto user = cmdParser.getOptionValue("--user");
+            const auto password = cmdParser.getOptionValue("--password");
+            const auto name = cmdParser.OptionExists("--name")
+                                  ? std::make_optional<std::string>(cmdParser.getOptionValue("--name"))
+                                  : std::nullopt;
+            const auto ip = cmdParser.OptionExists("--ip")
+                                ? std::make_optional<std::string>(cmdParser.getOptionValue("--ip"))
+                                : std::nullopt;
+
+            if (RegisterAgent(user, password, name, ip))
+            {
+                std::cout << "Agent registered." << std::endl;
+            }
+            else
+            {
+                std::cout << "Registration fail." << std::endl;
+            }
+        }
+        else
+        {
+            std::cout << "--user and --password args are mandatory" << std::endl;
+        }
+
+        std::cout << "Exiting ..." << std::endl;
+        return 0;
+    }
+
     Agent agent;
     std::this_thread::sleep_for(std::chrono::seconds(40));
 }

--- a/src/agent/src/register.cpp
+++ b/src/agent/src/register.cpp
@@ -8,12 +8,15 @@
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/version.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <iostream>
 #include <jwt-cpp/jwt.h>
 #include <nlohmann/json.hpp>
 
 namespace beast = boost::beast;
 namespace http = beast::http;
+namespace uuids = boost::uuids;
 using tcp = boost::asio::ip::tcp;
 using json = nlohmann::json;
 
@@ -112,6 +115,11 @@ namespace registration
         return res.result();
     }
 
+    std::string GenerateUuid()
+    {
+        return to_string(uuids::random_generator()());
+    }
+
 } // namespace registration
 
 bool RegisterAgent(const std::string& user,
@@ -119,7 +127,7 @@ bool RegisterAgent(const std::string& user,
                    const std::optional<std::string>& name,
                    const std::optional<std::string>& ip)
 {
-    const auto uuid = "01910343-4ab2-7d94-ab6f-ff76dbb1677d";
+    const auto uuid = registration::GenerateUuid();
 
     const auto configurationParser = std::make_shared<configuration::ConfigurationParser>();
     const auto managerIp = configurationParser->GetConfig<std::string>("agent", "manager_ip");

--- a/src/agent/src/register.cpp
+++ b/src/agent/src/register.cpp
@@ -1,0 +1,143 @@
+#include <register.hpp>
+
+#include <configuration_parser.hpp>
+
+#include <boost/asio/connect.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/ssl/stream.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/beast/version.hpp>
+#include <iostream>
+#include <jwt-cpp/jwt.h>
+#include <nlohmann/json.hpp>
+
+namespace beast = boost::beast;
+namespace http = beast::http;
+using tcp = boost::asio::ip::tcp;
+using json = nlohmann::json;
+
+namespace registration
+{
+    http::response<http::dynamic_body> sendRequest(const std::string& managerIp,
+                                                   const std::string& port,
+                                                   const http::verb& method,
+                                                   const std::string& url,
+                                                   const std::string& token,
+                                                   const std::string& body,
+                                                   const std::string& user_pass)
+    {
+        http::response<http::dynamic_body> res;
+        try
+        {
+            boost::asio::io_context io_context;
+            tcp::resolver resolver(io_context);
+            auto const results = resolver.resolve(managerIp, port);
+
+            tcp::socket socket(io_context);
+            boost::asio::connect(socket, results.begin(), results.end());
+
+            http::request<http::string_body> req {method, url, 11};
+            req.set(http::field::host, managerIp);
+            req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+            req.set(http::field::accept, "application/json");
+
+            if (!token.empty())
+            {
+                req.set(http::field::authorization, "Bearer " + token);
+            }
+
+            if (!user_pass.empty())
+            {
+                req.set(http::field::authorization, "Basic " + user_pass);
+            }
+
+            if (!body.empty())
+            {
+                req.set(http::field::content_type, "application/json");
+                req.body() = body;
+                req.prepare_payload();
+            }
+
+            http::write(socket, req);
+
+            beast::flat_buffer buffer;
+
+            http::read(socket, buffer, res);
+
+            std::cout << "Response code: " << res.result_int() << std::endl;
+            std::cout << "Response body: " << beast::buffers_to_string(res.body().data()) << std::endl;
+        }
+        catch (std::exception const& e)
+        {
+            std::cerr << "Error: " << e.what() << std::endl;
+            res.result(http::status::internal_server_error);
+            beast::ostream(res.body()) << "Internal server error: " << e.what();
+            res.prepare_payload();
+        }
+        return res;
+    }
+
+    std::pair<http::status, std::string>
+    SendAuthenticationRequest(const std::string& managerIp, const std::string& port, const std::string& user_pass)
+    {
+        http::response<http::dynamic_body> res =
+            sendRequest(managerIp, port, http::verb::post, "/authenticate", "", "", user_pass);
+        const auto token = beast::buffers_to_string(res.body().data());
+
+        return {res.result(), token};
+    }
+
+    http::status SendRegistrationRequest(const std::string& managerIp,
+                                     const std::string& port,
+                                     const std::string& token,
+                                     const std::string& uuid,
+                                     const std::optional<std::string>& name,
+                                     const std::optional<std::string>& ip)
+    {
+        json bodyJson = {{"uuid", uuid}};
+
+        if (name.has_value())
+        {
+            bodyJson["name"] = name.value();
+        }
+
+        if (ip.has_value())
+        {
+            bodyJson["ip"] = ip.value();
+        }
+
+        http::response<http::dynamic_body> res =
+            sendRequest(managerIp, port, http::verb::post, "/agents", token, bodyJson.dump(), "");
+        return res.result();
+    }
+
+} // namespace registration
+
+bool RegisterAgent(const std::string& user,
+                   const std::string& password,
+                   const std::optional<std::string>& name,
+                   const std::optional<std::string>& ip)
+{
+    const auto uuid = "01910343-4ab2-7d94-ab6f-ff76dbb1677d";
+
+    const auto configurationParser = std::make_shared<configuration::ConfigurationParser>();
+    const auto managerIp = configurationParser->GetConfig<std::string>("agent", "manager_ip");
+    const auto port = configurationParser->GetConfig<std::string>("agent", "port");
+
+    auto [authResultCode, token] = registration::SendAuthenticationRequest(managerIp, port, user + ":" + password);
+    if (authResultCode != http::status::ok)
+    {
+        std::cout << "Authentication error: " << authResultCode << std::endl;
+        return false;
+    }
+
+    if (auto registrationResultCode = registration::SendRegistrationRequest(managerIp, port, token, uuid, name, ip);
+        registrationResultCode != http::status::ok)
+    {
+        std::cout << "Registration error: " << registrationResultCode << std::endl;
+        return false;
+    }
+
+    return true;
+}

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(GTest CONFIG REQUIRED)
 set(TEST_SOURCES
     agent_test.cpp
     task_manager_test.cpp
+    register_test.cpp
 )
 
 add_executable(agent_test agent_test.cpp)
@@ -14,3 +15,7 @@ add_test(NAME AgentTest COMMAND agent_test)
 add_executable(task_manager_test task_manager_test.cpp)
 target_link_libraries(task_manager_test PRIVATE agent GTest::gtest)
 add_test(NAME TaskManagerTest COMMAND task_manager_test)
+
+add_executable(register_test register_test.cpp)
+target_link_libraries(register_test PRIVATE agent GTest::gtest)
+add_test(NAME RegisterTest COMMAND register_test)

--- a/src/agent/tests/register_test.cpp
+++ b/src/agent/tests/register_test.cpp
@@ -1,0 +1,19 @@
+#include <register.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(RegistrationTest, RegistrationTest)
+{
+    const std::string user = "user";
+    const std::string password = "123456";
+    const std::optional<std::string> name = "name";
+    const std::optional<std::string> ip = "192.168.56.1.2";
+    const bool res = RegisterAgent(user, password, name, ip);
+    ASSERT_TRUE(res);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -9,6 +9,7 @@
       "jwt-cpp",
       "nlohmann-json",
       "openssl",
+      "sqlitecpp",
       "toml11"
     ],
     "overrides": [

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -10,7 +10,8 @@
       "nlohmann-json",
       "openssl",
       "sqlitecpp",
-      "toml11"
+      "toml11",
+      "boost-uuid"
     ],
     "overrides": [
       {


### PR DESCRIPTION
## Description

This PR adds the changes to be able to register an agent through cli. The agent binary can be executed in the following way

`./wazuh-agent --register --user user_name --password 123456 --name agent_name --ip 192.168.56.1`.

Where:
- `--register` defines the behaivior to start the registration process.
- `--user_name` and `--password` are mandatory to athenticate with `ServerManagementAPI`.
- `--name` and `--ip` are optionals arguments to define agent's information.

During the registration process the agent's uuid is generated. This is done with the `boost::uuids` library, which currently implements up to `UUIDv5`, but we expect the next release containing `UUIDv7` to be released in August.
