### PR TITLE
Allows communication using https

### DIFF
--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -54,5 +54,6 @@ namespace communicator
         std::shared_ptr<std::string> m_token;
         long long m_tokenExpTimeInSeconds = 0;
         std::unique_ptr<boost::asio::steady_timer> m_tokenExpTimer;
+        bool m_useHttps = true;
     };
 } // namespace communicator

--- a/src/agent/communicator/include/http_client.hpp
+++ b/src/agent/communicator/include/http_client.hpp
@@ -38,12 +38,14 @@ namespace http_client
         std::optional<std::string> AuthenticateWithUuidAndKey(const std::string& host,
                                                               const std::string& port,
                                                               const std::string& uuid,
-                                                              const std::string& key) override;
+                                                              const std::string& key,
+                                                              const bool useHttps) override;
 
         std::optional<std::string> AuthenticateWithUserPassword(const std::string& host,
                                                                 const std::string& port,
                                                                 const std::string& user,
-                                                                const std::string& password) override;
+                                                                const std::string& password,
+                                                                const bool useHttps) override;
 
     private:
         std::shared_ptr<IHttpResolverFactory> m_resolverFactory;

--- a/src/agent/communicator/include/ihttp_client.hpp
+++ b/src/agent/communicator/include/ihttp_client.hpp
@@ -45,7 +45,8 @@ namespace http_client
         bool operator==(const HttpRequestParams& other) const
         {
             return Method == other.Method && Host == other.Host && Port == other.Port && Endpoint == other.Endpoint &&
-                   Token == other.Token && User_pass == other.User_pass && Body == other.Body && Use_Https == other.Use_Https;
+                   Token == other.Token && User_pass == other.User_pass && Body == other.Body &&
+                   Use_Https == other.Use_Https;
         }
     };
 

--- a/src/agent/communicator/include/ihttp_client.hpp
+++ b/src/agent/communicator/include/ihttp_client.hpp
@@ -18,6 +18,7 @@ namespace http_client
         std::string Host;
         std::string Port;
         std::string Endpoint;
+        bool Use_Https;
         std::string Token;
         std::string User_pass;
         std::string Body;
@@ -26,6 +27,7 @@ namespace http_client
                           const std::string& host,
                           const std::string& port,
                           const std::string& endpoint,
+                          const bool use_https,
                           const std::string& token = "",
                           const std::string& user_pass = "",
                           const std::string& body = "")
@@ -33,6 +35,7 @@ namespace http_client
             , Host(host)
             , Port(port)
             , Endpoint(endpoint)
+            , Use_Https(use_https)
             , Token(token)
             , User_pass(user_pass)
             , Body(body)
@@ -42,7 +45,7 @@ namespace http_client
         bool operator==(const HttpRequestParams& other) const
         {
             return Method == other.Method && Host == other.Host && Port == other.Port && Endpoint == other.Endpoint &&
-                   Token == other.Token && User_pass == other.User_pass && Body == other.Body;
+                   Token == other.Token && User_pass == other.User_pass && Body == other.Body && Use_Https == other.Use_Https;
         }
     };
 
@@ -68,11 +71,13 @@ namespace http_client
         virtual std::optional<std::string> AuthenticateWithUuidAndKey(const std::string& host,
                                                                       const std::string& port,
                                                                       const std::string& uuid,
-                                                                      const std::string& key) = 0;
+                                                                      const std::string& key,
+                                                                      const bool useHttps) = 0;
 
         virtual std::optional<std::string> AuthenticateWithUserPassword(const std::string& host,
                                                                         const std::string& port,
                                                                         const std::string& user,
-                                                                        const std::string& password) = 0;
+                                                                        const std::string& password,
+                                                                        const bool useHttps) = 0;
     };
 } // namespace http_client

--- a/src/agent/communicator/include/ihttp_socket_factory.hpp
+++ b/src/agent/communicator/include/ihttp_socket_factory.hpp
@@ -12,6 +12,6 @@ namespace http_client
     {
     public:
         virtual ~IHttpSocketFactory() = default;
-        virtual std::unique_ptr<IHttpSocket> Create(const boost::asio::any_io_executor& executor) = 0;
+        virtual std::unique_ptr<IHttpSocket> Create(const boost::asio::any_io_executor& executor, const bool use_https) = 0;
     };
 } // namespace http_client

--- a/src/agent/communicator/include/ihttp_socket_factory.hpp
+++ b/src/agent/communicator/include/ihttp_socket_factory.hpp
@@ -12,6 +12,7 @@ namespace http_client
     {
     public:
         virtual ~IHttpSocketFactory() = default;
-        virtual std::unique_ptr<IHttpSocket> Create(const boost::asio::any_io_executor& executor, const bool use_https) = 0;
+        virtual std::unique_ptr<IHttpSocket> Create(const boost::asio::any_io_executor& executor,
+                                                    const bool use_https) = 0;
     };
 } // namespace http_client

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -41,8 +41,9 @@ namespace communicator
         {
             m_managerIp = getStringConfigValue("agent", "manager_ip");
             m_port = getStringConfigValue("agent", "agent_comms_api_port");
-            const std::string httpsEnabled =  getStringConfigValue("agent", "https_enabled");
-            if (httpsEnabled == "no") {
+            const std::string httpsEnabled = getStringConfigValue("agent", "https_enabled");
+            if (httpsEnabled == "no")
+            {
                 m_useHttps = false;
                 LogInfo("Using insecure connection.");
             }
@@ -100,8 +101,8 @@ namespace communicator
             return m_keepRunning.load();
         };
 
-        const auto reqParams =
-            http_client::HttpRequestParams(boost::beast::http::verb::get, m_managerIp, m_port, "/api/v1/commands", m_useHttps);
+        const auto reqParams = http_client::HttpRequestParams(
+            boost::beast::http::verb::get, m_managerIp, m_port, "/api/v1/commands", m_useHttps);
         co_await m_httpClient->Co_PerformHttpRequest(
             m_token, reqParams, {}, onAuthenticationFailed, onSuccess, loopCondition);
     }

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -41,12 +41,17 @@ namespace communicator
         {
             m_managerIp = getStringConfigValue("agent", "manager_ip");
             m_port = getStringConfigValue("agent", "agent_comms_api_port");
+            const std::string httpsEnabled =  getStringConfigValue("agent", "https_enabled");
+            if (httpsEnabled == "no") {
+                m_useHttps = false;
+                LogInfo("Using insecure connection.");
+            }
         }
     }
 
     boost::beast::http::status Communicator::SendAuthenticationRequest()
     {
-        const auto token = m_httpClient->AuthenticateWithUuidAndKey(m_managerIp, m_port, m_uuid, m_key);
+        const auto token = m_httpClient->AuthenticateWithUuidAndKey(m_managerIp, m_port, m_uuid, m_key, m_useHttps);
 
         if (token.has_value())
         {
@@ -96,7 +101,7 @@ namespace communicator
         };
 
         const auto reqParams =
-            http_client::HttpRequestParams(boost::beast::http::verb::get, m_managerIp, m_port, "/api/v1/commands");
+            http_client::HttpRequestParams(boost::beast::http::verb::get, m_managerIp, m_port, "/api/v1/commands", m_useHttps);
         co_await m_httpClient->Co_PerformHttpRequest(
             m_token, reqParams, {}, onAuthenticationFailed, onSuccess, loopCondition);
     }
@@ -157,7 +162,7 @@ namespace communicator
         };
 
         const auto reqParams = http_client::HttpRequestParams(
-            boost::beast::http::verb::post, m_managerIp, m_port, "/api/v1/events/stateful");
+            boost::beast::http::verb::post, m_managerIp, m_port, "/api/v1/events/stateful", m_useHttps);
         co_await m_httpClient->Co_PerformHttpRequest(
             m_token, reqParams, getMessages, onAuthenticationFailed, onSuccess, loopCondition);
     }
@@ -177,7 +182,7 @@ namespace communicator
         };
 
         const auto reqParams = http_client::HttpRequestParams(
-            boost::beast::http::verb::post, m_managerIp, m_port, "/api/v1/events/stateless");
+            boost::beast::http::verb::post, m_managerIp, m_port, "/api/v1/events/stateless", m_useHttps);
         co_await m_httpClient->Co_PerformHttpRequest(
             m_token, reqParams, getMessages, onAuthenticationFailed, onSuccess, loopCondition);
     }

--- a/src/agent/communicator/src/http_socket_factory.hpp
+++ b/src/agent/communicator/src/http_socket_factory.hpp
@@ -14,8 +14,7 @@ namespace http_client
     class HttpSocketFactory : public IHttpSocketFactory
     {
     public:
-        std::unique_ptr<IHttpSocket> Create(const boost::asio::any_io_executor& executor,
-                                            const bool use_https) override
+        std::unique_ptr<IHttpSocket> Create(const boost::asio::any_io_executor& executor, const bool use_https) override
         {
             if (use_https)
                 return std::make_unique<HttpsSocket>(executor);

--- a/src/agent/communicator/src/http_socket_factory.hpp
+++ b/src/agent/communicator/src/http_socket_factory.hpp
@@ -14,8 +14,12 @@ namespace http_client
     class HttpSocketFactory : public IHttpSocketFactory
     {
     public:
-        std::unique_ptr<IHttpSocket> Create(const boost::asio::any_io_executor& executor) override
+        std::unique_ptr<IHttpSocket> Create(const boost::asio::any_io_executor& executor,
+                                            const bool use_https) override
         {
+            if (use_https)
+                return std::make_unique<HttpsSocket>(executor);
+
             return std::make_unique<HttpSocket>(executor);
         }
     };

--- a/src/agent/communicator/src/http_socket_factory.hpp
+++ b/src/agent/communicator/src/http_socket_factory.hpp
@@ -3,6 +3,7 @@
 #include <ihttp_socket_factory.hpp>
 
 #include "http_socket.hpp"
+#include "https_socket.hpp"
 
 #include <boost/asio/any_io_executor.hpp>
 

--- a/src/agent/communicator/src/https_socket.hpp
+++ b/src/agent/communicator/src/https_socket.hpp
@@ -1,8 +1,8 @@
 #include <ihttp_socket.hpp>
 
 #include <boost/asio.hpp>
-#include <boost/beast.hpp>
 #include <boost/asio/ssl.hpp>
+#include <boost/beast.hpp>
 
 namespace http_client
 {
@@ -10,8 +10,8 @@ namespace http_client
     {
     public:
         HttpsSocket(const boost::asio::any_io_executor& io_context)
-              : m_ctx(boost::asio::ssl::context::sslv23),
-                m_ssl_socket(io_context, m_ctx)
+            : m_ctx(boost::asio::ssl::context::sslv23)
+            , m_ssl_socket(io_context, m_ctx)
         {
             m_ctx.set_verify_mode(boost::asio::ssl::verify_peer);
         }
@@ -29,8 +29,8 @@ namespace http_client
             co_await boost::asio::async_connect(
                 m_ssl_socket.lowest_layer(), endpoints, boost::asio::redirect_error(boost::asio::use_awaitable, code));
 
-            co_await m_ssl_socket.async_handshake(
-                boost::asio::ssl::stream_base::client, boost::asio::redirect_error(boost::asio::use_awaitable, code));
+            co_await m_ssl_socket.async_handshake(boost::asio::ssl::stream_base::client,
+                                                  boost::asio::redirect_error(boost::asio::use_awaitable, code));
         }
 
         void Write(const boost::beast::http::request<boost::beast::http::string_body>& req) override

--- a/src/agent/communicator/src/https_socket.hpp
+++ b/src/agent/communicator/src/https_socket.hpp
@@ -1,0 +1,71 @@
+#include <ihttp_socket.hpp>
+
+#include <boost/asio.hpp>
+#include <boost/beast.hpp>
+#include <boost/asio/ssl.hpp>
+
+namespace http_client
+{
+    class HttpsSocket : public IHttpSocket
+    {
+    public:
+        HttpsSocket(const boost::asio::any_io_executor& io_context)
+              : m_ctx(boost::asio::ssl::context::sslv23),
+                m_ssl_socket(io_context, m_ctx)
+        {
+            m_ctx.set_verify_mode(boost::asio::ssl::verify_peer);
+        }
+
+        void Connect(const boost::asio::ip::tcp::resolver::results_type& endpoints) override
+        {
+            boost::asio::connect(m_ssl_socket.next_layer(), endpoints.begin(), endpoints.end());
+
+            m_ssl_socket.handshake(boost::asio::ssl::stream_base::client);
+        }
+
+        boost::asio::awaitable<void> AsyncConnect(const boost::asio::ip::tcp::resolver::results_type& endpoints,
+                                                  boost::system::error_code& code) override
+        {
+            co_await boost::asio::async_connect(
+                m_ssl_socket.lowest_layer(), endpoints, boost::asio::redirect_error(boost::asio::use_awaitable, code));
+
+            co_await m_ssl_socket.async_handshake(
+                boost::asio::ssl::stream_base::client, boost::asio::redirect_error(boost::asio::use_awaitable, code));
+        }
+
+        void Write(const boost::beast::http::request<boost::beast::http::string_body>& req) override
+        {
+            boost::beast::http::write(m_ssl_socket, req);
+        }
+
+        boost::asio::awaitable<void> AsyncWrite(const boost::beast::http::request<boost::beast::http::string_body>& req,
+                                                boost::beast::error_code& ec) override
+        {
+            co_await boost::beast::http::async_write(
+                m_ssl_socket, req, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        }
+
+        void Read(boost::beast::http::response<boost::beast::http::dynamic_body>& res) override
+        {
+            boost::beast::flat_buffer buffer;
+            boost::beast::http::read(m_ssl_socket, buffer, res);
+        }
+
+        boost::asio::awaitable<void> AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
+                                               boost::beast::error_code& ec) override
+        {
+            boost::beast::flat_buffer buffer;
+            co_await boost::beast::http::async_read(
+                m_ssl_socket, buffer, res, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        }
+
+        void Close() override
+        {
+            m_ssl_socket.shutdown();
+        }
+
+    private:
+        boost::asio::ssl::context m_ctx;
+        boost::asio::ssl::stream<boost::asio::ip::tcp::socket> m_ssl_socket;
+    };
+} // namespace http_client

--- a/src/agent/communicator/tests/communicator_test.cpp
+++ b/src/agent/communicator/tests/communicator_test.cpp
@@ -80,12 +80,13 @@ TEST(CommunicatorTest, WaitForTokenExpirationAndAuthenticate_FailedAuthenticatio
         std::make_shared<communicator::Communicator>(std::move(mockHttpClient), "uuid", "key", nullptr);
 
     // A failed authentication won't return a token
-    EXPECT_CALL(*mockHttpClientPtr, AuthenticateWithUuidAndKey(_, _, _, _))
+    EXPECT_CALL(*mockHttpClientPtr, AuthenticateWithUuidAndKey(_, _, _, _, _))
         .WillOnce(Invoke(
             [communicatorPtr]([[maybe_unused]] const std::string& host,
                               [[maybe_unused]] const std::string& port,
                               [[maybe_unused]] const std::string& uuid,
-                              [[maybe_unused]] const std::string& key) -> std::optional<std::string>
+                              [[maybe_unused]] const std::string& key,
+                              [[maybe_unused]] const bool useHttps) -> std::optional<std::string>
             {
                 communicatorPtr->Stop();
                 return std::nullopt;
@@ -138,7 +139,7 @@ TEST(CommunicatorTest, StatelessMessageProcessingTask_CallsWithValidToken)
         std::make_shared<communicator::Communicator>(std::move(mockHttpClient), "uuid", "key", nullptr);
 
     const auto mockedToken = CreateToken();
-    EXPECT_CALL(*mockHttpClientPtr, AuthenticateWithUuidAndKey(_, _, _, _)).WillOnce(Return(mockedToken));
+    EXPECT_CALL(*mockHttpClientPtr, AuthenticateWithUuidAndKey(_, _, _, _, _)).WillOnce(Return(mockedToken));
 
     std::string capturedToken;
     EXPECT_CALL(*mockHttpClientPtr, Co_PerformHttpRequest(_, _, _, _, _, _))

--- a/src/agent/communicator/tests/mocks/mock_http_client.hpp
+++ b/src/agent/communicator/tests/mocks/mock_http_client.hpp
@@ -27,12 +27,19 @@ public:
 
     MOCK_METHOD(std::optional<std::string>,
                 AuthenticateWithUuidAndKey,
-                (const std::string& host, const std::string& port, const std::string& uuid, const std::string& key),
+                (const std::string& host,
+                 const std::string& port,
+                 const std::string& uuid,
+                 const std::string& key,
+                 const bool useHttps),
                 (override));
 
-    MOCK_METHOD(
-        std::optional<std::string>,
-        AuthenticateWithUserPassword,
-        (const std::string& host, const std::string& port, const std::string& user, const std::string& password),
-        (override));
+    MOCK_METHOD(std::optional<std::string>,
+                AuthenticateWithUserPassword,
+                (const std::string& host,
+                 const std::string& port,
+                 const std::string& user,
+                 const std::string& password,
+                 const bool useHttps),
+                (override));
 };

--- a/src/agent/communicator/tests/mocks/mock_http_socket_factory.hpp
+++ b/src/agent/communicator/tests/mocks/mock_http_socket_factory.hpp
@@ -8,6 +8,6 @@ class MockHttpSocketFactory : public http_client::IHttpSocketFactory
 public:
     MOCK_METHOD(std::unique_ptr<http_client::IHttpSocket>,
                 Create,
-                (const boost::asio::any_io_executor& executor),
+                (const boost::asio::any_io_executor& executor, const bool use_https),
                 (override));
 };

--- a/src/agent/configuration_parser/src/configuration_parser.cpp
+++ b/src/agent/configuration_parser/src/configuration_parser.cpp
@@ -22,7 +22,8 @@ namespace configuration
                 R"([agent]
                 server_mgmt_api_port = "55000"
                 agent_comms_api_port = "27000"
-                manager_ip = "localhost")",
+                manager_ip = "localhost"
+                https_enabled = "yes")",
                 toml::spec::v(1, 0, 0));
         }
     }

--- a/src/agent/src/register.cpp
+++ b/src/agent/src/register.cpp
@@ -16,9 +16,10 @@ namespace registration
         const configuration::ConfigurationParser configurationParser;
         const auto managerIp = configurationParser.GetConfig<std::string>("agent", "manager_ip");
         const auto managerPort = configurationParser.GetConfig<std::string>("agent", "server_mgmt_api_port");
+        const bool useHttps = !(configurationParser.GetConfig<std::string>("agent", "https_enabled") == "no");
 
         const auto token = httpClient.AuthenticateWithUserPassword(
-            managerIp, managerPort, userCredentials.user, userCredentials.password);
+            managerIp, managerPort, userCredentials.user, userCredentials.password, useHttps);
 
         if (!token.has_value())
         {
@@ -36,7 +37,7 @@ namespace registration
         }
 
         const auto reqParams = http_client::HttpRequestParams(
-            http::verb::post, managerIp, managerPort, "/agents", token.value(), "", bodyJson.dump());
+            http::verb::post, managerIp, managerPort, "/agents", useHttps, token.value(), "", bodyJson.dump());
 
         const auto res = httpClient.PerformHttpRequest(reqParams);
 

--- a/src/agent/tests/register_test.cpp
+++ b/src/agent/tests/register_test.cpp
@@ -39,14 +39,21 @@ public:
 
     MOCK_METHOD(std::optional<std::string>,
                 AuthenticateWithUuidAndKey,
-                (const std::string& host, const std::string& port, const std::string& uuid, const std::string& key),
+                (const std::string& host,
+                 const std::string& port,
+                 const std::string& uuid,
+                 const std::string& key,
+                 const bool useHttps),
                 (override));
 
-    MOCK_METHOD(
-        std::optional<std::string>,
-        AuthenticateWithUserPassword,
-        (const std::string& host, const std::string& port, const std::string& user, const std::string& password),
-        (override));
+    MOCK_METHOD(std::optional<std::string>,
+                AuthenticateWithUserPassword,
+                (const std::string& host,
+                 const std::string& port,
+                 const std::string& user,
+                 const std::string& password,
+                 const bool useHttps),
+                (override));
 };
 
 class RegisterTest : public ::testing::Test
@@ -65,7 +72,8 @@ protected:
 TEST_F(RegisterTest, RegistrationTestSuccess)
 {
     EXPECT_CALL(mockHttpClient,
-                AuthenticateWithUserPassword(testing::_, testing::_, userCredentials.user, userCredentials.password))
+                AuthenticateWithUserPassword(
+                    testing::_, testing::_, userCredentials.user, userCredentials.password, testing::_))
         .WillOnce(testing::Return("token"));
 
     nlohmann::json bodyJson = {{"id", agent->GetUUID()}, {"key", agent->GetKey()}};
@@ -76,7 +84,7 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
     }
 
     http_client::HttpRequestParams reqParams(
-        boost::beast::http::verb::post, "localhost", "55000", "/agents", "token", "", bodyJson.dump());
+        boost::beast::http::verb::post, "localhost", "55000", "/agents", true, "token", "", bodyJson.dump());
 
     boost::beast::http::response<boost::beast::http::dynamic_body> expectedResponse;
     expectedResponse.result(boost::beast::http::status::ok);
@@ -90,7 +98,8 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
 
 TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
 {
-    EXPECT_CALL(mockHttpClient, AuthenticateWithUserPassword(testing::_, testing::_, testing::_, testing::_))
+    EXPECT_CALL(mockHttpClient,
+                AuthenticateWithUserPassword(testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Return(std::nullopt));
 
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
@@ -101,7 +110,8 @@ TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
 TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
 {
     EXPECT_CALL(mockHttpClient,
-                AuthenticateWithUserPassword(testing::_, testing::_, userCredentials.user, userCredentials.password))
+                AuthenticateWithUserPassword(
+                    testing::_, testing::_, userCredentials.user, userCredentials.password, testing::_))
         .WillOnce(testing::Return("token"));
 
     boost::beast::http::response<boost::beast::http::dynamic_body> expectedResponse;


### PR DESCRIPTION
|Related issue|
|---|
|#158|


## Description

This PR adds the changes to allow communication using https. It also adds a configuration option `“https_enabled”` to allow the use of http or https.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
