### PR TITLE
Add raw Windows events support

### DIFF
--- a/src/modules/logcollector/src/read_win_event_channel.c
+++ b/src/modules/logcollector/src/read_win_event_channel.c
@@ -398,7 +398,6 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
     DWORD count = 0;
     int result = 0;
     wchar_t *wprovider_name = NULL;
-    char *msg_sent = NULL;
     char *provider_name = NULL;
     char *msg_from_prov = NULL;
     char *xml_event = NULL;
@@ -406,8 +405,6 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
     char *end_prov = NULL;
     char *find_prov = NULL;
     size_t num;
-
-    cJSON *event_json = cJSON_CreateObject();
 
     os_malloc(OS_MAXSTR, provider_name);
 
@@ -486,19 +483,13 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
                 "Could not get message for (%s)",
                 channel->evt_log);
         }
-        else {
-            cJSON_AddStringToObject(event_json, "Message", msg_from_prov);
-        }
     }
 
     win_format_event_string(xml_event);
 
-    cJSON_AddStringToObject(event_json, "Event", xml_event);
-    msg_sent = cJSON_PrintUnformatted(event_json);
+    w_logcollector_state_update_file(channel->evt_log, strlen(xml_event));
 
-    w_logcollector_state_update_file(channel->evt_log, strlen(msg_sent));
-
-    if (SendMSG(logr_queue, msg_sent, "EventChannel", WIN_EVT_MQ) < 0) {
+    if (SendMSG(logr_queue, xml_event, "EventChannel", WIN_EVT_MQ) < 0) {
         merror(QUEUE_SEND);
         w_logcollector_state_update_target(channel->evt_log, "agent", true);
     } else {
@@ -512,11 +503,9 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
 cleanup:
     os_free(msg_from_prov);
     os_free(xml_event);
-    os_free(msg_sent);
     os_free(properties_values);
     os_free(provider_name);
     os_free(wprovider_name);
-    cJSON_Delete(event_json);
 
     return;
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #50|

## Description

This PR addresses the need to update the Wazuh-Logcollector for EventChannel events in accordance with the new standards set by Wazuh-Engine. The current implementation wraps the original XML event inside a JSON object, which is no longer desirable. Our goal is to modify the logcollector to send the original EventChannel event directly, preserving its format and minimizing any manipulation or modification of logs at the agent level.

## Objectives

- **Remove JSON Wrapping:** Update logcollector to send the original XML event directly, without embedding it into a JSON structure.
- **Deprecation of Message Key:** Discontinue the use of the `message` key that fetches event descriptions via the Windows API.

### Implementation

- Ported the existing code changes from Logcollector to the Engine branch: https://github.com/wazuh/wazuh/pull/17880
- Modified the logcollector to handle EventChannel events in their original XML format.

## Testing
- Successfully compiled in the master branch of `wazuh/wazuh`.

**Note:** The code ported to _wazuh-agent_ is not yet available for testing.