### PR TITLE
Support macOS 15 "Sequoia" name in agent

### DIFF
--- a/src/common/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/common/data_provider/src/osinfo/sysOsParsers.cpp
@@ -438,6 +438,7 @@ bool MacOsParser::parseUname(const std::string& in, nlohmann::json& output)
         {"21", "Monterey"},
         {"22", "Ventura"},
         {"23", "Sonoma"},
+        {"24", "Sequoia"},
     };
     constexpr auto PATTERN_MATCH{"[0-9]+"};
     std::string match;

--- a/src/common/version_op/src/version_op.c
+++ b/src/common/version_op/src/version_op.c
@@ -377,6 +377,7 @@ const char *OSX_ReleaseName(int version) {
     /* 21 */ "Monterey",
     /* 22 */ "Ventura",
     /* 23 */ "Sonoma",
+    /* 24 */ "Sequoia",
     };
 
     version -= 10;

--- a/src/common/version_op/tests/unit/tests/test_version_op.c
+++ b/src/common/version_op/tests/unit/tests/test_version_op.c
@@ -2184,7 +2184,8 @@ void test_OSX_ReleaseName(void **state) {
     assert_string_equal(OSX_ReleaseName(21), "Monterey");
     assert_string_equal(OSX_ReleaseName(22), "Ventura");
     assert_string_equal(OSX_ReleaseName(23), "Sonoma");
-    assert_string_equal(OSX_ReleaseName(24), "Unknown");
+    assert_string_equal(OSX_ReleaseName(24), "Sequoia");
+    assert_string_equal(OSX_ReleaseName(25), "Unknown");
 }
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/25652|

This PR is a port of:
- https://github.com/wazuh/wazuh/pull/25654

It adds support for macOS 15 "Sequoia" to the Wazuh agent, ensuring proper version detection and system inventory reporting.