### PR TITLE
Implement Windows Service for the agent

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,11 @@ add_subdirectory(agent)
 add_executable(wazuh-agent agent/src/main.cpp)
 target_link_libraries(wazuh-agent Agent Logger)
 
+if(WIN32)
+    include(cmake/SetWindowsManifest.cmake)
+    set_windows_manifest()
+endif()
+
 include(cmake/ConfigureTarget.cmake)
 configure_target(wazuh-agent)
 

--- a/src/agent/service/app.manifest
+++ b/src/agent/service/app.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/src/agent/src/main.cpp
+++ b/src/agent/src/main.cpp
@@ -7,8 +7,6 @@ int main(int argc, char* argv[])
     Logger logger;
     CommandlineParser cmdParser(argc, argv);
 
-    LogInfo("Starting wazuh-agent service.");
-
     try
     {
         if (cmdParser.OptionExists("register"))
@@ -33,6 +31,20 @@ int main(int argc, char* argv[])
         else if (cmdParser.OptionExists("stop"))
         {
             StopAgent();
+        }
+        else if (cmdParser.OptionExists("install"))
+        {
+            if (!InstallService())
+                return 1;
+        }
+        else if (cmdParser.OptionExists("remove"))
+        {
+            if (!RemoveService())
+                return 1;
+        }
+        else if (cmdParser.OptionExists("service"))
+        {
+            SetDispatcherThread();
         }
         else
         {

--- a/src/agent/src/process_options.cpp
+++ b/src/agent/src/process_options.cpp
@@ -41,6 +41,9 @@ void PrintHelp()
     std::cout << "     status          Get wazuh-agent daemon status\n";
     std::cout << "     stop            Stop wazuh-agent daemon\n";
     std::cout << "     restart         Restart wazuh-agent daemon\n";
-    std::cout << "     register        Register wazuh-agent daemon\n";
+    std::cout << "     register        Register wazuh-agent\n";
+    std::cout << "     install         Install Windows Service\n";
+    std::cout << "     remove          Remove Windows Service\n";
+    std::cout << "     service         Used by Windows SCM to run as Service\n";
     std::cout << "     --help          This help message\n";
 }

--- a/src/agent/src/process_options.hpp
+++ b/src/agent/src/process_options.hpp
@@ -11,6 +11,6 @@ void StartAgent();
 void StatusAgent();
 void StopAgent();
 void PrintHelp();
-void InstallService([[maybe_unused]] const std::string& exePath);
-void RemoveService();
+bool InstallService();
+bool RemoveService();
 void SetDispatcherThread();

--- a/src/agent/src/process_options_unix.cpp
+++ b/src/agent/src/process_options_unix.cpp
@@ -35,8 +35,14 @@ void StopAgent()
     LogInfo("Stopping wazuh-agent");
 }
 
-void InstallService([[maybe_unused]] const std::string& exePath) {}
+bool InstallService()
+{
+    return true;
+}
 
-void RemoveService() {}
+bool RemoveService()
+{
+    return true;
+}
 
 void SetDispatcherThread() {}

--- a/src/agent/src/process_options_win.cpp
+++ b/src/agent/src/process_options_win.cpp
@@ -1,13 +1,10 @@
 #include <process_options.hpp>
 
-/****************************************************
- *  Placeholder file. To be replaced on branch merge
- ****************************************************/
-
 #include <agent.hpp>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <logger.hpp>
+#include <windows_service.hpp>
 
 #include <vector>
 
@@ -15,8 +12,7 @@ void RestartAgent() {}
 
 void StartAgent()
 {
-    Agent agent;
-    agent.Run();
+    LogInfo("Starting Wazuh Agent.");
 }
 
 void StatusAgent() {}
@@ -26,8 +22,17 @@ void StopAgent()
     LogInfo("Stopping Wazuh Agent.");
 }
 
-void InstallService([[maybe_unused]] const std::string& exePath) {}
+bool InstallService()
+{
+    return WindowsService::InstallService();
+}
 
-void RemoveService() {}
+bool RemoveService()
+{
+    return WindowsService::RemoveService();
+}
 
-void SetDispatcherThread() {}
+void SetDispatcherThread()
+{
+    WindowsService::SetDispatcherThread();
+}

--- a/src/agent/src/process_options_win.cpp
+++ b/src/agent/src/process_options_win.cpp
@@ -8,18 +8,24 @@
 
 #include <vector>
 
-void RestartAgent() {}
+void RestartAgent()
+{
+    WindowsService::ServiceRestart();
+}
 
 void StartAgent()
 {
-    LogInfo("Starting Wazuh Agent.");
+    WindowsService::ServiceStart();
 }
 
-void StatusAgent() {}
+void StatusAgent()
+{
+    WindowsService::ServiceStatus();
+}
 
 void StopAgent()
 {
-    LogInfo("Stopping Wazuh Agent.");
+    WindowsService::ServiceStop();
 }
 
 bool InstallService()

--- a/src/agent/src/signal_handler_win.cpp
+++ b/src/agent/src/signal_handler_win.cpp
@@ -7,7 +7,8 @@ void SignalHandler::Initialize([[maybe_unused]] const std::vector<int>& signalsT
     SetConsoleCtrlHandler(
         [](DWORD dwCtrlType) -> BOOL
         {
-            if (dwCtrlType == CTRL_C_EVENT || dwCtrlType == CTRL_BREAK_EVENT)
+            if (dwCtrlType == CTRL_C_EVENT || dwCtrlType == CTRL_BREAK_EVENT || dwCtrlType == SERVICE_CONTROL_STOP ||
+                dwCtrlType == SERVICE_CONTROL_SHUTDOWN)
             {
                 SignalHandler::HandleSignal(dwCtrlType);
                 return TRUE;

--- a/src/agent/src/windows_service.cpp
+++ b/src/agent/src/windows_service.cpp
@@ -1,0 +1,176 @@
+#include <windows_service.hpp>
+
+#include <logger.hpp>
+
+#include <chrono>
+#include <thread>
+
+namespace
+{
+    SERVICE_STATUS g_ServiceStatus = {};
+    SERVICE_STATUS_HANDLE g_StatusHandle = nullptr;
+    HANDLE g_ServiceStopEvent = INVALID_HANDLE_VALUE;
+    SERVICE_DESCRIPTION g_serviceDescription;
+    const std::string AGENT_SERVICENAME = "Wazuh Agent";
+    const std::string AGENT_SERVICEDESCRIPTION = "Wazuh Windows Agent";
+
+    std::string GetExecutablePath()
+    {
+        char buffer[MAX_PATH];
+        GetModuleFileName(NULL, buffer, MAX_PATH);
+        return std::string(buffer);
+    }
+} // namespace
+
+namespace WindowsService
+{
+    bool InstallService()
+    {
+        const std::string exePath = GetExecutablePath() + " service";
+
+        SC_HANDLE schSCManager = OpenSCManager(nullptr, nullptr, SC_MANAGER_CREATE_SERVICE);
+        if (!schSCManager)
+        {
+            LogError("OpenSCManager fail: {}", GetLastError());
+            return false;
+        }
+
+        SC_HANDLE schService = CreateService(schSCManager,
+                                             AGENT_SERVICENAME.c_str(),
+                                             AGENT_SERVICENAME.c_str(),
+                                             SERVICE_ALL_ACCESS,
+                                             SERVICE_WIN32_OWN_PROCESS,
+                                             SERVICE_AUTO_START,
+                                             SERVICE_ERROR_NORMAL,
+                                             exePath.c_str(),
+                                             nullptr,
+                                             nullptr,
+                                             nullptr,
+                                             nullptr,
+                                             nullptr);
+
+        if (!schService)
+        {
+            LogError("CreateService fail: {}", GetLastError());
+            CloseServiceHandle(schSCManager);
+            return false;
+        }
+
+        g_serviceDescription.lpDescription = const_cast<char*>(AGENT_SERVICEDESCRIPTION.c_str());
+        ChangeServiceConfig2(schService, SERVICE_CONFIG_DESCRIPTION, &g_serviceDescription);
+
+        CloseServiceHandle(schService);
+        CloseServiceHandle(schSCManager);
+
+        LogInfo("Wazuh Agent Service successfully installed.");
+
+        return true;
+    }
+
+    bool RemoveService()
+    {
+        SC_HANDLE schSCManager = OpenSCManager(nullptr, nullptr, SC_MANAGER_CREATE_SERVICE);
+        if (!schSCManager)
+        {
+            LogError("OpenSCManager fail: {}", GetLastError());
+            return false;
+        }
+
+        SC_HANDLE schService = OpenService(schSCManager, AGENT_SERVICENAME.c_str(), DELETE);
+        if (!schService)
+        {
+            LogError("OpenService fail: {}", GetLastError());
+            CloseServiceHandle(schSCManager);
+            return false;
+        }
+
+        if (!DeleteService(schService))
+        {
+            LogError("DeleteService fail: {}", GetLastError());
+            CloseServiceHandle(schService);
+            CloseServiceHandle(schSCManager);
+            return false;
+        }
+
+        CloseServiceHandle(schService);
+        CloseServiceHandle(schSCManager);
+
+        LogInfo("Wazuh Agent Service successfully removed.");
+
+        return true;
+    }
+
+    void SetDispatcherThread()
+    {
+        SERVICE_TABLE_ENTRY ServiceTable[] = {{(LPSTR)AGENT_SERVICENAME.c_str(), (LPSERVICE_MAIN_FUNCTION)ServiceMain},
+                                              {NULL, NULL}};
+
+        if (!StartServiceCtrlDispatcher(ServiceTable))
+        {
+            LogError("Error: StartServiceCtrlDispatcher {}", GetLastError());
+        }
+    }
+
+    void WINAPI ServiceMain()
+    {
+        g_StatusHandle = RegisterServiceCtrlHandler(AGENT_SERVICENAME.c_str(), ServiceCtrlHandler);
+
+        if (!g_StatusHandle)
+        {
+            LogError("Failed to register ServiceCtrlHandler. Error: {}", GetLastError());
+            return;
+        }
+
+        g_ServiceStatus.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
+        g_ServiceStatus.dwCurrentState = SERVICE_START_PENDING;
+        g_ServiceStatus.dwControlsAccepted = SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN | SERVICE_ACCEPT_PARAMCHANGE;
+        g_ServiceStatus.dwWin32ExitCode = 0;
+        g_ServiceStatus.dwServiceSpecificExitCode = 0;
+        g_ServiceStatus.dwCheckPoint = 0;
+
+        SetServiceStatus(g_StatusHandle, &g_ServiceStatus);
+
+        g_ServiceStopEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+        if (!g_ServiceStopEvent)
+        {
+            LogError("Failed to create stop event. Error: {}", GetLastError());
+            g_ServiceStatus.dwCurrentState = SERVICE_STOPPED;
+            SetServiceStatus(g_StatusHandle, &g_ServiceStatus);
+            return;
+        }
+
+        g_ServiceStatus.dwCurrentState = SERVICE_RUNNING;
+        SetServiceStatus(g_StatusHandle, &g_ServiceStatus);
+
+        LogInfo("Starting Wazuh Agent.");
+        while (true)
+        {
+            LogInfo("Agent is still running in the registration loop...");
+            std::this_thread::sleep_for(std::chrono::seconds(5));
+        }
+
+        WaitForSingleObject(g_ServiceStopEvent, INFINITE);
+
+        CloseHandle(g_ServiceStopEvent);
+        g_ServiceStatus.dwCurrentState = SERVICE_STOPPED;
+        SetServiceStatus(g_StatusHandle, &g_ServiceStatus);
+    }
+
+    void WINAPI ServiceCtrlHandler(DWORD CtrlCode)
+    {
+        switch (CtrlCode)
+        {
+            case SERVICE_CONTROL_STOP:
+                // TO DO
+                break;
+            case SERVICE_CONTROL_SHUTDOWN:
+                // TO DO
+                break;
+            case SERVICE_CONTROL_PARAMCHANGE:
+                // TO DO
+                break;
+            default: break;
+        }
+    }
+
+} // namespace WindowsService

--- a/src/agent/src/windows_service.hpp
+++ b/src/agent/src/windows_service.hpp
@@ -1,3 +1,14 @@
 #pragma once
 
-#include <process_options.hpp>
+#include <string>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+namespace WindowsService
+{
+    bool InstallService();
+    bool RemoveService();
+    void SetDispatcherThread();
+    void WINAPI ServiceMain();
+    void WINAPI ServiceCtrlHandler(DWORD CtrlCode);
+} // namespace WindowsService

--- a/src/agent/src/windows_service.hpp
+++ b/src/agent/src/windows_service.hpp
@@ -11,4 +11,8 @@ namespace WindowsService
     void SetDispatcherThread();
     void WINAPI ServiceMain();
     void WINAPI ServiceCtrlHandler(DWORD CtrlCode);
+    void ServiceStart();
+    void ServiceStop();
+    void ServiceRestart();
+    void ServiceStatus();
 } // namespace WindowsService

--- a/src/cmake/SetWindowsManifest.cmake
+++ b/src/cmake/SetWindowsManifest.cmake
@@ -1,0 +1,10 @@
+function(set_windows_manifest)
+    set(MANIFEST_FILE "${CMAKE_SOURCE_DIR}/agent/service/app.manifest")
+
+    add_custom_command(TARGET wazuh-agent POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E
+            echo "Embedding manifest in the executable..."
+        COMMAND mt.exe -nologo -manifest ${MANIFEST_FILE} -outputresource:$<TARGET_FILE:wazuh-agent>;#1
+        COMMENT "Embedding manifest in ${CMAKE_CURRENT_BINARY_DIR}/wazuh-agent"
+    )
+endfunction()


### PR DESCRIPTION
|Related issue|
|---|
|[141](https://github.com/wazuh/wazuh-agent/issues/142)|

## Description

This PR aims to make wazuh-agent run in the background and support CLI commands start, status, restart and stop creating a windows service.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
