### PR TITLE
Fix null pointer possible usage

### DIFF
--- a/src/common/file_op/src/file_op.c
+++ b/src/common/file_op/src/file_op.c
@@ -725,6 +725,7 @@ int UnmergeFiles(const char *finalpath, const char *optdir, int mode, char ***un
         if(!tmp_file){
             merror("Unmerging '%s': could not reserve temporary memory for '%s'", finalpath, files);
             state_ok = 0;
+            continue;
         }
         snprintf(tmp_file, tmp_file_size, "%sXXXXXX", final_name);
 


### PR DESCRIPTION
## Description

If a malloc memory allocation failed in file_op.c, although the pointer returned was being checked for success, thhe process was allowed to continue, thus allowing to use a null pointer in several functions, allowing an undetermined behavior.

