### PR TITLE
Remove entrypoints from Dockerfiles and create volumes for scripts

### DIFF
--- a/packages/build.sh
+++ b/packages/build.sh
@@ -79,14 +79,14 @@ src="$7"
 
 build_dir="/build_wazuh"
 
-source helper_function.sh
+source /home/helper_function.sh
 
 set -x
 
 # Download source code if it is not shared from the local host
 if [ ! -d "/wazuh-local-src" ] ; then
-    curl -sL https://github.com/wazuh/wazuh/tarball/${WAZUH_BRANCH} | tar zx
-    short_commit_hash="$(curl -s https://api.github.com/repos/wazuh/wazuh/commits/${WAZUH_BRANCH} \
+    curl -sL https://github.com/wazuh/wazuh-agent/tarball/${WAZUH_BRANCH} | tar zx
+    short_commit_hash="$(curl -s https://api.github.com/repos/wazuh/wazuh-agent/commits/${WAZUH_BRANCH} \
                           | grep '"sha"' | head -n 1| cut -d '"' -f 4 | cut -c 1-11)"
 else
     if [ "${legacy}" = "no" ]; then

--- a/packages/debs/amd64/agent/Dockerfile
+++ b/packages/debs/amd64/agent/Dockerfile
@@ -33,12 +33,3 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
         CC=/usr/local/gcc-9.4.0/bin/gcc && \
     make -j$(nproc) && make install && ln -s /usr/local/bin/cmake /usr/bin/cmake && \
     cd / && rm -rf cmake-*
-
-# Add the script and helper_funcitons to build the Debian package
-ADD build.sh /usr/local/bin/build_package
-RUN chmod +x /usr/local/bin/build_package
-ADD helper_function.sh /usr/local/bin/helper_function.sh
-ADD gen_permissions.sh /tmp/gen_permissions.sh
-
-# Set the entrypoint
-ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/packages/debs/arm64/agent/Dockerfile
+++ b/packages/debs/arm64/agent/Dockerfile
@@ -36,12 +36,3 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     ./bootstrap --no-system-curl && \
     make -j$(nproc) && make install && ln -s /usr/local/bin/cmake /usr/bin/cmake && \
     cd / && rm -rf cmake-*
-
-# Add the script to build the Debian package
-ADD build.sh /usr/local/bin/build_package
-RUN chmod +x /usr/local/bin/build_package
-ADD helper_function.sh /usr/local/bin/helper_function.sh
-ADD gen_permissions.sh /tmp/gen_permissions.sh
-
-# Set the entrypoint
-ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/packages/debs/armhf/agent/Dockerfile
+++ b/packages/debs/armhf/agent/Dockerfile
@@ -37,12 +37,3 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     linux32 ./bootstrap --no-system-curl && \
     linux32 make -j$(nproc) && linux32 make install && \
     ln -s /usr/local/bin/cmake /usr/bin/cmake && cd / && rm -rf cmake-*
-
-# Add the script to build the Debian package
-ADD build.sh /usr/local/bin/build_package
-RUN chmod +x /usr/local/bin/build_package
-ADD helper_function.sh /usr/local/bin/helper_function.sh
-ADD gen_permissions.sh /tmp/gen_permissions.sh
-
-# Set the entrypoint
-ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/packages/debs/i386/agent/Dockerfile
+++ b/packages/debs/i386/agent/Dockerfile
@@ -36,12 +36,3 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
         CC=/usr/local/gcc-9.4.0/bin/gcc && \
     linux32 make -j$(nproc) && linux32 make install && \
     ln -s /usr/local/bin/cmake /usr/bin/cmake && cd / && rm -rf cmake-*
-
-# Add the script to build the Debian package
-ADD build.sh /usr/local/bin/build_package
-RUN chmod +x /usr/local/bin/build_package
-ADD helper_function.sh /usr/local/bin/helper_function.sh
-ADD gen_permissions.sh /tmp/gen_permissions.sh
-
-# Set the entrypoint
-ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/packages/debs/ppc64le/agent/Dockerfile
+++ b/packages/debs/ppc64le/agent/Dockerfile
@@ -36,12 +36,3 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
         CC=/usr/local/gcc-9.4.0/bin/gcc && \
     make -j$(nproc) && make install && ln -s /usr/local/bin/cmake /usr/bin/cmake && \
     cd / && rm -rf cmake-*
-
-# Add the script to build the Debian package
-ADD build.sh /usr/local/bin/build_package
-RUN chmod +x /usr/local/bin/build_package
-ADD helper_function.sh /usr/local/bin/helper_function.sh
-ADD gen_permissions.sh /tmp/gen_permissions.sh
-
-# Set the entrypoint
-ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/packages/debs/utils/helper_function.sh
+++ b/packages/debs/utils/helper_function.sh
@@ -19,7 +19,7 @@ setup_build(){
     debug="$5"
 
     cp -pr ${specs_path}/wazuh-${BUILD_TARGET}/debian ${sources_dir}/debian
-    cp -p /tmp/gen_permissions.sh ${sources_dir}
+    cp -p /home/gen_permissions.sh ${sources_dir}
 
     # Generating directory structure to build the .deb package
     cd ${build_dir}/${BUILD_TARGET} && tar -czf ${package_name}.orig.tar.gz "${package_name}"

--- a/packages/generate_package.sh
+++ b/packages/generate_package.sh
@@ -27,6 +27,7 @@ CHECKSUM="no"
 FUTURE="no"
 LEGACY="no"
 IS_STAGE="no"
+ENTRYPOINT="/home/build.sh"
 
 
 trap ctrl_c INT
@@ -97,7 +98,7 @@ build_pkg() {
         ${CUSTOM_CODE_VOL} \
         -v ${DOCKERFILE_PATH}:/home:Z \
         ${CONTAINER_NAME}:${DOCKER_TAG} \
-        /home/build.sh \
+        ${ENTRYPOINT} \
         ${REVISION} ${JOBS} ${DEBUG} \
         ${CHECKSUM} ${FUTURE} ${LEGACY} ${SRC}|| return 1
 
@@ -126,6 +127,7 @@ help() {
     echo "    -d, --debug                [Optional] Build the binaries with debug symbols. By default: no."
     echo "    -c, --checksum             [Optional] Generate checksum on the same directory than the package. By default: no."
     echo "    -l, --legacy               [Optional only for RPM] Build package for CentOS 5."
+    echo "    -e, --entrypoint <path>    [Optional] Script to execute as entrypoint."
     echo "    --dont-build-docker        [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --tag                      [Optional] Tag to use with the docker image."
     echo "    --sources <path>           [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub. By default use the script path."
@@ -193,6 +195,14 @@ main() {
         "-p"|"--path")
             if [ -n "$2" ]; then
                 INSTALLATION_PATH="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "-e"|"--entrypoint")
+            if [ -n "$2" ]; then
+                ENTRYPOINT="$2"
                 shift 2
             else
                 help 1

--- a/packages/generate_package.sh
+++ b/packages/generate_package.sh
@@ -95,7 +95,9 @@ build_pkg() {
         -e IS_STAGE="${IS_STAGE}" \
         -e WAZUH_BRANCH="${BRANCH}" \
         ${CUSTOM_CODE_VOL} \
+        -v ${DOCKERFILE_PATH}:/home:Z \
         ${CONTAINER_NAME}:${DOCKER_TAG} \
+        /home/build.sh \
         ${REVISION} ${JOBS} ${DEBUG} \
         ${CHECKSUM} ${FUTURE} ${LEGACY} ${SRC}|| return 1
 

--- a/packages/rpms/amd64/agent/Dockerfile
+++ b/packages/rpms/amd64/agent/Dockerfile
@@ -64,11 +64,3 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     ./bootstrap --no-system-curl CC=/usr/local/gcc-9.4.0/bin/gcc \
         CXX=/usr/local/gcc-9.4.0/bin/g++ && \
     make -j$(nproc) && make install && cd / && rm -rf cmake-*
-
-# Add the scripts to build the RPM package
-ADD build.sh /usr/local/bin/build_package
-RUN chmod +x /usr/local/bin/build_package
-ADD helper_function.sh /usr/local/bin/helper_function.sh
-
-# Set the entrypoint
-ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/packages/rpms/arm64/agent/Dockerfile
+++ b/packages/rpms/arm64/agent/Dockerfile
@@ -73,11 +73,3 @@ RUN curl -O http://packages.wazuh.com/utils/rpm/rpm-4.15.1.tar.bz2 && \
 RUN mkdir -p /usr/local/var/lib/rpm && \
     cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages && \
     /usr/local/bin/rpm --rebuilddb && rm -rf /root/rpmbuild
-
-# Add the scripts to build the RPM package
-ADD build.sh /usr/local/bin/build_package
-RUN chmod +x /usr/local/bin/build_package
-ADD helper_function.sh /usr/local/bin/helper_function.sh
-
-# Set the entrypoint
-ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/packages/rpms/armhf/agent/Dockerfile
+++ b/packages/rpms/armhf/agent/Dockerfile
@@ -57,11 +57,3 @@ RUN echo "%_arch                  armv7hl" >> /root/.rpmmacros
 RUN mkdir -p /usr/local/var/lib/rpm && \
     cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages && \
     /usr/local/bin/rpm --rebuilddb && rm -rf /root/rpmbuild
-
-# Add the scripts to build the RPM package
-ADD build.sh /usr/local/bin/build_package
-RUN chmod +x /usr/local/bin/build_package
-ADD helper_function.sh /usr/local/bin/helper_function.sh
-
-# Set the entrypoint
-ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/packages/rpms/i386/agent/Dockerfile
+++ b/packages/rpms/i386/agent/Dockerfile
@@ -64,11 +64,3 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     linux32 ./bootstrap --no-system-curl CC=/usr/local/gcc-9.4.0/bin/gcc \
         CXX=/usr/local/gcc-9.4.0/bin/g++ && \
     linux32 make -j$(nproc) && linux32 make install && cd / && rm -rf cmake-*
-
-# Add the scripts to build the RPM package
-ADD build.sh /usr/local/bin/build_package
-RUN chmod +x /usr/local/bin/build_package
-ADD helper_function.sh /usr/local/bin/helper_function.sh
-
-# Set the entrypoint
-ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/packages/rpms/ppc64le/agent/Dockerfile
+++ b/packages/rpms/ppc64le/agent/Dockerfile
@@ -47,11 +47,3 @@ RUN curl -OL http://packages.wazuh.com/utils/perl/perl-5.10.1.tar.gz && \
     cd /perl-5.10.1 && ./Configure -des -Dcc='gcc' -Dusethreads && \
     make -j2 && make install && ln -fs /usr/local/bin/perl /bin/perl && \
     cd / && rm -rf /perl-5.10.1*
-
-# Add the scripts to build the RPM package
-ADD build.sh /usr/local/bin/build_package
-RUN chmod +x /usr/local/bin/build_package
-ADD helper_function.sh /usr/local/bin/helper_function.sh
-
-# Set the entrypoint
-ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/packages/windows/entrypoint.sh
+++ b/packages/windows/entrypoint.sh
@@ -19,7 +19,7 @@ if [ -z "${BRANCH}"]; then
     mkdir /wazuh-local-src
     cp -r /local-src/* /wazuh-local-src
 else
-    URL_REPO=https://github.com/wazuh/wazuh/archive/${BRANCH}.zip
+    URL_REPO=https://github.com/wazuh/wazuh-agent/archive/${BRANCH}.zip
 
     # Download the wazuh repository
     wget -O wazuh.zip ${URL_REPO} && unzip wazuh.zip


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/128|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR we are going to include all the necessary changes so that the Dockerfile to generate agent packages does not contain directly any script inside the image, removing also the entrypoint.
This change is to eliminate the need to update the image every time a generation script is updated. This way, the Docker image generation workflows will only trigger when the Dockerfile itself is modified.

## Test
I was able to successfully create a package using branch `enhancement/128-remove-entrypoints`, and cherry-picking the commit of this PR. In this way, the Docker image used did not contain the scripts inside, but they were passed using a volume.
