### PR TITLE
Extend MS-Graph integration - MDM Intune integration

### DIFF
--- a/src/modules/ms_graph/include/wm_ms_graph.h
+++ b/src/modules/ms_graph/include/wm_ms_graph.h
@@ -33,9 +33,15 @@
 #define WM_MS_GRAPH_DOD_API_QUERY_FQDN "dod-graph.microsoft.us"
 
 
-#define WM_MS_GRAPH_API_URL "https://%s/%s/%s/%s?$filter=createdDateTime+gt+%s"
+#define WM_MS_GRAPH_API_URL "https://%s/%s/%s/%s"
+#define WM_MS_GRAPH_API_URL_FILTER_CREATED_DATE WM_MS_GRAPH_API_URL "?$filter=createdDateTime+gt+%s"
+#define WM_MS_GRAPH_API_URL_FILTER_ACTIVITY_DATE WM_MS_GRAPH_API_URL "?$filter=activityDateTime+gt+%s"
 #define WM_MS_GRAPH_ACCESS_TOKEN_URL "https://%s/%s/oauth2/v2.0/token"
 #define WM_MS_GRAPH_ACCESS_TOKEN_PAYLOAD "scope=https://%s/.default&grant_type=client_credentials&client_id=%s&client_secret=%s"
+
+// MDM Intune
+#define WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT "deviceManagement"
+#define WM_MS_GRAPH_RELATIONSHIP_AUDIT_EVENTS "auditEvents"
 
 typedef struct wm_ms_graph_state_t {
 	time_t next_time;

--- a/src/modules/ms_graph/include/wm_ms_graph.h
+++ b/src/modules/ms_graph/include/wm_ms_graph.h
@@ -41,11 +41,12 @@
 #define WM_MS_GRAPH_ITEM_PER_PAGE 100
 
 // MDM Intune
+#define WM_MS_GRAPH_API_URL_DEVICES_EXPANDED "https://%s/%s/%s/%s/%s/%s?$top=%d"
+#define WM_MS_GRAPH_API_URL_FILTER_DEVICE_FIELDS WM_MS_GRAPH_API_URL_DEVICES_EXPANDED "&$select=id,deviceName"
 #define WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT "deviceManagement"
 #define WM_MS_GRAPH_RELATIONSHIP_AUDIT_EVENTS "auditEvents"
 #define WM_MS_GRAPH_RELATIONSHIP_MANAGED_DEVICES "managedDevices"
 #define WM_MS_GRAPH_RELATIONSHIP_DETECTED_APPS "detectedApps"
-#define WM_MS_GRAPH_API_URL_EXPAND_DEVICES WM_MS_GRAPH_API_URL "&$expand=" WM_MS_GRAPH_RELATIONSHIP_MANAGED_DEVICES "($select=id)"
 
 typedef struct wm_ms_graph_state_t {
 	time_t next_time;

--- a/src/modules/ms_graph/include/wm_ms_graph.h
+++ b/src/modules/ms_graph/include/wm_ms_graph.h
@@ -33,11 +33,12 @@
 #define WM_MS_GRAPH_DOD_API_QUERY_FQDN "dod-graph.microsoft.us"
 
 
-#define WM_MS_GRAPH_API_URL "https://%s/%s/%s/%s"
-#define WM_MS_GRAPH_API_URL_FILTER_CREATED_DATE WM_MS_GRAPH_API_URL "?$filter=createdDateTime+ge+%s+and+createdDateTime+lt+%s"
-#define WM_MS_GRAPH_API_URL_FILTER_ACTIVITY_DATE WM_MS_GRAPH_API_URL "?$filter=activityDateTime+ge+%s+and+activityDateTime+lt+%s"
+#define WM_MS_GRAPH_API_URL "https://%s/%s/%s/%s?$top=%d"
+#define WM_MS_GRAPH_API_URL_FILTER_CREATED_DATE WM_MS_GRAPH_API_URL "&$filter=createdDateTime+ge+%s+and+createdDateTime+lt+%s"
+#define WM_MS_GRAPH_API_URL_FILTER_ACTIVITY_DATE WM_MS_GRAPH_API_URL "&$filter=activityDateTime+ge+%s+and+activityDateTime+lt+%s"
 #define WM_MS_GRAPH_ACCESS_TOKEN_URL "https://%s/%s/oauth2/v2.0/token"
 #define WM_MS_GRAPH_ACCESS_TOKEN_PAYLOAD "scope=https://%s/.default&grant_type=client_credentials&client_id=%s&client_secret=%s"
+#define WM_MS_GRAPH_ITEM_PER_PAGE 100
 
 // MDM Intune
 #define WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT "deviceManagement"

--- a/src/modules/ms_graph/include/wm_ms_graph.h
+++ b/src/modules/ms_graph/include/wm_ms_graph.h
@@ -43,6 +43,9 @@
 // MDM Intune
 #define WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT "deviceManagement"
 #define WM_MS_GRAPH_RELATIONSHIP_AUDIT_EVENTS "auditEvents"
+#define WM_MS_GRAPH_RELATIONSHIP_MANAGED_DEVICES "managedDevices"
+#define WM_MS_GRAPH_RELATIONSHIP_DETECTED_APPS "detectedApps"
+#define WM_MS_GRAPH_API_URL_EXPAND_DEVICES WM_MS_GRAPH_API_URL "&$expand=" WM_MS_GRAPH_RELATIONSHIP_MANAGED_DEVICES "($select=id)"
 
 typedef struct wm_ms_graph_state_t {
 	time_t next_time;

--- a/src/modules/ms_graph/include/wm_ms_graph.h
+++ b/src/modules/ms_graph/include/wm_ms_graph.h
@@ -34,8 +34,8 @@
 
 
 #define WM_MS_GRAPH_API_URL "https://%s/%s/%s/%s"
-#define WM_MS_GRAPH_API_URL_FILTER_CREATED_DATE WM_MS_GRAPH_API_URL "?$filter=createdDateTime+gt+%s"
-#define WM_MS_GRAPH_API_URL_FILTER_ACTIVITY_DATE WM_MS_GRAPH_API_URL "?$filter=activityDateTime+gt+%s"
+#define WM_MS_GRAPH_API_URL_FILTER_CREATED_DATE WM_MS_GRAPH_API_URL "?$filter=createdDateTime+ge+%s+and+createdDateTime+lt+%s"
+#define WM_MS_GRAPH_API_URL_FILTER_ACTIVITY_DATE WM_MS_GRAPH_API_URL "?$filter=activityDateTime+ge+%s+and+activityDateTime+lt+%s"
 #define WM_MS_GRAPH_ACCESS_TOKEN_URL "https://%s/%s/oauth2/v2.0/token"
 #define WM_MS_GRAPH_ACCESS_TOKEN_PAYLOAD "scope=https://%s/.default&grant_type=client_credentials&client_id=%s&client_secret=%s"
 

--- a/src/modules/ms_graph/src/wm_ms_graph.c
+++ b/src/modules/ms_graph/src/wm_ms_graph.c
@@ -26,7 +26,8 @@ static void* wm_ms_graph_main(wm_ms_graph* ms_graph);
 static bool wm_ms_graph_setup(wm_ms_graph* ms_graph);
 static bool wm_ms_graph_check();
 static void wm_ms_graph_get_access_token(wm_ms_graph_auth* auth_config, const ssize_t curl_max_size);
-static void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_scan);
+static void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, wm_ms_graph_auth* auth_config, const bool initial_scan);
+static cJSON* wm_ms_graph_scan_apps_devices(const wm_ms_graph* ms_graph, const cJSON* app_id, const char* query_fqdn, char** headers);
 static void wm_ms_graph_destroy(wm_ms_graph* ms_graph);
 static void wm_ms_graph_cleanup();
 cJSON* wm_ms_graph_dump(const wm_ms_graph* ms_graph);
@@ -80,7 +81,7 @@ void* wm_ms_graph_main(wm_ms_graph* ms_graph) {
 
                 if (it->access_token && time(NULL) < it->token_expiration_time) {
                     mtinfo(WM_MS_GRAPH_LOGTAG, "Scanning tenant '%s'", it->tenant_id);
-                    wm_ms_graph_scan_relationships(ms_graph, initial);
+                    wm_ms_graph_scan_relationships(ms_graph, it, initial);
                     initial = false;
                 }
             }
@@ -186,7 +187,7 @@ void wm_ms_graph_get_access_token(wm_ms_graph_auth* auth_config, const ssize_t c
     }
 }
 
-void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_scan) {
+void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, wm_ms_graph_auth* auth_config, const bool initial_scan) {
     char url[OS_SIZE_8192] = { '\0' };
     char auth_header[OS_SIZE_8192] = { '\0' };
     char* headers[] = { NULL, NULL };
@@ -205,179 +206,223 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_sc
 
         for (unsigned int relationship_num = 0; relationship_num < ms_graph->resources[resource_num].num_relationships; relationship_num++) {
 
-            int e;
-            wm_ms_graph_auth *it;
-
-            for (e = 0; ms_graph->auth_config[e]; e++) {
-                it = ms_graph->auth_config[e];
-
-                if (!strcmp(ms_graph->resources[resource_num].name, WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT)) {
-                    // If not auditEvents, treat as inventory
-                    if (strcmp(ms_graph->resources[resource_num].relationships[relationship_num], WM_MS_GRAPH_RELATIONSHIP_AUDIT_EVENTS)) {
-                        inventory = true;
-                    }
+            if (!strcmp(ms_graph->resources[resource_num].name, WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT)) {
+                // If not auditEvents, treat as inventory
+                if (strcmp(ms_graph->resources[resource_num].relationships[relationship_num], WM_MS_GRAPH_RELATIONSHIP_AUDIT_EVENTS)) {
+                    inventory = true;
                 }
+            }
 
-                if (!inventory) {
-                    snprintf(relationship_state_name, OS_SIZE_1024 -1, "%s-%s-%s-%s", WM_MS_GRAPH_CONTEXT.name,
-                        it->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num]);
+            if (!inventory) {
+                snprintf(relationship_state_name, OS_SIZE_1024 -1, "%s-%s-%s-%s", WM_MS_GRAPH_CONTEXT.name,
+                    auth_config->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num]);
 
+                memset(&relationship_state_struc, 0, sizeof(relationship_state_struc));
+
+                // Load state for tenant-resource-relationship
+                if (wm_state_io(relationship_state_name, WM_IO_READ, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
                     memset(&relationship_state_struc, 0, sizeof(relationship_state_struc));
-
-                    // Load state for tenant-resource-relationship
-                    if (wm_state_io(relationship_state_name, WM_IO_READ, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
-                        memset(&relationship_state_struc, 0, sizeof(relationship_state_struc));
-                    }
-
-                    now = time(0);
-
-                    if ((initial_scan && (!relationship_state_struc.next_time || ms_graph->only_future_events)) ||
-                        (!initial_scan && !relationship_state_struc.next_time)) {
-                        relationship_state_struc.next_time = now;
-                        if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
-                            mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state.");
-                        } else if (isDebug()) {
-                            gmtime_r(&now, &tm_aux);
-                            strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
-                            mtdebug1(WM_MS_GRAPH_LOGTAG, "Bookmark updated to '%s' for tenant '%s' resource '%s' and relationship '%s', waiting '%d' seconds to run first scan.",
-                                start_time_str, it->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num], ms_graph->scan_config.interval);
-                        }
-                        continue;
-                    }
-
-                    gmtime_r(&relationship_state_struc.next_time, &tm_aux);
-                    strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
-
-                    gmtime_r(&now, &tm_aux);
-                    strftime(end_time_str, sizeof(end_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
                 }
 
-                snprintf(auth_header, OS_SIZE_8192 - 1, "Authorization: Bearer %s", it->access_token);
-                os_strdup(auth_header, headers[0]);
+                now = time(0);
 
-                if (!strcmp(ms_graph->resources[resource_num].name, WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT)) {
-                    if (!strcmp(ms_graph->resources[resource_num].relationships[relationship_num], WM_MS_GRAPH_RELATIONSHIP_AUDIT_EVENTS)) {
-                        snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL_FILTER_ACTIVITY_DATE,
-                        it->query_fqdn,
-                        ms_graph->version,
-                        WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT,
-                        WM_MS_GRAPH_RELATIONSHIP_AUDIT_EVENTS,
-                        WM_MS_GRAPH_ITEM_PER_PAGE,
-                        start_time_str,
-                        end_time_str);
-                    } else if (!strcmp(ms_graph->resources[resource_num].relationships[relationship_num], WM_MS_GRAPH_RELATIONSHIP_DETECTED_APPS)) {
-                        snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL_EXPAND_DEVICES,
-                        it->query_fqdn,
-                        ms_graph->version,
-                        WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT,
-                        ms_graph->resources[resource_num].relationships[relationship_num],
-                        WM_MS_GRAPH_ITEM_PER_PAGE);
-                    } else {
-                        snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL,
-                        it->query_fqdn,
-                        ms_graph->version,
-                        WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT,
-                        ms_graph->resources[resource_num].relationships[relationship_num],
-                        WM_MS_GRAPH_ITEM_PER_PAGE);
-                    }
-                } else {
-                    snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL_FILTER_CREATED_DATE,
-                    it->query_fqdn,
-                    ms_graph->version,
-                    ms_graph->resources[resource_num].name,
-                    ms_graph->resources[resource_num].relationships[relationship_num],
-                    WM_MS_GRAPH_ITEM_PER_PAGE,
-                    start_time_str,
-                    end_time_str);
-                }
-
-                next_page = true;
-                while (next_page) {
-                    mtdebug1(WM_MS_GRAPH_LOGTAG, "Microsoft Graph API Log URL: '%s'", url);
-
-                    fail = true;
-                    next_page = false;
-                    response = wurl_http_request(WURL_GET_METHOD, headers, url, "", ms_graph->curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
-                    if (response) {
-                        if (response->status_code != 200) {
-                            char status_code[4];
-                            snprintf(status_code, 4, "%ld", response->status_code);
-                            mtwarn(WM_MS_GRAPH_LOGTAG, "Received unsuccessful status code when attempting to get relationship '%s' logs: Status code was '%s' & response was '%s'",
-                            ms_graph->resources[resource_num].relationships[relationship_num],
-                            status_code,
-                            response->body);
-                        } else if (response->max_size_reached) {
-                            mtwarn(WM_MS_GRAPH_LOGTAG, "Reached maximum CURL size when attempting to get relationship '%s' logs. Consider increasing the value of 'curl_max_size'.",
-                            ms_graph->resources[resource_num].relationships[relationship_num]);
-                        } else {
-                            cJSON* body_parse = NULL;
-                            if (body_parse = cJSON_Parse(response->body), body_parse) {
-                                cJSON* logs = cJSON_GetObjectItem(body_parse, "value");
-                                int num_logs = cJSON_GetArraySize(logs);
-                                if (num_logs > 0) {
-                                    for (int log_index = 0; log_index < num_logs; log_index++) {
-                                        cJSON* log = NULL;
-                                        if (log = cJSON_GetArrayItem(logs, log_index), log) {
-                                            cJSON* full_log = cJSON_CreateObject();
-                                            char* payload;
-
-                                            cJSON_AddStringToObject(log, "resource", ms_graph->resources[resource_num].name);
-                                            cJSON_AddStringToObject(log, "relationship", ms_graph->resources[resource_num].relationships[relationship_num]);
-                                            cJSON_AddStringToObject(full_log, "integration", WM_MS_GRAPH_CONTEXT.name);
-                                            cJSON_AddItemToObject(full_log, WM_MS_GRAPH_CONTEXT.name, cJSON_Duplicate(log, true));
-
-                                            payload = cJSON_PrintUnformatted(full_log);
-                                            mtdebug2(WM_MS_GRAPH_LOGTAG, "Sending log: '%s'", payload);
-                                            if (wm_sendmsg(1000000 / wm_max_eps, queue_fd, payload, WM_MS_GRAPH_CONTEXT.name, LOCALFILE_MQ) < 0) {
-                                                mterror(WM_MS_GRAPH_LOGTAG, QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
-                                            }
-
-                                            os_free(payload);
-                                            cJSON_Delete(full_log);
-                                        } else {
-                                            mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse log array into singular log.");
-                                        }
-                                    }
-                                    fail = false;
-                                } else {
-                                    mtdebug2(WM_MS_GRAPH_LOGTAG, "No new logs received.");
-                                    fail = false;
-                                }
-
-                                cJSON* next_url = cJSON_GetObjectItem(body_parse, "@odata.nextLink");
-                                if (cJSON_IsString(next_url)) {
-                                    memset(url, '\0', OS_SIZE_8192);
-                                    snprintf(url, OS_SIZE_8192 -1, "%s", next_url->valuestring);
-                                    next_page = true;
-                                }
-
-                                cJSON_Delete(body_parse);
-                            } else {
-                                mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse relationship '%s' JSON body.", ms_graph->resources[resource_num].relationships[relationship_num]);
-                            }
-                        }
-                        wurl_free_response(response);
-                    } else {
-                        mtwarn(WM_MS_GRAPH_LOGTAG, "No response received when attempting to get relationship '%s' from resource '%s' on API version '%s'.",
-                        ms_graph->resources[resource_num].relationships[relationship_num],
-                        ms_graph->resources[resource_num].name,
-                        ms_graph->version);
-                    }
-                }
-
-                if (!inventory && !fail) {
+                if ((initial_scan && (!relationship_state_struc.next_time || ms_graph->only_future_events)) ||
+                    (!initial_scan && !relationship_state_struc.next_time)) {
                     relationship_state_struc.next_time = now;
                     if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
                         mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state.");
+                    } else if (isDebug()) {
+                        gmtime_r(&now, &tm_aux);
+                        strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
+                        mtdebug1(WM_MS_GRAPH_LOGTAG, "Bookmark updated to '%s' for tenant '%s' resource '%s' and relationship '%s', waiting '%d' seconds to run first scan.",
+                            start_time_str, auth_config->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num], ms_graph->scan_config.interval);
+                    }
+                    continue;
+                }
+
+                gmtime_r(&relationship_state_struc.next_time, &tm_aux);
+                strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
+
+                gmtime_r(&now, &tm_aux);
+                strftime(end_time_str, sizeof(end_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
+            }
+
+            snprintf(auth_header, OS_SIZE_8192 - 1, "Authorization: Bearer %s", auth_config->access_token);
+            os_strdup(auth_header, headers[0]);
+
+            if (!strcmp(ms_graph->resources[resource_num].name, WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT)) {
+                if (!strcmp(ms_graph->resources[resource_num].relationships[relationship_num], WM_MS_GRAPH_RELATIONSHIP_AUDIT_EVENTS)) {
+                    snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL_FILTER_ACTIVITY_DATE,
+                    auth_config->query_fqdn,
+                    ms_graph->version,
+                    WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT,
+                    WM_MS_GRAPH_RELATIONSHIP_AUDIT_EVENTS,
+                    WM_MS_GRAPH_ITEM_PER_PAGE,
+                    start_time_str,
+                    end_time_str);
+                } else {
+                    snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL,
+                    auth_config->query_fqdn,
+                    ms_graph->version,
+                    WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT,
+                    ms_graph->resources[resource_num].relationships[relationship_num],
+                    WM_MS_GRAPH_ITEM_PER_PAGE);
+                }
+            } else {
+                snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL_FILTER_CREATED_DATE,
+                auth_config->query_fqdn,
+                ms_graph->version,
+                ms_graph->resources[resource_num].name,
+                ms_graph->resources[resource_num].relationships[relationship_num],
+                WM_MS_GRAPH_ITEM_PER_PAGE,
+                start_time_str,
+                end_time_str);
+            }
+
+            next_page = true;
+            while (next_page) {
+                mtdebug1(WM_MS_GRAPH_LOGTAG, "Microsoft Graph API Log URL: '%s'", url);
+
+                fail = true;
+                next_page = false;
+                response = wurl_http_request(WURL_GET_METHOD, headers, url, "", ms_graph->curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
+                if (response) {
+                    if (response->status_code != 200) {
+                        char status_code[4];
+                        snprintf(status_code, 4, "%ld", response->status_code);
+                        mtwarn(WM_MS_GRAPH_LOGTAG, "Received unsuccessful status code when attempting to get relationship '%s' logs: Status code was '%s' & response was '%s'",
+                        ms_graph->resources[resource_num].relationships[relationship_num],
+                        status_code,
+                        response->body);
+                        if (response->status_code == 401) {
+                            auth_config->token_expiration_time = time(NULL);
+                        }
+                    } else if (response->max_size_reached) {
+                        mtwarn(WM_MS_GRAPH_LOGTAG, "Reached maximum CURL size when attempting to get relationship '%s' logs. Consider increasing the value of 'curl_max_size'.",
+                        ms_graph->resources[resource_num].relationships[relationship_num]);
                     } else {
-                        mtdebug1(WM_MS_GRAPH_LOGTAG, "Bookmark updated to '%s' for tenant '%s' resource '%s' and relationship '%s', waiting '%d' seconds to run next scan.",
-                            end_time_str, it->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num], ms_graph->scan_config.interval);
+                        cJSON* body_parse = NULL;
+                        if (body_parse = cJSON_Parse(response->body), body_parse) {
+                            cJSON* logs = cJSON_GetObjectItem(body_parse, "value");
+                            int num_logs = cJSON_GetArraySize(logs);
+                            if (num_logs > 0) {
+                                for (int log_index = 0; log_index < num_logs; log_index++) {
+                                    cJSON* log = NULL;
+                                    if (log = cJSON_GetArrayItem(logs, log_index), log) {
+                                        cJSON* full_log = cJSON_CreateObject();
+                                        char* payload;
+
+                                        if (inventory && !strcmp(ms_graph->resources[resource_num].relationships[relationship_num], WM_MS_GRAPH_RELATIONSHIP_DETECTED_APPS)) {
+                                            cJSON_AddItemToObject(log, WM_MS_GRAPH_RELATIONSHIP_MANAGED_DEVICES,
+                                                wm_ms_graph_scan_apps_devices(ms_graph, cJSON_GetObjectItem(log, "id"), auth_config->query_fqdn, headers));
+                                        }
+
+                                        cJSON_AddStringToObject(log, "resource", ms_graph->resources[resource_num].name);
+                                        cJSON_AddStringToObject(log, "relationship", ms_graph->resources[resource_num].relationships[relationship_num]);
+                                        cJSON_AddStringToObject(full_log, "integration", WM_MS_GRAPH_CONTEXT.name);
+                                        cJSON_AddItemToObject(full_log, WM_MS_GRAPH_CONTEXT.name, cJSON_Duplicate(log, true));
+
+                                        payload = cJSON_PrintUnformatted(full_log);
+                                        mtdebug2(WM_MS_GRAPH_LOGTAG, "Sending log: '%s'", payload);
+                                        if (wm_sendmsg(1000000 / wm_max_eps, queue_fd, payload, WM_MS_GRAPH_CONTEXT.name, LOCALFILE_MQ) < 0) {
+                                            mterror(WM_MS_GRAPH_LOGTAG, QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
+                                        }
+
+                                        os_free(payload);
+                                        cJSON_Delete(full_log);
+                                    } else {
+                                        mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse log array into singular log.");
+                                    }
+                                }
+                                fail = false;
+                            } else {
+                                mtdebug2(WM_MS_GRAPH_LOGTAG, "No new logs received.");
+                                fail = false;
+                            }
+
+                            cJSON* next_url = cJSON_GetObjectItem(body_parse, "@odata.nextLink");
+                            if (cJSON_IsString(next_url)) {
+                                memset(url, '\0', OS_SIZE_8192);
+                                snprintf(url, OS_SIZE_8192 -1, "%s", next_url->valuestring);
+                                next_page = true;
+                            }
+
+                            cJSON_Delete(body_parse);
+                        } else {
+                            mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse relationship '%s' JSON body.", ms_graph->resources[resource_num].relationships[relationship_num]);
+                        }
+                    }
+                    wurl_free_response(response);
+                } else {
+                    mtwarn(WM_MS_GRAPH_LOGTAG, "No response received when attempting to get relationship '%s' from resource '%s' on API version '%s'.",
+                    ms_graph->resources[resource_num].relationships[relationship_num],
+                    ms_graph->resources[resource_num].name,
+                    ms_graph->version);
+                }
+            }
+
+            if (!inventory && !fail) {
+                relationship_state_struc.next_time = now;
+                if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
+                    mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state.");
+                } else {
+                    mtdebug1(WM_MS_GRAPH_LOGTAG, "Bookmark updated to '%s' for tenant '%s' resource '%s' and relationship '%s', waiting '%d' seconds to run next scan.",
+                        end_time_str, auth_config->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num], ms_graph->scan_config.interval);
+                }
+            }
+            os_free(headers[0]);
+        }
+    }
+}
+
+cJSON* wm_ms_graph_scan_apps_devices(const wm_ms_graph* ms_graph, const cJSON* app_id, const char* query_fqdn, char** headers) {
+    char url[OS_SIZE_8192] = { '\0' };
+    curl_response* response;
+    bool next_page;
+
+    cJSON *array = cJSON_CreateArray();
+
+    if (cJSON_IsString(app_id)) {
+        snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL_FILTER_DEVICE_FIELDS, query_fqdn, ms_graph->version, WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT,
+            WM_MS_GRAPH_RELATIONSHIP_DETECTED_APPS, app_id->valuestring, WM_MS_GRAPH_RELATIONSHIP_MANAGED_DEVICES, WM_MS_GRAPH_ITEM_PER_PAGE);
+
+        next_page = true;
+        while (next_page) {
+            mtdebug1(WM_MS_GRAPH_LOGTAG, "Microsoft Graph API Log URL: '%s'", url);
+
+            next_page = false;
+            response = wurl_http_request(WURL_GET_METHOD, headers, url, "", ms_graph->curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
+            if (response) {
+                if (response->status_code == 200 && !response->max_size_reached) {
+                    cJSON* body_parse = NULL;
+                    if (body_parse = cJSON_Parse(response->body), body_parse) {
+                        cJSON* logs = cJSON_GetObjectItem(body_parse, "value");
+                        int num_logs = cJSON_GetArraySize(logs);
+                        if (num_logs > 0) {
+                            for (int log_index = 0; log_index < num_logs; log_index++) {
+                                cJSON* log = NULL;
+                                if (log = cJSON_GetArrayItem(logs, log_index), log) {
+                                    cJSON_AddItemToArray(array, cJSON_Duplicate(log, true));
+                                }
+                            }
+                        }
+
+                        cJSON* next_url = cJSON_GetObjectItem(body_parse, "@odata.nextLink");
+                        if (cJSON_IsString(next_url)) {
+                            memset(url, '\0', OS_SIZE_8192);
+                            snprintf(url, OS_SIZE_8192 -1, "%s", next_url->valuestring);
+                            next_page = true;
+                        }
+
+                        cJSON_Delete(body_parse);
                     }
                 }
-                os_free(headers[0]);
+                wurl_free_response(response);
             }
         }
     }
+
+    return array;
 }
 
 void wm_ms_graph_destroy(wm_ms_graph* ms_graph) {

--- a/src/modules/ms_graph/src/wm_ms_graph.c
+++ b/src/modules/ms_graph/src/wm_ms_graph.c
@@ -265,6 +265,13 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_sc
                         WM_MS_GRAPH_ITEM_PER_PAGE,
                         start_time_str,
                         end_time_str);
+                    } else if (!strcmp(ms_graph->resources[resource_num].relationships[relationship_num], WM_MS_GRAPH_RELATIONSHIP_DETECTED_APPS)) {
+                        snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL_EXPAND_DEVICES,
+                        it->query_fqdn,
+                        ms_graph->version,
+                        WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT,
+                        ms_graph->resources[resource_num].relationships[relationship_num],
+                        WM_MS_GRAPH_ITEM_PER_PAGE);
                     } else {
                         snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL,
                         it->query_fqdn,

--- a/src/modules/ms_graph/src/wm_ms_graph.c
+++ b/src/modules/ms_graph/src/wm_ms_graph.c
@@ -202,6 +202,21 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, wm_ms_graph_auth* aut
     bool next_page;
     bool inventory = false;
 
+#ifndef WIN32
+    int id = os_random();
+    if (id < 0) {
+        id = -id;
+    }
+#else
+    char random_id[RANDOM_LENGTH];
+    snprintf(random_id, RANDOM_LENGTH - 1, "%u%u", os_random(), os_random());
+    int id = atoi(random_id);
+
+    if (id < 0) {
+        id = -id;
+    }
+#endif
+
     for (unsigned int resource_num = 0; resource_num < ms_graph->num_resources; resource_num++) {
 
         for (unsigned int relationship_num = 0; relationship_num < ms_graph->resources[resource_num].num_relationships; relationship_num++) {
@@ -319,6 +334,10 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, wm_ms_graph_auth* aut
 
                                         cJSON_AddStringToObject(log, "resource", ms_graph->resources[resource_num].name);
                                         cJSON_AddStringToObject(log, "relationship", ms_graph->resources[resource_num].relationships[relationship_num]);
+
+                                        if (inventory) {
+                                            cJSON_AddNumberToObject(full_log, "scan_id", id);
+                                        }
                                         cJSON_AddStringToObject(full_log, "integration", WM_MS_GRAPH_CONTEXT.name);
                                         cJSON_AddItemToObject(full_log, WM_MS_GRAPH_CONTEXT.name, cJSON_Duplicate(log, true));
 

--- a/src/modules/ms_graph/src/wm_ms_graph.c
+++ b/src/modules/ms_graph/src/wm_ms_graph.c
@@ -198,6 +198,7 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_sc
     wm_ms_graph_state_t relationship_state_struc;
     time_t now;
     bool fail;
+    bool next_page;
 
     for (unsigned int resource_num = 0; resource_num < ms_graph->num_resources; resource_num++) {
 
@@ -251,6 +252,7 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_sc
                         ms_graph->version,
                         WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT,
                         WM_MS_GRAPH_RELATIONSHIP_AUDIT_EVENTS,
+                        WM_MS_GRAPH_ITEM_PER_PAGE,
                         start_time_str,
                         end_time_str);
                     } else {
@@ -258,7 +260,8 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_sc
                         it->query_fqdn,
                         ms_graph->version,
                         WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT,
-                        ms_graph->resources[resource_num].relationships[relationship_num]);
+                        ms_graph->resources[resource_num].relationships[relationship_num],
+                        WM_MS_GRAPH_ITEM_PER_PAGE);
                     }
                 } else {
                     snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL_FILTER_CREATED_DATE,
@@ -266,70 +269,83 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, const bool initial_sc
                     ms_graph->version,
                     ms_graph->resources[resource_num].name,
                     ms_graph->resources[resource_num].relationships[relationship_num],
+                    WM_MS_GRAPH_ITEM_PER_PAGE,
                     start_time_str,
                     end_time_str);
                 }
 
-                mtdebug1(WM_MS_GRAPH_LOGTAG, "Microsoft Graph API Log URL: '%s'", url);
+                next_page = true;
+                while (next_page) {
+                    mtdebug1(WM_MS_GRAPH_LOGTAG, "Microsoft Graph API Log URL: '%s'", url);
 
-                fail = true;
-                response = wurl_http_request(WURL_GET_METHOD, headers, url, "", ms_graph->curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
-                if (response) {
-                    if (response->status_code != 200) {
-                        char status_code[4];
-                        snprintf(status_code, 4, "%ld", response->status_code);
-                        mtwarn(WM_MS_GRAPH_LOGTAG, "Received unsuccessful status code when attempting to get relationship '%s' logs: Status code was '%s' & response was '%s'",
-                        ms_graph->resources[resource_num].relationships[relationship_num],
-                        status_code,
-                        response->body);
-                    } else if (response->max_size_reached) {
-                        mtwarn(WM_MS_GRAPH_LOGTAG, "Reached maximum CURL size when attempting to get relationship '%s' logs. Consider increasing the value of 'curl_max_size'.",
-                        ms_graph->resources[resource_num].relationships[relationship_num]);
-                    } else {
-                        cJSON* body_parse = NULL;
-                        if (body_parse = cJSON_Parse(response->body), body_parse) {
-                            cJSON* logs = cJSON_GetObjectItem(body_parse, "value");
-                            int num_logs = cJSON_GetArraySize(logs);
-                            if (num_logs > 0) {
-                                for (int log_index = 0; log_index < num_logs; log_index++) {
-                                    cJSON* log = NULL;
-                                    if (log = cJSON_GetArrayItem(logs, log_index), log) {
-                                        cJSON* full_log = cJSON_CreateObject();
-                                        char* payload;
-
-                                        cJSON_AddStringToObject(log, "resource", ms_graph->resources[resource_num].name);
-                                        cJSON_AddStringToObject(log, "relationship", ms_graph->resources[resource_num].relationships[relationship_num]);
-                                        cJSON_AddStringToObject(full_log, "integration", WM_MS_GRAPH_CONTEXT.name);
-                                        cJSON_AddItemToObject(full_log, WM_MS_GRAPH_CONTEXT.name, cJSON_Duplicate(log, true));
-
-                                        payload = cJSON_PrintUnformatted(full_log);
-                                        mtdebug2(WM_MS_GRAPH_LOGTAG, "Sending log: '%s'", payload);
-                                        if (wm_sendmsg(1000000 / wm_max_eps, queue_fd, payload, WM_MS_GRAPH_CONTEXT.name, LOCALFILE_MQ) < 0) {
-                                            mterror(WM_MS_GRAPH_LOGTAG, QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
-                                        }
-
-                                        os_free(payload);
-                                        cJSON_Delete(full_log);
-                                    } else {
-                                        mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse log array into singular log.");
-                                    }
-                                }
-                                fail = false;
-                            } else {
-                                mtdebug2(WM_MS_GRAPH_LOGTAG, "No new logs received.");
-                                fail = false;
-                            }
-                            cJSON_Delete(body_parse);
+                    fail = true;
+                    next_page = false;
+                    response = wurl_http_request(WURL_GET_METHOD, headers, url, "", ms_graph->curl_max_size, WM_MS_GRAPH_DEFAULT_TIMEOUT);
+                    if (response) {
+                        if (response->status_code != 200) {
+                            char status_code[4];
+                            snprintf(status_code, 4, "%ld", response->status_code);
+                            mtwarn(WM_MS_GRAPH_LOGTAG, "Received unsuccessful status code when attempting to get relationship '%s' logs: Status code was '%s' & response was '%s'",
+                            ms_graph->resources[resource_num].relationships[relationship_num],
+                            status_code,
+                            response->body);
+                        } else if (response->max_size_reached) {
+                            mtwarn(WM_MS_GRAPH_LOGTAG, "Reached maximum CURL size when attempting to get relationship '%s' logs. Consider increasing the value of 'curl_max_size'.",
+                            ms_graph->resources[resource_num].relationships[relationship_num]);
                         } else {
-                            mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse relationship '%s' JSON body.", ms_graph->resources[resource_num].relationships[relationship_num]);
+                            cJSON* body_parse = NULL;
+                            if (body_parse = cJSON_Parse(response->body), body_parse) {
+                                cJSON* logs = cJSON_GetObjectItem(body_parse, "value");
+                                int num_logs = cJSON_GetArraySize(logs);
+                                if (num_logs > 0) {
+                                    for (int log_index = 0; log_index < num_logs; log_index++) {
+                                        cJSON* log = NULL;
+                                        if (log = cJSON_GetArrayItem(logs, log_index), log) {
+                                            cJSON* full_log = cJSON_CreateObject();
+                                            char* payload;
+
+                                            cJSON_AddStringToObject(log, "resource", ms_graph->resources[resource_num].name);
+                                            cJSON_AddStringToObject(log, "relationship", ms_graph->resources[resource_num].relationships[relationship_num]);
+                                            cJSON_AddStringToObject(full_log, "integration", WM_MS_GRAPH_CONTEXT.name);
+                                            cJSON_AddItemToObject(full_log, WM_MS_GRAPH_CONTEXT.name, cJSON_Duplicate(log, true));
+
+                                            payload = cJSON_PrintUnformatted(full_log);
+                                            mtdebug2(WM_MS_GRAPH_LOGTAG, "Sending log: '%s'", payload);
+                                            if (wm_sendmsg(1000000 / wm_max_eps, queue_fd, payload, WM_MS_GRAPH_CONTEXT.name, LOCALFILE_MQ) < 0) {
+                                                mterror(WM_MS_GRAPH_LOGTAG, QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
+                                            }
+
+                                            os_free(payload);
+                                            cJSON_Delete(full_log);
+                                        } else {
+                                            mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse log array into singular log.");
+                                        }
+                                    }
+                                    fail = false;
+                                } else {
+                                    mtdebug2(WM_MS_GRAPH_LOGTAG, "No new logs received.");
+                                    fail = false;
+                                }
+
+                                cJSON* next_url = cJSON_GetObjectItem(body_parse, "@odata.nextLink");
+                                if (cJSON_IsString(next_url)) {
+                                    memset(url, '\0', OS_SIZE_8192);
+                                    snprintf(url, OS_SIZE_8192 -1, "%s", next_url->valuestring);
+                                    next_page = true;
+                                }
+
+                                cJSON_Delete(body_parse);
+                            } else {
+                                mtwarn(WM_MS_GRAPH_LOGTAG, "Failed to parse relationship '%s' JSON body.", ms_graph->resources[resource_num].relationships[relationship_num]);
+                            }
                         }
+                        wurl_free_response(response);
+                    } else {
+                        mtwarn(WM_MS_GRAPH_LOGTAG, "No response received when attempting to get relationship '%s' from resource '%s' on API version '%s'.",
+                        ms_graph->resources[resource_num].relationships[relationship_num],
+                        ms_graph->resources[resource_num].name,
+                        ms_graph->version);
                     }
-                    wurl_free_response(response);
-                } else {
-                    mtwarn(WM_MS_GRAPH_LOGTAG, "No response received when attempting to get relationship '%s' from resource '%s' on API version '%s'.",
-                    ms_graph->resources[resource_num].relationships[relationship_num],
-                    ms_graph->resources[resource_num].name,
-                    ms_graph->version);
                 }
 
                 if (!fail) {

--- a/src/modules/ms_graph/tests/integration/test_API/data/response_samples/responses.json
+++ b/src/modules/ms_graph/tests/integration/test_API/data/response_samples/responses.json
@@ -20,7 +20,7 @@
       }
     },
     {
-      "url": "http://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+gt+*",
+      "url": "http://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
       "method": "GET",
       "responseCode": 200,
       "responseBody": {
@@ -30,7 +30,7 @@
       }
     },
     {
-      "url": "http://graph.microsoft.com/v1.0/security/incidents?$filter=createdDateTime+gt+*",
+      "url": "http://graph.microsoft.com/v1.0/security/incidents?$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
       "method": "GET",
       "responseCode": 200,
       "responseBody": {
@@ -40,7 +40,7 @@
       }
     },
     {
-      "url": "http://graph.microsoft.com/v1.0/resource_name/resource_relationship?$filter=createdDateTime+gt+*",
+      "url": "http://graph.microsoft.com/v1.0/resource_name/resource_relationship?$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
       "method": "GET",
       "responseCode": 200,
       "responseBody": {
@@ -50,7 +50,7 @@
       }
     },
     {
-      "url": "http://*/*/*/*$filter=createdDateTime+gt+*",
+      "url": "http://*/*/*/*$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
       "method": "GET",
       "responseCode": 403,
       "responseBody": {

--- a/src/modules/ms_graph/tests/integration/test_API/data/response_samples/responses.json
+++ b/src/modules/ms_graph/tests/integration/test_API/data/response_samples/responses.json
@@ -20,7 +20,7 @@
       }
     },
     {
-      "url": "http://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
+      "url": "http://graph.microsoft.com/v1.0/security/alerts_v2?$top=*&$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
       "method": "GET",
       "responseCode": 200,
       "responseBody": {
@@ -30,7 +30,7 @@
       }
     },
     {
-      "url": "http://graph.microsoft.com/v1.0/security/incidents?$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
+      "url": "http://graph.microsoft.com/v1.0/security/incidents?$top=*&$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
       "method": "GET",
       "responseCode": 200,
       "responseBody": {
@@ -40,7 +40,7 @@
       }
     },
     {
-      "url": "http://graph.microsoft.com/v1.0/resource_name/resource_relationship?$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
+      "url": "http://graph.microsoft.com/v1.0/resource_name/resource_relationship?$top=*&$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
       "method": "GET",
       "responseCode": 200,
       "responseBody": {
@@ -50,7 +50,7 @@
       }
     },
     {
-      "url": "http://*/*/*/*$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
+      "url": "http://*/*/*/*$top=*&$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
       "method": "GET",
       "responseCode": 403,
       "responseBody": {

--- a/src/modules/ms_graph/tests/unit/tests/CMakeLists.txt
+++ b/src/modules/ms_graph/tests/unit/tests/CMakeLists.txt
@@ -14,8 +14,8 @@ list(APPEND tests_flags "-Wl,--wrap=_merror -Wl,--wrap=_mtinfo -Wl,--wrap=_mtwar
                         -Wl,--wrap,atexit -Wl,--wrap,time -Wl,--wrap,wm_state_io -Wl,--wrap,StartMQ -Wl,--wrap,gmtime_r -Wl,--wrap,isDebug \
                         -Wl,--wrap,sched_scan_get_time_until_next_scan -Wl,--wrap,is_fim_shutdown -Wl,--wrap,fim_db_teardown -Wl,--wrap,Start_win32_Syscheck \
                         -Wl,--wrap,strftime -Wl,--wrap,_mtdebug2 -Wl,--wrap,wm_sendmsg -Wl,--wrap,strerror -Wl,--wrap,_imp__rsync_initialize \
-                        -Wl,--wrap,syscom_dispatch -Wl,--wrap,_imp__dbsync_initialize -Wl,--wrap,w_get_timestamp -Wl,--wrap,FOREVER")
-                        
+                        -Wl,--wrap,syscom_dispatch -Wl,--wrap,_imp__dbsync_initialize -Wl,--wrap,w_get_timestamp -Wl,--wrap,os_random -Wl,--wrap,FOREVER")
+
 
 list(APPEND use_shared_libs 1)
 

--- a/src/modules/ms_graph/tests/unit/tests/test_wm_ms_graph.c
+++ b/src/modules/ms_graph/tests/unit/tests/test_wm_ms_graph.c
@@ -1361,6 +1361,12 @@ void test_main_relationships(void **state) {
 
     will_return(__wrap_FOREVER, 1);
 
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
+
     expect_string(__wrap_wm_state_io, tag, "ms-graph");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
     expect_value(__wrap_wm_state_io, state, &module_data->state);
@@ -2063,6 +2069,12 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no(void **state) {
     size_t max_size = OS_SIZE_8192;
     bool initial = true;
 
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
+
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
     expect_any(__wrap_wm_state_io, state);
@@ -2130,6 +2142,12 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_yes_fail_write(void
     size_t max_size = OS_SIZE_8192;
     bool initial = true;
 
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
+
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
     expect_any(__wrap_wm_state_io, state);
@@ -2191,6 +2209,12 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_res
     module_data->resources[0].num_relationships = 1;
     size_t max_size = OS_SIZE_8192;
     bool initial = true;
+
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
 
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
@@ -2271,6 +2295,12 @@ void test_wm_ms_graph_scan_relationships_single_no_initial_no_timestamp(void **s
     size_t max_size = OS_SIZE_8192;
     bool initial = false;
 
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
+
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
     expect_any(__wrap_wm_state_io, state);
@@ -2345,6 +2375,12 @@ void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **
     response->status_code = 400;
     os_strdup("{\"error\":\"bad_request\"}", response->body);
     os_strdup("test", response->header);
+
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
 
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
@@ -2432,6 +2468,12 @@ void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) 
     os_strdup("{\"error\":\"bad_request\"}", response->body);
     os_strdup("test", response->header);
 
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
+
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
     expect_any(__wrap_wm_state_io, state);
@@ -2518,6 +2560,12 @@ void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
     os_strdup("no json", response->body);
     os_strdup("test", response->header);
 
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
+
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
     expect_any(__wrap_wm_state_io, state);
@@ -2603,6 +2651,12 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
     response->max_size_reached = false;
     os_strdup("{\"value\":[]}", response->body);
     os_strdup("test", response->header);
+
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
 
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
@@ -2699,6 +2753,12 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
     response->max_size_reached = false;
     os_strdup("{\"value\":[{\"full_log\":\"log1\"}]}", response->body);
     os_strdup("test", response->header);
+
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
 
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
@@ -2803,6 +2863,12 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     os_strdup("{\"value\":[{\"full_log\":\"log1\"},{\"full_log\":\"log2\"}]}", response->body);
     os_strdup("test", response->header);
 
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
+
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps?$top=100'");
 
@@ -2815,12 +2881,20 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     will_return(__wrap_wurl_http_request, response);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}'");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"scan_id\":1234512345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}'");
+#else
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"scan_id\":12345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}'");
+#endif
 
     queue_fd = 0;
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, queue_fd);
-    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap_wm_sendmsg, message, "{\"scan_id\":1234512345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}");
+#else
+    expect_string(__wrap_wm_sendmsg, message, "{\"scan_id\":12345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}");
+#endif
     expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, -1);
@@ -2831,11 +2905,19 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Error'");
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}'");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"scan_id\":1234512345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}'");
+#else
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"scan_id\":12345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}'");
+#endif
 
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, queue_fd);
-    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap_wm_sendmsg, message, "{\"scan_id\":1234512345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}");
+#else
+    expect_string(__wrap_wm_sendmsg, message, "{\"scan_id\":12345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}");
+#endif
     expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, 1);
@@ -2893,6 +2975,12 @@ void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) 
     os_strdup("{\"@odata.nextLink\":\"next_page_url\",\"value\":[{\"full_log\":\"log1\"},{\"full_log\":\"log2\"}]}", response->body);
     os_strdup("test", response->header);
 
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
+
     os_calloc(1, sizeof(curl_response), response2);
     response2->status_code = 200;
     response2->max_size_reached = false;
@@ -2911,12 +2999,20 @@ void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) 
     will_return(__wrap_wurl_http_request, response);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}'");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"scan_id\":1234512345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}'");
+#else
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"scan_id\":12345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}'");
+#endif
 
     queue_fd = 0;
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, queue_fd);
-    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap_wm_sendmsg, message, "{\"scan_id\":1234512345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}");
+#else
+    expect_string(__wrap_wm_sendmsg, message, "{\"scan_id\":12345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}");
+#endif
     expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, -1);
@@ -2927,11 +3023,19 @@ void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) 
     expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Error'");
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}'");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"scan_id\":1234512345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}'");
+#else
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"scan_id\":12345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}'");
+#endif
 
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, queue_fd);
-    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap_wm_sendmsg, message, "{\"scan_id\":1234512345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}");
+#else
+    expect_string(__wrap_wm_sendmsg, message, "{\"scan_id\":12345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}");
+#endif
     expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, 1);
@@ -2948,12 +3052,20 @@ void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) 
     will_return(__wrap_wurl_http_request, response2);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log3\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}'");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"scan_id\":1234512345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log3\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}'");
+#else
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"scan_id\":12345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log3\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}'");
+#endif
 
     queue_fd = 0;
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, queue_fd);
-    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log3\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap_wm_sendmsg, message, "{\"scan_id\":1234512345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log3\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}");
+#else
+    expect_string(__wrap_wm_sendmsg, message, "{\"scan_id\":12345,\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log3\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}");
+#endif
     expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, 1);
@@ -3021,6 +3133,12 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     response->max_size_reached = false;
     os_strdup("{\"value\":[{\"full_log\":\"log1\"}]}", response->body);
     os_strdup("test", response->header);
+
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
 
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);

--- a/src/modules/ms_graph/tests/unit/tests/test_wm_ms_graph.c
+++ b/src/modules/ms_graph/tests/unit/tests/test_wm_ms_graph.c
@@ -2086,7 +2086,7 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run first scan.");
 
-    wm_ms_graph_scan_relationships(module_data, initial);
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
 
 void test_wm_ms_graph_scan_relationships_single_initial_only_yes_fail_write(void **state) {
@@ -2145,7 +2145,7 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_yes_fail_write(void
     expect_string(__wrap__mterror, tag, WM_MS_GRAPH_LOGTAG);
     expect_string(__wrap__mterror, formatted_msg, "Couldn't save running state.");
 
-    wm_ms_graph_scan_relationships(module_data, initial);
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
 
 void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_response(void **state) {
@@ -2225,7 +2225,7 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_res
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtwarn, formatted_msg, "No response received when attempting to get relationship 'alerts_v2' from resource 'security' on API version 'v1.0'.");
 
-    wm_ms_graph_scan_relationships(module_data, initial);
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
 
 void test_wm_ms_graph_scan_relationships_single_no_initial_no_timestamp(void **state) {
@@ -2294,7 +2294,7 @@ void test_wm_ms_graph_scan_relationships_single_no_initial_no_timestamp(void **s
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run first scan.");
 
-    wm_ms_graph_scan_relationships(module_data, initial);
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
 
 void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **state) {
@@ -2379,7 +2379,7 @@ void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtwarn, formatted_msg, "Received unsuccessful status code when attempting to get relationship 'alerts_v2' logs: Status code was '400' & response was '{\"error\":\"bad_request\"}'");
 
-    wm_ms_graph_scan_relationships(module_data, initial);
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
 
 void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) {
@@ -2465,7 +2465,7 @@ void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) 
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtwarn, formatted_msg, "Reached maximum CURL size when attempting to get relationship 'alerts_v2' logs. Consider increasing the value of 'curl_max_size'.");
 
-    wm_ms_graph_scan_relationships(module_data, initial);
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
 
 void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
@@ -2551,7 +2551,7 @@ void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtwarn, formatted_msg, "Failed to parse relationship 'alerts_v2' JSON body.");
 
-    wm_ms_graph_scan_relationships(module_data, initial);
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
 
 void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
@@ -2646,7 +2646,7 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:25:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
 
-    wm_ms_graph_scan_relationships(module_data, initial);
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
 
 void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
@@ -2751,7 +2751,7 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:25:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
 
-    wm_ms_graph_scan_relationships(module_data, initial);
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
 
 void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
@@ -2804,7 +2804,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     os_strdup("test", response->header);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps?$top=100&$expand=managedDevices($select=id)'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps?$top=100'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2815,12 +2815,12 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     will_return(__wrap_wurl_http_request, response);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}'");
 
     queue_fd = 0;
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, queue_fd);
-    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}");
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}");
     expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, -1);
@@ -2831,16 +2831,16 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Error'");
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}'");
 
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, queue_fd);
-    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}");
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"managedDevices\":[],\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}");
     expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, 1);
 
-    wm_ms_graph_scan_relationships(module_data, initial);
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
 
 void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) {
@@ -2958,7 +2958,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) 
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, 1);
 
-    wm_ms_graph_scan_relationships(module_data, initial);
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
 
 void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **state) {
@@ -3129,7 +3129,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mterror, formatted_msg, "Couldn't save running state.");
 
-    wm_ms_graph_scan_relationships(module_data, initial);
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
 
 int main(void) {

--- a/src/modules/ms_graph/tests/unit/tests/test_wm_ms_graph.c
+++ b/src/modules/ms_graph/tests/unit/tests/test_wm_ms_graph.c
@@ -2205,8 +2205,14 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_res
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+    will_return(__wrap_strftime,"2023-02-08T12:25:56Z");
+    will_return(__wrap_strftime, 20);
+
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+gt+2023-02-08T12:24:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2353,8 +2359,14 @@ void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+    will_return(__wrap_strftime,"2023-02-08T12:25:56Z");
+    will_return(__wrap_strftime, 20);
+
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+gt+2023-02-08T12:24:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2433,8 +2445,14 @@ void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) 
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+    will_return(__wrap_strftime,"2023-02-08T12:25:56Z");
+    will_return(__wrap_strftime, 20);
+
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+gt+2023-02-08T12:24:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2513,8 +2531,14 @@ void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+    will_return(__wrap_strftime,"2023-02-08T12:25:56Z");
+    will_return(__wrap_strftime, 20);
+
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+gt+2023-02-08T12:24:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2593,8 +2617,14 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+    will_return(__wrap_strftime,"2023-02-08T12:25:56Z");
+    will_return(__wrap_strftime, 20);
+
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+gt+2023-02-08T12:24:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2607,12 +2637,6 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
     expect_string(__wrap__mtdebug2, formatted_msg, "No new logs received.");
 
-#ifndef WIN32
-    will_return(__wrap_gmtime_r, 1);
-#endif
-    will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
-    will_return(__wrap_strftime, 20);
-
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_WRITE);
     expect_any(__wrap_wm_state_io, state);
@@ -2620,7 +2644,7 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
     will_return(__wrap_wm_state_io, 1);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:25:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
 }
@@ -2689,8 +2713,14 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+    will_return(__wrap_strftime,"2023-02-08T12:25:56Z");
+    will_return(__wrap_strftime, 20);
+
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+gt+2023-02-08T12:24:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2712,12 +2742,6 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, result);
 
-#ifndef WIN32
-    will_return(__wrap_gmtime_r, 1);
-#endif
-    will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
-    will_return(__wrap_strftime, 20);
-
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_WRITE);
     expect_any(__wrap_wm_state_io, state);
@@ -2725,7 +2749,7 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
     will_return(__wrap_wm_state_io, 1);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:25:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
 }
@@ -2794,8 +2818,14 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+    will_return(__wrap_strftime,"2023-02-08T12:25:56Z");
+    will_return(__wrap_strftime, 20);
+
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+gt+2023-02-08T12:24:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2831,12 +2861,6 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, 1);
 
-#ifndef WIN32
-    will_return(__wrap_gmtime_r, 1);
-#endif
-    will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
-    will_return(__wrap_strftime, 20);
-
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_WRITE);
     expect_any(__wrap_wm_state_io, state);
@@ -2844,7 +2868,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     will_return(__wrap_wm_state_io, 1);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:25:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
 }
@@ -2891,13 +2915,13 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     os_strdup(WM_MS_GRAPH_GLOBAL_API_QUERY_FQDN, module_data->auth_config[0]->query_fqdn);
     os_malloc(sizeof(wm_ms_graph_resource) * 2, module_data->resources);
     os_strdup("security", module_data->resources[0].name);
-    os_strdup("auditlogs", module_data->resources[1].name);
+    os_strdup("deviceManagement", module_data->resources[1].name);
     module_data->num_resources = 2;
     os_malloc(sizeof(char*) * 2, module_data->resources[0].relationships);
     os_strdup("alerts_v2", module_data->resources[0].relationships[0]);
     module_data->resources[0].num_relationships = 1;
     os_malloc(sizeof(char*) * 2, module_data->resources[1].relationships);
-    os_strdup("signIns", module_data->resources[1].relationships[0]);
+    os_strdup("auditEvents", module_data->resources[1].relationships[0]);
     module_data->resources[1].num_relationships = 1;
     size_t max_size = OS_SIZE_8192;
     bool initial = false;
@@ -2923,8 +2947,14 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+    will_return(__wrap_strftime,"2023-02-08T12:25:56Z");
+    will_return(__wrap_strftime, 20);
+
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+gt+2023-02-08T12:24:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2945,12 +2975,6 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, 1);
 
-#ifndef WIN32
-    will_return(__wrap_gmtime_r, 1);
-#endif
-    will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
-    will_return(__wrap_strftime, 20);
-
     expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
     expect_value(__wrap_wm_state_io, op, WM_IO_WRITE);
     expect_any(__wrap_wm_state_io, state);
@@ -2958,7 +2982,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_wm_state_io, 1);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:25:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
 
     // resource auditlogs
     os_calloc(1, sizeof(curl_response), response);
@@ -2967,7 +2991,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     os_strdup("{\"value\":[{\"full_log\":\"log1_resource_2\"}]}", response->body);
     os_strdup("test", response->header);
 
-    expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-auditlogs-signIns");
+    expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-deviceManagement-auditEvents");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
     expect_any(__wrap_wm_state_io, state);
     expect_any(__wrap_wm_state_io, size);
@@ -2980,8 +3004,14 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+    will_return(__wrap_strftime,"2023-02-08T12:25:56Z");
+    will_return(__wrap_strftime, 20);
+
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/auditlogs/signIns?$filter=createdDateTime+gt+2023-02-08T12:24:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/auditEvents?$filter=activityDateTime+ge+2023-02-08T12:24:56Z+and+activityDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2992,23 +3022,17 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_wurl_http_request, response);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1_resource_2\",\"resource\":\"auditlogs\",\"relationship\":\"signIns\"}}'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1_resource_2\",\"resource\":\"deviceManagement\",\"relationship\":\"auditEvents\"}}'");
 
     queue_fd = 0;
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, queue_fd);
-    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1_resource_2\",\"resource\":\"auditlogs\",\"relationship\":\"signIns\"}}");
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1_resource_2\",\"resource\":\"deviceManagement\",\"relationship\":\"auditEvents\"}}");
     expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, 1);
 
-#ifndef WIN32
-    will_return(__wrap_gmtime_r, 1);
-#endif
-    will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
-    will_return(__wrap_strftime, 20);
-
-    expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-auditlogs-signIns");
+    expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-deviceManagement-auditEvents");
     expect_value(__wrap_wm_state_io, op, WM_IO_WRITE);
     expect_any(__wrap_wm_state_io, state);
     expect_any(__wrap_wm_state_io, size);

--- a/src/modules/ms_graph/tests/unit/tests/test_wm_ms_graph.c
+++ b/src/modules/ms_graph/tests/unit/tests/test_wm_ms_graph.c
@@ -2212,7 +2212,7 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_res
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2366,7 +2366,7 @@ void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2452,7 +2452,7 @@ void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) 
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2538,7 +2538,7 @@ void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2624,7 +2624,7 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2720,7 +2720,7 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2825,7 +2825,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2873,6 +2873,124 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     wm_ms_graph_scan_relationships(module_data, initial);
 }
 
+void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) {
+    /*
+    <enabled>yes</enabled>
+    <only_future_events>no</only_future_events>
+    <curl_max_size>1M</curl_max_size>
+    <run_on_start>yes</run_on_start>
+    <version>v1.0</version>
+    <api_auth>
+      <client_id>example_client</client_id>
+      <tenant_id>example_tenant</tenant_id>
+      <secret_value>example_secret</secret_value>
+      <api_type>global</api_type>
+    </api_auth>
+    <resource>
+      <name>deviceManagement</name>
+      <relationship>managedDevices</relationship>
+    </resource>
+    */
+    wm_ms_graph* module_data = (wm_ms_graph *)*state;
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
+    module_data->enabled = true;
+    module_data->only_future_events = false;
+    module_data->curl_max_size = 1024L;
+    module_data->run_on_start = true;
+    module_data->scan_config.interval = 60;
+    os_strdup("v1.0", module_data->version);
+    os_strdup("example_client", module_data->auth_config[0]->client_id);
+    os_strdup("example_tenant", module_data->auth_config[0]->tenant_id);
+    os_strdup("example_secret", module_data->auth_config[0]->secret_value);
+    os_strdup(WM_MS_GRAPH_GLOBAL_API_LOGIN_FQDN, module_data->auth_config[0]->login_fqdn);
+    os_strdup(WM_MS_GRAPH_GLOBAL_API_QUERY_FQDN, module_data->auth_config[0]->query_fqdn);
+    os_malloc(sizeof(wm_ms_graph_resource), module_data->resources);
+    os_strdup("deviceManagement", module_data->resources[0].name);
+    module_data->num_resources = 1;
+    os_malloc(sizeof(char*), module_data->resources[0].relationships);
+    os_strdup("managedDevices", module_data->resources[0].relationships[0]);
+    module_data->resources[0].num_relationships = 1;
+    size_t max_size = OS_SIZE_8192;
+    bool initial = false;
+    curl_response* response;
+    curl_response* response2;
+    wm_max_eps = 1;
+
+    os_calloc(1, sizeof(curl_response), response);
+    response->status_code = 200;
+    response->max_size_reached = false;
+    os_strdup("{\"@odata.nextLink\":\"next_page_url\",\"value\":[{\"full_log\":\"log1\"},{\"full_log\":\"log2\"}]}", response->body);
+    os_strdup("test", response->header);
+
+    os_calloc(1, sizeof(curl_response), response2);
+    response2->status_code = 200;
+    response2->max_size_reached = false;
+    os_strdup("{\"value\":[{\"full_log\":\"log3\"}]}", response2->body);
+    os_strdup("test2", response2->header);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/managedDevices?$top=100'");
+
+    expect_any(__wrap_wurl_http_request, method);
+    expect_any(__wrap_wurl_http_request, header);
+    expect_any(__wrap_wurl_http_request, url);
+    expect_any(__wrap_wurl_http_request, payload);
+    expect_any(__wrap_wurl_http_request, max_size);
+    expect_value(__wrap_wurl_http_request, timeout, WM_MS_GRAPH_DEFAULT_TIMEOUT);
+    will_return(__wrap_wurl_http_request, response);
+
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}'");
+
+    queue_fd = 0;
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue_fd);
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+    will_return(__wrap_wm_sendmsg, -1);
+
+    will_return(__wrap_strerror, "Error");
+
+    expect_string(__wrap__mterror, tag, WM_MS_GRAPH_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Error'");
+
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}'");
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue_fd);
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+    will_return(__wrap_wm_sendmsg, 1);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'next_page_url'");
+
+    expect_any(__wrap_wurl_http_request, method);
+    expect_any(__wrap_wurl_http_request, header);
+    expect_any(__wrap_wurl_http_request, url);
+    expect_any(__wrap_wurl_http_request, payload);
+    expect_any(__wrap_wurl_http_request, max_size);
+    expect_value(__wrap_wurl_http_request, timeout, WM_MS_GRAPH_DEFAULT_TIMEOUT);
+    will_return(__wrap_wurl_http_request, response2);
+
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log3\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}'");
+
+    queue_fd = 0;
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue_fd);
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log3\",\"resource\":\"deviceManagement\",\"relationship\":\"managedDevices\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+    will_return(__wrap_wm_sendmsg, 1);
+
+    wm_ms_graph_scan_relationships(module_data, initial);
+}
+
 void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **state) {
     /*
     <enabled>yes</enabled>
@@ -2891,8 +3009,8 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
       <relationship>alerts_v2</relationship>
     </resource>
     <resource>
-      <name>auditlogs</name>
-      <relationship>signIns</relationship>
+      <name>deviceManagement</name>
+      <relationship>auditEvents</relationship>
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
@@ -2954,7 +3072,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -3011,7 +3129,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/auditEvents?$filter=activityDateTime+ge+2023-02-08T12:24:56Z+and+activityDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/auditEvents?$top=100&$filter=activityDateTime+ge+2023-02-08T12:24:56Z+and+activityDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -3109,6 +3227,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_no_logs, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_success_one_log, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_success_two_logs, setup_conf, teardown_conf),
+        cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_success_two_pages, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_success_two_resources, setup_conf, teardown_conf)
     };
     int result = 0;

--- a/src/modules/ms_graph/tests/unit/tests/test_wm_ms_graph.c
+++ b/src/modules/ms_graph/tests/unit/tests/test_wm_ms_graph.c
@@ -2768,15 +2768,13 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
       <api_type>global</api_type>
     </api_auth>
     <resource>
-      <name>security</name>
-      <relationship>alerts_v2</relationship>
+      <name>deviceManagement</name>
+      <relationship>detectedApps</relationship>
     </resource>
     */
     wm_ms_graph* module_data = (wm_ms_graph *)*state;
-    wm_ms_graph_state_t relationship_state_struc;
     os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
     os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
-    relationship_state_struc.next_time = 10;
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
@@ -2789,10 +2787,10 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     os_strdup(WM_MS_GRAPH_GLOBAL_API_LOGIN_FQDN, module_data->auth_config[0]->login_fqdn);
     os_strdup(WM_MS_GRAPH_GLOBAL_API_QUERY_FQDN, module_data->auth_config[0]->query_fqdn);
     os_malloc(sizeof(wm_ms_graph_resource), module_data->resources);
-    os_strdup("security", module_data->resources[0].name);
+    os_strdup("deviceManagement", module_data->resources[0].name);
     module_data->num_resources = 1;
     os_malloc(sizeof(char*), module_data->resources[0].relationships);
-    os_strdup("alerts_v2", module_data->resources[0].relationships[0]);
+    os_strdup("detectedApps", module_data->resources[0].relationships[0]);
     module_data->resources[0].num_relationships = 1;
     size_t max_size = OS_SIZE_8192;
     bool initial = false;
@@ -2805,27 +2803,8 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     os_strdup("{\"value\":[{\"full_log\":\"log1\"},{\"full_log\":\"log2\"}]}", response->body);
     os_strdup("test", response->header);
 
-    expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
-    expect_value(__wrap_wm_state_io, op, WM_IO_READ);
-    expect_any(__wrap_wm_state_io, state);
-    expect_any(__wrap_wm_state_io, size);
-    will_return(__wrap_wm_state_io, 0);
-    will_return(__wrap_wm_state_io, (void *)&relationship_state_struc);
-
-#ifndef WIN32
-    will_return(__wrap_gmtime_r, 1);
-#endif
-    will_return(__wrap_strftime,"2023-02-08T12:24:56Z");
-    will_return(__wrap_strftime, 20);
-
-#ifndef WIN32
-    will_return(__wrap_gmtime_r, 1);
-#endif
-    will_return(__wrap_strftime,"2023-02-08T12:25:56Z");
-    will_return(__wrap_strftime, 20);
-
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps?$top=100&$expand=managedDevices($select=id)'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2836,12 +2815,12 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     will_return(__wrap_wurl_http_request, response);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"security\",\"relationship\":\"alerts_v2\"}}'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}'");
 
     queue_fd = 0;
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, queue_fd);
-    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"security\",\"relationship\":\"alerts_v2\"}}");
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}");
     expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, -1);
@@ -2852,23 +2831,14 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Error'");
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"security\",\"relationship\":\"alerts_v2\"}}'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}'");
 
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, queue_fd);
-    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"security\",\"relationship\":\"alerts_v2\"}}");
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log2\",\"resource\":\"deviceManagement\",\"relationship\":\"detectedApps\"}}");
     expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, 1);
-
-    expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
-    expect_value(__wrap_wm_state_io, op, WM_IO_WRITE);
-    expect_any(__wrap_wm_state_io, state);
-    expect_any(__wrap_wm_state_io, size);
-    will_return(__wrap_wm_state_io, 1);
-
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:25:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
 
     wm_ms_graph_scan_relationships(module_data, initial);
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/24498|

## Description

This PR includes the following changes:

- New query to obtain `auditEvents` from MDM Intune API suing the `ms-graph` module.
  - Query:
    - https://graph.microsoft.com/v1.0/deviceManagement/auditEvents
- New query to obtain `managedDevices` from MDM Intune API using the `ms-graph` module.
  - Query:
    - https://graph.microsoft.com/v1.0/deviceManagement/managedDevices
- New queries to obtain `detectedApps` from MDM Intune API using the `ms-graph` module.
  - Results are expanded to include `managedDevices` information for each app.
  - Queries: 
    - https://graph.microsoft.com/v1.0/deviceManagement/detectedApps
    - https://graph.microsoft.com/v1.0/deviceManagement/detectedApps/{appId}/managedDevices?$select=id,deviceName
- Add `scan_id` to inventory queries (`managedDevices` and `detectedApps`) so results can be distinguished.
- Improve `ms-graph` queries filters to obtain logs, to avoid losing some of them.
- Fix `auth_header` size, as it can be over 2048 characters.
- Fix `relationship` configuration parse.
- Add pagination to ms-graph queries, to avoid losing logs.
- Create generic rules to `auditEvents` from MDM Intune API.
- Create generic rules to `managedDevices` from MDM Intune API.
- Create generic rules to `detectedApps` from MDM Intune API.

## Configuration options

```xml
  <ms-graph>
    <enabled>yes</enabled>
    <only_future_events>yes</only_future_events>
    <curl_max_size>10M</curl_max_size>
    <run_on_start>yes</run_on_start>
    <interval>10s</interval>
    <version>v1.0</version>
    <api_auth>
      <tenant_id>xxxxx</tenant_id>
      <client_id>xxxxxx</client_id>
      <secret_value>xxxxxx</secret_value>
      <api_type>global</api_type>
    </api_auth>
    <resource>
      <name>deviceManagement</name>
      <relationship>auditEvents</relationship>
      <relationship>managedDevices</relationship>
      <relationship>detectedApps</relationship>
    </resource>
  </ms-graph>
```

## Logs/Alerts example

```
2024/08/09 14:56:42 wazuh-modulesd:ms-graph[1302] wm_ms_graph.c:82 at wm_ms_graph_main(): INFO: Scanning tenant '0fea4e03-8146-453b-b889-54b4bd11565b'
2024/08/09 14:56:45 wazuh-modulesd:ms-graph[1302] wm_ms_graph.c:296 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/auditEvents?$top=100&$filter=activityDateTime+ge+2024-08-09T14:56:34Z+and+activityDateTime+lt+2024-08-09T14:56:45Z'
2024/08/09 14:56:46 wazuh-modulesd:ms-graph[1302] wm_ms_graph.c:343 at wm_ms_graph_scan_relationships(): DEBUG: No new logs received.
2024/08/09 14:56:46 wazuh-modulesd:ms-graph[1302] wm_ms_graph.c:373 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2024-08-09T14:56:45Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' resource 'deviceManagement' and relationship 'auditEvents', waiting '10' seconds to run next scan.
2024/08/09 14:56:46 wazuh-modulesd:ms-graph[1302] wm_ms_graph.c:296 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/managedDevices?$top=100'
2024/08/09 14:56:47 wazuh-modulesd:ms-graph[1302] wm_ms_graph.c:343 at wm_ms_graph_scan_relationships(): DEBUG: No new logs received.
2024/08/09 14:56:47 wazuh-modulesd:ms-graph[1302] wm_ms_graph.c:296 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps?$top=100&$expand=managedDevices($select=id)'
2024/08/09 14:56:48 wazuh-modulesd:ms-graph[1302] wm_ms_graph.c:343 at wm_ms_graph_scan_relationships(): DEBUG: No new logs received.
2024/08/09 14:56:48 wazuh-modulesd:ms-graph[1302] wm_ms_graph.c:68 at wm_ms_graph_main(): DEBUG: Waiting until: 2024/08/09 14:56:52
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)