### PR TITLE
Fix agent connection

### DIFF
--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -96,7 +96,7 @@ namespace communicator
         };
 
         const auto reqParams =
-            http_client::HttpRequestParams(boost::beast::http::verb::get, m_managerIp, m_port, "/commands");
+            http_client::HttpRequestParams(boost::beast::http::verb::get, m_managerIp, m_port, "/api/v1/commands");
         co_await m_httpClient->Co_PerformHttpRequest(
             m_token, reqParams, {}, onAuthenticationFailed, onSuccess, loopCondition);
     }
@@ -156,8 +156,8 @@ namespace communicator
             return m_keepRunning.load();
         };
 
-        const auto reqParams =
-            http_client::HttpRequestParams(boost::beast::http::verb::post, m_managerIp, m_port, "/stateful");
+        const auto reqParams = http_client::HttpRequestParams(
+            boost::beast::http::verb::post, m_managerIp, m_port, "/api/v1/events/stateful");
         co_await m_httpClient->Co_PerformHttpRequest(
             m_token, reqParams, getMessages, onAuthenticationFailed, onSuccess, loopCondition);
     }
@@ -176,8 +176,8 @@ namespace communicator
             return m_keepRunning.load();
         };
 
-        const auto reqParams =
-            http_client::HttpRequestParams(boost::beast::http::verb::post, m_managerIp, m_port, "/stateless");
+        const auto reqParams = http_client::HttpRequestParams(
+            boost::beast::http::verb::post, m_managerIp, m_port, "/api/v1/events/stateless");
         co_await m_httpClient->Co_PerformHttpRequest(
             m_token, reqParams, getMessages, onAuthenticationFailed, onSuccess, loopCondition);
     }

--- a/src/agent/communicator/tests/http_client_test.cpp
+++ b/src/agent/communicator/tests/http_client_test.cpp
@@ -408,7 +408,7 @@ TEST_F(HttpClientTest, AuthenticateWithUuidAndKey_Success)
             [](auto& res)
             {
                 res.result(boost::beast::http::status::ok);
-                boost::beast::ostream(res.body()) << "valid_token";
+                boost::beast::ostream(res.body()) << R"({"token":"valid_token"})";
             });
 
     const auto token = client->AuthenticateWithUuidAndKey("localhost", "8080", "test-uuid", "test-key");
@@ -447,7 +447,7 @@ TEST_F(HttpClientTest, AuthenticateWithUserPassword_Success)
             [](auto& res)
             {
                 res.result(boost::beast::http::status::ok);
-                boost::beast::ostream(res.body()) << "valid_token";
+                boost::beast::ostream(res.body()) << R"({"data":{"token":"valid_token"}})";
             });
 
     const auto token = client->AuthenticateWithUserPassword("localhost", "8080", "user", "password");

--- a/src/agent/configuration_parser/src/configuration_parser.cpp
+++ b/src/agent/configuration_parser/src/configuration_parser.cpp
@@ -21,7 +21,7 @@ namespace configuration
             tbl = toml::parse_str(
                 R"([agent]
                 server_mgmt_api_port = "55000"
-                agent_comms_api_port = "8080"
+                agent_comms_api_port = "27000"
                 manager_ip = "localhost")",
                 toml::spec::v(1, 0, 0));
         }

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -5,5 +5,5 @@ std::tuple<command_store::Status, std::string> DispatchCommand(const command_sto
 {
     // TO_DO: Implement real dispatch function.
     LogInfo("Dispatching command {}({})", cmd.m_command, cmd.m_module);
-    return {command_store::Status::SUCCESS, "Successfully executed."};
+    return {command_store::Status::SUCCESS, "Successfully executed"};
 }

--- a/src/agent/src/main.cpp
+++ b/src/agent/src/main.cpp
@@ -33,6 +33,10 @@ int main(int argc, char* argv[])
                 {
                     agentInfo.SetName(cmdParser.GetOptionValue("--name"));
                 }
+                else
+                {
+                    agentInfo.SetName(boost::asio::ip::host_name());
+                }
 
                 http_client::HttpClient httpClient;
                 const registration::UserCredentials userCredentials {user, password};

--- a/src/agent/src/register.cpp
+++ b/src/agent/src/register.cpp
@@ -28,7 +28,7 @@ namespace registration
 
         const AgentInfo agentInfo {};
 
-        nlohmann::json bodyJson = {{"uuid", agentInfo.GetUUID()}, {"key", agentInfo.GetKey()}};
+        nlohmann::json bodyJson = {{"id", agentInfo.GetUUID()}, {"key", agentInfo.GetKey()}};
 
         if (!agentInfo.GetName().empty())
         {

--- a/src/agent/tests/message_queue_utils_test.cpp
+++ b/src/agent/tests/message_queue_utils_test.cpp
@@ -8,8 +8,8 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
-const nlohmann::json BASE_DATA_CONTENT = R"([{"data": {"id":"112233", "origin": {"module": "origin_test"},
-                                        "command": "command_test", "parameters": "parameters_test"}}])"_json;
+const nlohmann::json BASE_DATA_CONTENT = R"([{"data": {"id":"112233", "args": ["origin_test",
+                                        "command_test", "parameters_test"]}}])"_json;
 
 class MockMultiTypeQueue : public MultiTypeQueue
 {
@@ -39,7 +39,8 @@ protected:
 
 TEST_F(MessageQueueUtilsTest, GetMessagesFromQueueTest)
 {
-    Message testMessage {MessageType::STATEFUL, "test_data"};
+    std::vector<std::string> data {"test_data"};
+    Message testMessage {MessageType::STATEFUL, data};
 
     // NOLINTBEGIN(cppcoreguidelines-avoid-capturing-lambda-coroutines)
     EXPECT_CALL(*mockQueue, getNextNAwaitable(MessageType::STATEFUL, 1, ""))
@@ -117,7 +118,7 @@ TEST_F(MessageQueueUtilsTest, GetCommandFromQueueTest)
     ASSERT_EQ(cmd.has_value() ? cmd.value().m_id : "", "112233");
     ASSERT_EQ(cmd.has_value() ? cmd.value().m_module : "", "origin_test");
     ASSERT_EQ(cmd.has_value() ? cmd.value().m_command : "", "command_test");
-    ASSERT_EQ(cmd.has_value() ? cmd.value().m_parameters : "", "\"parameters_test\"");
+    ASSERT_EQ(cmd.has_value() ? cmd.value().m_parameters : "", "parameters_test");
     ASSERT_EQ(cmd.has_value() ? cmd.value().m_status : command_store::Status::UNKNOWN,
               command_store::Status::IN_PROGRESS);
 }

--- a/src/agent/tests/register_test.cpp
+++ b/src/agent/tests/register_test.cpp
@@ -68,7 +68,7 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
                 AuthenticateWithUserPassword(testing::_, testing::_, userCredentials.user, userCredentials.password))
         .WillOnce(testing::Return("token"));
 
-    nlohmann::json bodyJson = {{"uuid", agent->GetUUID()}, {"key", agent->GetKey()}};
+    nlohmann::json bodyJson = {{"id", agent->GetUUID()}, {"key", agent->GetKey()}};
 
     if (!agent->GetName().empty())
     {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/160|

## Description

This PR includes the following changes to make the agent compatible with the new API:

- Fix API paths:
  - `/api/v1/authentication`
  - `/api/v1/commands`
  - `/api/v1/events/stateful`
  - `/api/v1/events/stateless`
- Base64 encoding `user:password`.
- Fix response token parsing.
- Add 403 error code validation for reauthentication.
- Change agent communications API port to 27000.
- Rename `uuid` to `id` in registration parameter.
- Auto-complete agent name with hostname when not provided during registration.
- Some fixes to event JSON format (might change in the future).
