### PR TITLE
Set compiler options for test targets

### DIFF
--- a/src/agent/agent_info/tests/CMakeLists.txt
+++ b/src/agent/agent_info/tests/CMakeLists.txt
@@ -1,11 +1,13 @@
 find_package(GTest CONFIG REQUIRED)
 
 add_executable(agent_info_test agent_info_test.cpp)
+configure_target(agent_info_test)
 target_include_directories(agent_info_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_link_libraries(agent_info_test PRIVATE AgentInfo GTest::gtest)
 add_test(NAME AgentInfoTest COMMAND agent_info_test)
 
 add_executable(agent_info_persistance_test agent_info_persistance_test.cpp)
+configure_target(agent_info_persistance_test)
 target_include_directories(agent_info_persistance_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_link_libraries(agent_info_persistance_test PRIVATE AgentInfo GTest::gtest)
 add_test(NAME AgentInfoPersistanceTest COMMAND agent_info_persistance_test)

--- a/src/agent/communicator/tests/CMakeLists.txt
+++ b/src/agent/communicator/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ target_link_libraries(communicator_test PUBLIC Communicator GTest::gtest GTest::
 add_test(NAME CommunicatorTest COMMAND communicator_test)
 
 add_executable(http_client_test http_client_test.cpp)
+configure_target(http_client_test)
 target_include_directories(http_client_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 target_link_libraries(http_client_test PUBLIC Communicator GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
 add_test(NAME HttpClientTest COMMAND http_client_test)

--- a/src/agent/communicator/tests/CMakeLists.txt
+++ b/src/agent/communicator/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(GTest CONFIG REQUIRED)
 
 add_executable(communicator_test communicator_test.cpp)
+configure_target(communicator_test)
 target_include_directories(communicator_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 target_link_libraries(communicator_test PUBLIC Communicator GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
 add_test(NAME CommunicatorTest COMMAND communicator_test)

--- a/src/agent/communicator/tests/communicator_test.cpp
+++ b/src/agent/communicator/tests/communicator_test.cpp
@@ -53,7 +53,7 @@ TEST(CommunicatorTest, StatefulMessageProcessingTask_Success)
                std::function<boost::asio::awaitable<std::string>()> pGetMessages,
                std::function<void()>,
                std::function<void(const std::string&)> pOnSuccess,
-               std::function<bool()> loopRequestCondition) -> boost::asio::awaitable<void>
+               [[maybe_unused]] std::function<bool()> loopRequestCondition) -> boost::asio::awaitable<void>
             {
                 const auto message = co_await pGetMessages();
                 pOnSuccess(message);
@@ -82,10 +82,10 @@ TEST(CommunicatorTest, WaitForTokenExpirationAndAuthenticate_FailedAuthenticatio
     // A failed authentication won't return a token
     EXPECT_CALL(*mockHttpClientPtr, AuthenticateWithUuidAndKey(_, _, _, _))
         .WillOnce(Invoke(
-            [communicatorPtr](const std::string& host,
-                              const std::string& port,
-                              const std::string& uuid,
-                              const std::string& key) -> std::optional<std::string>
+            [communicatorPtr]([[maybe_unused]] const std::string& host,
+                              [[maybe_unused]] const std::string& port,
+                              [[maybe_unused]] const std::string& uuid,
+                              [[maybe_unused]] const std::string& key) -> std::optional<std::string>
             {
                 communicatorPtr->Stop();
                 return std::nullopt;
@@ -96,10 +96,10 @@ TEST(CommunicatorTest, WaitForTokenExpirationAndAuthenticate_FailedAuthenticatio
         .WillOnce(Invoke(
             [](std::shared_ptr<std::string> token,
                http_client::HttpRequestParams,
-               std::function<boost::asio::awaitable<std::string>()> getMessages,
-               std::function<void()> onUnauthorized,
-               std::function<void(const std::string&)> onSuccess,
-               std::function<bool()> loopCondition) -> boost::asio::awaitable<void>
+               [[maybe_unused]] std::function<boost::asio::awaitable<std::string>()> getMessages,
+               [[maybe_unused]] std::function<void()> onUnauthorized,
+               [[maybe_unused]] std::function<void(const std::string&)> onSuccess,
+               [[maybe_unused]] std::function<bool()> loopCondition) -> boost::asio::awaitable<void>
             {
                 EXPECT_TRUE(token->empty());
                 co_return;
@@ -117,8 +117,9 @@ TEST(CommunicatorTest, WaitForTokenExpirationAndAuthenticate_FailedAuthenticatio
         ioContext,
         [communicatorPtr]() mutable -> boost::asio::awaitable<void>
         {
-            co_await communicatorPtr->StatelessMessageProcessingTask(
-                []() -> boost::asio::awaitable<std::string> { co_return "message"; }, [](const std::string& msg) {});
+            co_await communicatorPtr->StatelessMessageProcessingTask([]() -> boost::asio::awaitable<std::string>
+                                                                     { co_return "message"; },
+                                                                     []([[maybe_unused]] const std::string& msg) {});
         },
         boost::asio::detached);
 
@@ -136,18 +137,18 @@ TEST(CommunicatorTest, StatelessMessageProcessingTask_CallsWithValidToken)
     auto communicatorPtr =
         std::make_shared<communicator::Communicator>(std::move(mockHttpClient), "uuid", "key", nullptr);
 
-    const auto token = CreateToken();
-    EXPECT_CALL(*mockHttpClientPtr, AuthenticateWithUuidAndKey(_, _, _, _)).WillOnce(Return(token));
+    const auto mockedToken = CreateToken();
+    EXPECT_CALL(*mockHttpClientPtr, AuthenticateWithUuidAndKey(_, _, _, _)).WillOnce(Return(mockedToken));
 
     std::string capturedToken;
     EXPECT_CALL(*mockHttpClientPtr, Co_PerformHttpRequest(_, _, _, _, _, _))
         .WillOnce(Invoke(
             [&capturedToken](std::shared_ptr<std::string> token,
                              http_client::HttpRequestParams,
-                             std::function<boost::asio::awaitable<std::string>()> getMessages,
-                             std::function<void()> onUnauthorized,
-                             std::function<void(const std::string&)> onSuccess,
-                             std::function<bool()> loopCondition) -> boost::asio::awaitable<void>
+                             [[maybe_unused]] std::function<boost::asio::awaitable<std::string>()> getMessages,
+                             [[maybe_unused]] std::function<void()> onUnauthorized,
+                             [[maybe_unused]] std::function<void(const std::string&)> onSuccess,
+                             [[maybe_unused]] std::function<bool()> loopCondition) -> boost::asio::awaitable<void>
             {
                 capturedToken = *token;
                 co_return;
@@ -165,15 +166,16 @@ TEST(CommunicatorTest, StatelessMessageProcessingTask_CallsWithValidToken)
         ioContext,
         [communicatorPtr]() mutable -> boost::asio::awaitable<void>
         {
-            co_await communicatorPtr->StatelessMessageProcessingTask(
-                []() -> boost::asio::awaitable<std::string> { co_return "message"; }, [](const std::string& msg) {});
+            co_await communicatorPtr->StatelessMessageProcessingTask([]() -> boost::asio::awaitable<std::string>
+                                                                     { co_return "message"; },
+                                                                     []([[maybe_unused]] const std::string& msg) {});
         },
         boost::asio::detached);
 
     ioContext.run();
 
     EXPECT_FALSE(capturedToken.empty());
-    EXPECT_EQ(capturedToken, token);
+    EXPECT_EQ(capturedToken, mockedToken);
 }
 
 int main(int argc, char** argv)

--- a/src/agent/communicator/tests/http_client_test.cpp
+++ b/src/agent/communicator/tests/http_client_test.cpp
@@ -204,7 +204,8 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_Success)
     };
 
     auto onSuccessCalled = false;
-    std::function<void(const std::string&)> onSuccess = [&onSuccessCalled](const std::string& responseBody)
+    std::function<void(const std::string&)> onSuccess =
+        [&onSuccessCalled]([[maybe_unused]] const std::string& responseBody)
     {
         onSuccessCalled = true;
     };
@@ -243,7 +244,8 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_CallbacksNotCalledIfCannotConnect)
     };
 
     auto onSuccessCalled = false;
-    std::function<void(const std::string&)> onSuccess = [&onSuccessCalled](const std::string& responseBody)
+    std::function<void(const std::string&)> onSuccess =
+        [&onSuccessCalled]([[maybe_unused]] const std::string& responseBody)
     {
         onSuccessCalled = true;
     };
@@ -283,7 +285,8 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncWriteFails
     };
 
     auto onSuccessCalled = false;
-    std::function<void(const std::string&)> onSuccess = [&onSuccessCalled](const std::string& responseBody)
+    std::function<void(const std::string&)> onSuccess =
+        [&onSuccessCalled]([[maybe_unused]] const std::string& responseBody)
     {
         onSuccessCalled = true;
     };
@@ -325,7 +328,8 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncReadFails)
     };
 
     auto onSuccessCalled = false;
-    std::function<void(const std::string&)> onSuccess = [&onSuccessCalled](const std::string& responseBody)
+    std::function<void(const std::string&)> onSuccess =
+        [&onSuccessCalled]([[maybe_unused]] const std::string& responseBody)
     {
         onSuccessCalled = true;
     };
@@ -366,7 +370,8 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_UnauthorizedCalledWhenAuthorization
     };
 
     auto onSuccessCalled = false;
-    std::function<void(const std::string&)> onSuccess = [&onSuccessCalled](const std::string& responseBody)
+    std::function<void(const std::string&)> onSuccess =
+        [&onSuccessCalled]([[maybe_unused]] const std::string& responseBody)
     {
         onSuccessCalled = true;
     };

--- a/src/agent/configuration_parser/tests/CMakeLists.txt
+++ b/src/agent/configuration_parser/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(GTest CONFIG REQUIRED)
 
 add_executable(ConfigurationParser_test configuration_parser_test.cpp)
+configure_target(ConfigurationParser_test)
 target_include_directories(ConfigurationParser_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 target_link_libraries(ConfigurationParser_test PUBLIC ConfigurationParser GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
 add_test(NAME ConfigParserTest COMMAND ConfigurationParser_test)

--- a/src/agent/configuration_parser/tests/configuration_parser_test.cpp
+++ b/src/agent/configuration_parser/tests/configuration_parser_test.cpp
@@ -53,7 +53,7 @@ TEST(ConfigurationParser, GetConfigFloat)
     )";
     const auto parserStr = std::make_unique<configuration::ConfigurationParser>(strConfig);
     const auto ret = parserStr->GetConfig<float>("agent_array", "float_conf");
-    EXPECT_FLOAT_EQ(ret, 12.34);
+    EXPECT_FLOAT_EQ(ret, 12.34f);
 }
 
 TEST(ConfigurationParser, GetConfigNoKey)

--- a/src/agent/include/cmd_ln_parser.hpp
+++ b/src/agent/include/cmd_ln_parser.hpp
@@ -7,7 +7,7 @@
 class CommandlineParser
 {
 public:
-    CommandlineParser(int& argc, char** argv)
+    CommandlineParser(int argc, char** argv)
     {
         for (int i = 1; i < argc; ++i)
         {

--- a/src/agent/multitype_queue/tests/CMakeLists.txt
+++ b/src/agent/multitype_queue/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(GTest REQUIRED)
 
 add_executable(test_MultiTypeQueue multitype_queue_test.cpp)
+configure_target(test_MultiTypeQueue)
 target_include_directories(test_MultiTypeQueue PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_link_libraries(test_MultiTypeQueue PUBLIC
     MultiTypeQueue

--- a/src/agent/multitype_queue/tests/CMakeLists.txt
+++ b/src/agent/multitype_queue/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(test_MultiTypeQueue PUBLIC
 add_test(NAME MultiTypeQueueTest COMMAND test_MultiTypeQueue)
 
 add_executable(test_sqlitestorage sqlitestorage_test.cpp)
+configure_target(test_sqlitestorage)
 target_include_directories(test_sqlitestorage PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_link_libraries(test_sqlitestorage
     MultiTypeQueue

--- a/src/agent/multitype_queue/tests/sqlitestorage_test.cpp
+++ b/src/agent/multitype_queue/tests/sqlitestorage_test.cpp
@@ -219,26 +219,21 @@ protected:
     void TearDown() override {}
 };
 
-void StoreMessages(SQLiteStorage& storage, const json& messages, const std::string& tableName)
+namespace
 {
-    for (const auto& message : messages)
+    void StoreMessages(SQLiteStorage& storage, const json& messages, const std::string& tableName)
     {
-        storage.Store(message, tableName);
+        for (const auto& message : messages)
+        {
+            storage.Store(message, tableName);
+        }
     }
-}
 
-void RetrieveMessages(SQLiteStorage& storage,
-                      int count,
-                      std::vector<json>& retrievedMessages,
-                      const std::string& tableName)
-{
-    retrievedMessages = storage.RetrieveMultiple(count, tableName);
-}
-
-void RemoveMessages(SQLiteStorage& storage, int count, const std::string& tableName)
-{
-    storage.RemoveMultiple(count, tableName);
-}
+    void RemoveMessages(SQLiteStorage& storage, size_t count, const std::string& tableName)
+    {
+        storage.RemoveMultiple(static_cast<int>(count), tableName);
+    }
+} // namespace
 
 TEST_F(SQLiteStorageMultithreadedTest, MultithreadedStoreAndRetrieve)
 {

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(task_manager_test PRIVATE Agent GTest::gtest)
 add_test(NAME TaskManagerTest COMMAND task_manager_test)
 
 add_executable(register_test register_test.cpp)
+configure_target(register_test)
 target_include_directories(register_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_link_libraries(register_test PRIVATE Agent GTest::gmock GTest::gtest)
 add_test(NAME RegisterTest COMMAND register_test)

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -1,11 +1,13 @@
 find_package(GTest CONFIG REQUIRED)
 
 add_executable(agent_test agent_test.cpp)
+configure_target(agent_test)
 target_include_directories(agent_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_link_libraries(agent_test PRIVATE Agent GTest::gtest GTest::gmock)
 add_test(NAME AgentTest COMMAND agent_test)
 
 add_executable(task_manager_test task_manager_test.cpp)
+configure_target(task_manager_test)
 target_include_directories(task_manager_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_link_libraries(task_manager_test PRIVATE Agent GTest::gtest)
 add_test(NAME TaskManagerTest COMMAND task_manager_test)
@@ -17,6 +19,7 @@ target_link_libraries(register_test PRIVATE Agent GTest::gmock GTest::gtest)
 add_test(NAME RegisterTest COMMAND register_test)
 
 add_executable(signal_handler_test signal_handler_test.cpp)
+configure_target(signal_handler_test)
 target_include_directories(signal_handler_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_link_libraries(signal_handler_test PRIVATE Agent GTest::gtest)
 add_test(NAME SignalHandlerTest COMMAND signal_handler_test)

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(signal_handler_test PRIVATE Agent GTest::gtest)
 add_test(NAME SignalHandlerTest COMMAND signal_handler_test)
 
 add_executable(message_queue_utils_test message_queue_utils_test.cpp)
+configure_target(message_queue_utils_test)
 target_include_directories(message_queue_utils_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_link_libraries(message_queue_utils_test PRIVATE Agent MultiTypeQueue GTest::gtest GTest::gmock)
 add_test(NAME MessageQueueUtilsTest COMMAND message_queue_utils_test)

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(message_queue_utils_test PRIVATE Agent MultiTypeQueue GTes
 add_test(NAME MessageQueueUtilsTest COMMAND message_queue_utils_test)
 
 add_executable(cmd_ln_parser_test cmd_ln_parser_test.cpp)
+configure_target(cmd_ln_parser_test)
 target_include_directories(cmd_ln_parser_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 target_link_libraries(cmd_ln_parser_test PRIVATE GTest::gtest)
 add_test(NAME CommandlineParserTest COMMAND cmd_ln_parser_test)

--- a/src/agent/tests/cmd_ln_parser_test.cpp
+++ b/src/agent/tests/cmd_ln_parser_test.cpp
@@ -2,49 +2,45 @@
 
 #include <cmd_ln_parser.hpp>
 
-TEST(CommandlineParserTest, GetOptionValue_OptionExists)
-{
-    char* argv[] = {(char*)"program", (char*)"--option", (char*)"value"};
-    int argc = 3;
-    CommandlineParser parser(argc, argv);
+#include <array>
+#include <string>
 
-    EXPECT_EQ(parser.GetOptionValue("--option"), "value");
+class CommandlineParserTest : public ::testing::Test
+{
+protected:
+    std::string program = "program";
+    std::string option = "--option";
+    std::string value = "value";
+    std::array<char*, 3> args = {program.data(), option.data(), value.data()};
+    CommandlineParser parser {static_cast<int>(args.size()), args.data()};
+};
+
+TEST_F(CommandlineParserTest, GetOptionValue_OptionExists)
+{
+    EXPECT_EQ(parser.GetOptionValue(option), value);
 }
 
-TEST(CommandlineParserTest, GetOptionValue_OptionDoesNotExist)
+TEST_F(CommandlineParserTest, GetOptionValue_OptionDoesNotExist)
 {
-    char* argv[] = {(char*)"program", (char*)"--option", (char*)"value"};
-    int argc = 3;
-    CommandlineParser parser(argc, argv);
-
     EXPECT_EQ(parser.GetOptionValue("--nonexistent"), "");
 }
 
-TEST(CommandlineParserTest, OptionExists_OptionExists)
+TEST_F(CommandlineParserTest, OptionExists_OptionExists)
 {
-    char* argv[] = {(char*)"program", (char*)"--option", (char*)"value"};
-    int argc = 3;
-    CommandlineParser parser(argc, argv);
-
-    EXPECT_TRUE(parser.OptionExists("--option"));
+    EXPECT_TRUE(parser.OptionExists(option));
 }
 
-TEST(CommandlineParserTest, OptionExists_OptionDoesNotExist)
+TEST_F(CommandlineParserTest, OptionExists_OptionDoesNotExist)
 {
-    char* argv[] = {(char*)"program", (char*)"--option", (char*)"value"};
-    int argc = 3;
-    CommandlineParser parser(argc, argv);
-
     EXPECT_FALSE(parser.OptionExists("--nonexistent"));
 }
 
-TEST(CommandlineParserTest, GetOptionValue_NoValueForOption)
+TEST_F(CommandlineParserTest, GetOptionValue_NoValueForOption)
 {
-    char* argv[] = {(char*)"program", (char*)"--option"};
-    int argc = 2;
-    CommandlineParser parser(argc, argv);
+    std::array<char*, 2> noValueArgs = {program.data(), option.data()};
+    CommandlineParser noValueParser {static_cast<int>(noValueArgs.size()), noValueArgs.data()};
 
-    EXPECT_EQ(parser.GetOptionValue("--option"), "");
+    EXPECT_EQ(noValueParser.GetOptionValue(option), "");
 }
 
 int main(int argc, char** argv)

--- a/src/agent/tests/message_queue_utils_test.cpp
+++ b/src/agent/tests/message_queue_utils_test.cpp
@@ -16,6 +16,7 @@ public:
                 (MessageType, int, const std::string module),
                 (override));
     MOCK_METHOD(int, popN, (MessageType, int, const std::string module), (override));
+    MOCK_METHOD(int, push, (Message, bool), (override));
     MOCK_METHOD(int, push, (std::vector<Message>), (override));
 };
 

--- a/src/agent/tests/register_test.cpp
+++ b/src/agent/tests/register_test.cpp
@@ -14,10 +14,6 @@
 #include <optional>
 #include <string>
 
-using ::testing::_;
-using ::testing::MockFunction;
-using ::testing::Return;
-
 class MockHttpClient : public http_client::IHttpClient
 {
 public:


### PR DESCRIPTION
## Description

Test targets were overlooked in https://github.com/wazuh/wazuh-agent/pull/99 when applying the `ConfigureTarget.cmake` function.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
