### PR TITLE
Fix: disable openmp and plugins from librpm

### DIFF
--- a/src/ports-overlay/librpm/portfile.cmake
+++ b/src/ports-overlay/librpm/portfile.cmake
@@ -8,6 +8,9 @@ vcpkg_from_github(
 
 vcpkg_configure_make(
   SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+  "--disable-openmp"
+  "--disable-plugins"
 )
 
 vcpkg_install_make()


### PR DESCRIPTION
## Description

It was noted that on some systems configuring the cmake project failed during the building of RPM. These options were also disabled on the original Wazuh repository, disabling them here allowed the project to configure and build successfully.

Some other options may be needed, depending on the final usage of the library, this PR only fixes the configure and compilation errors.

For more details see: https://github.com/wazuh/wazuh/issues/21615#issuecomment-1959563644

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
