### PR TITLE
Fix regex for XProtect SCA ruleset on macOS

### DIFF
--- a/etc/ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml
+++ b/etc/ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml
@@ -1433,8 +1433,8 @@ checks:
       - soc_2: ["CC6.8"]
     condition: all
     rules:
-      - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan" -> r:^1$'
-      - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan.startup" -> r:^1$'
+      - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan$" -> r:^1$'
+      - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan.startup$" -> r:^1$'
 
   # 6.1.1 Ensure Show All Filename Extensions Setting is Enabled. (Automated) - Not Implemented
   # 6.2.1 Ensure Protect Mail Activity in Mail Is Enabled. (Manual) - Not Implemented


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

SCA rule `Ensure XProtect Is Running and Updated` checks if XProtected is running and included in startup. Since grepping on `com.apple.XProtect.daemon.scan` also includes `com.apple.XProtect.daemon.scan.startup`, the count will be 2.

By adding this end of string match, the count is back to 1 which results in a successful check.

## Configuration options

None.

## Logs/Alerts example

None.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] MAC OS X

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [x] runtests.py executed without errors