### PR TITLE
Specify Minimum Versions for Dependencies in vcpkg.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ This project uses the following third-party software:
 
 | Software                                                                      | Description                                                      | License                        | Version |
 | ----------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------ | ------- |
-| [Boost Asio](https://www.boost.org/doc/libs/release/doc/html/boost_asio.html) | Cross-platform C++ library for network programming               | Boost Software License 1.0     | 1.86.0  |
-| [Boost Beast](https://www.boost.org/doc/libs/release/libs/beast/)             | Library built on Boost Asio for HTTP and WebSocket communication | Boost Software License 1.0     | 1.86.0  |
-| [Boost Uuid](https://www.boost.org/doc/libs/release/libs/uuid/)               | Provides support for universally unique identifiers (UUIDs)      | Boost Software License 1.0     | 1.86.0  |
-| [fmt](https://fmt.dev/)                                                       | A formatting library for C++                                     | MIT License                    | 11.0    |
+| [Boost Asio](https://www.boost.org/doc/libs/release/doc/html/boost_asio.html) | Cross-platform C++ library for network programming               | Boost Software License 1.0     | 1.85.0  |
+| [Boost Beast](https://www.boost.org/doc/libs/release/libs/beast/)             | Library built on Boost Asio for HTTP and WebSocket communication | Boost Software License 1.0     | 1.85.0  |
+| [Boost Uuid](https://www.boost.org/doc/libs/release/libs/uuid/)               | Provides support for universally unique identifiers (UUIDs)      | Boost Software License 1.0     | 1.85.0  |
+| [fmt](https://fmt.dev/)                                                       | A formatting library for C++                                     | MIT License                    | 10.2.1  |
 | [gtest](https://github.com/google/googletest)                                 | Google's C++ testing framework                                   | BSD-3-Clause                   | 1.15.2  |
 | [jwt-cpp](https://github.com/Thalhammer/jwt-cpp)                              | C++ library for handling JSON Web Tokens (JWT)                   | MIT License                    | 0.7.0   |
+| [libdb](https://github.com/yasuhirokimura/db18)                               | Database management library                                      | AGPL-3.0                       | 18.1.40 |
 | [librpm](https://github.com/rpm-software-management/rpm)                      | RPM package manager                                              | GPL-2.0                        | 4.18.2  |
 | [nlohmann-json](https://github.com/nlohmann/json)                             | JSON parsing and serialization library for C++                   | MIT License                    | 3.11.3  |
 | [OpenSSL](https://www.openssl.org/)                                           | Toolkit for SSL/TLS protocols                                    | Apache 2.0 and OpenSSL License | 3.3.2   |

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -1,35 +1,65 @@
 {
-    "name": "wazuh-agent-mvp",
+    "name": "wazuh-agent",
     "version": "5.0.0",
     "dependencies": [
-      "boost-asio",
-      "boost-beast",
-      "boost-uuid",
-      "fmt",
-      "gtest",
-      "jwt-cpp",
-      "nlohmann-json",
-      "openssl",
-      "spdlog",
-      "sqlitecpp",
-      "toml11",
       {
-        "name": "procps",
-        "platform": "linux"
+        "name": "boost-asio",
+        "version>=": "1.85.0"
+      },
+      {
+        "name": "boost-beast",
+        "version>=": "1.85.0"
+      },
+      {
+        "name": "boost-uuid",
+        "version>=": "1.85.0"
+      },
+      {
+        "name": "fmt",
+        "version>=": "10.2.1"
+      },
+      {
+        "name": "gtest",
+        "version>=": "1.15.2"
+      },
+      {
+        "name": "jwt-cpp",
+        "version>=": "0.7.0"
       },
       {
         "name": "libdb",
+        "version>=": "18.1.40",
         "platform": "linux"
       },
       {
         "name": "librpm",
+        "version>=": "4.18.2",
         "platform": "linux"
-      }
-    ],
-    "overrides": [
+      },
+      {
+        "name": "nlohmann-json",
+        "version>=": "3.11.3"
+      },
+      {
+        "name": "openssl",
+        "version>=": "3.3.2"
+      },
+      {
+        "name": "procps",
+        "version>=": "3.3.0",
+        "platform": "linux"
+      },
+      {
+        "name": "spdlog",
+        "version>=": "1.14.0"
+      },
+      {
+        "name": "sqlitecpp",
+        "version>=": "3.3.2"
+      },
       {
         "name": "toml11",
-        "version": "4.0.0"
+        "version>=": "4.0.0"
       }
     ],
     "vcpkg-configuration": {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #172|

## Description

This pull request updates the `vcpkg.json` file to specify minimum versions for all dependencies using the `version>=` field. By doing this, we ensure that each dependency will use at least the specified version, allowing `vcpkg` to choose the minimum version that satisfies all requirements, including transitive dependencies.

This change provides more control over the versions of libraries used, while still maintaining flexibility to resolve conflicts in dependencies where necessary.

## Changes Made

- Updated the `vcpkg.json` file to specify minimum versions for all external dependencies using the `version>=` syntax.
- `vcpkg` will now select the lowest compatible version that satisfies the version constraints for both direct and transitive dependencies.

## Benefits

1. **Controlled Flexibility**: By using `version>=`, we can ensure that builds use at least the minimum version of each library, while still allowing `vcpkg` to resolve versions based on other dependencies and requirements.
   
2. **Reproducibility**: This change reduces the chance of using outdated or unsupported versions of dependencies, ensuring a more consistent build environment.

3. **Compatibility with Transitive Dependencies**: The approach allows for smoother integration with transitive dependencies, as `vcpkg` will automatically resolve the best possible versions across the full dependency tree.

## Testing

- [x] Verified that the build completes successfully with the updated `vcpkg.json`.
- [x] Ensured compatibility with transitive dependencies using the `version>=` approach.