### PR TITLE
Integrate the command handler with the module manager

### DIFF
--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(agent_info)
 add_subdirectory(command_handler)
 add_subdirectory(communicator)
 add_subdirectory(configuration_parser)
+add_subdirectory(module_command)
 add_subdirectory(multitype_queue)
 add_subdirectory(sqlite_manager)
 add_subdirectory(command_store)
@@ -34,7 +35,7 @@ set(SOURCES
 
 add_library(Agent ${SOURCES})
 target_include_directories(Agent PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(Agent PUBLIC ConfigurationParser Communicator AgentInfo CommandHandler MultiTypeQueue ModuleManager PRIVATE OpenSSL::SSL OpenSSL::Crypto Boost::asio Boost::beast)
+target_link_libraries(Agent PUBLIC ConfigurationParser Communicator AgentInfo CommandHandler MultiTypeQueue ModuleManager ModuleCommand PRIVATE OpenSSL::SSL OpenSSL::Crypto Boost::asio Boost::beast)
 
 include(../cmake/ConfigureTarget.cmake)
 configure_target(Agent)

--- a/src/agent/command_handler/include/command_handler.hpp
+++ b/src/agent/command_handler/include/command_handler.hpp
@@ -18,7 +18,7 @@ namespace command_handler
         boost::asio::awaitable<void> CommandsProcessingTask(
             const std::function<std::optional<T>()> GetCommandFromQueue,
             const std::function<void()> PopCommandFromQueue,
-            const std::function<boost::asio::awaitable<std::tuple<command_store::Status, std::string>>(T&)>
+            const std::function<boost::asio::awaitable<std::tuple<module_command::Status, std::string>>(T&)>
                 DispatchCommand)
         {
             using namespace std::chrono_literals;

--- a/src/agent/command_handler/include/command_handler.hpp
+++ b/src/agent/command_handler/include/command_handler.hpp
@@ -39,8 +39,8 @@ namespace command_handler
                 PopCommandFromQueue();
                 auto result = co_await DispatchCommand(cmd.value());
 
-                cmd.value().CurrentStatus = std::get<0>(result);
-                cmd.value().Result = std::get<1>(result);
+                cmd.value().ExecutionResult.ErrorCode = std::get<0>(result);
+                cmd.value().ExecutionResult.Message = std::get<1>(result);
                 m_commandStore.UpdateCommand(cmd.value());
 
                 LogInfo("Done processing command: {}({})", cmd.value().Command, cmd.value().Module);

--- a/src/agent/command_handler/include/command_handler.hpp
+++ b/src/agent/command_handler/include/command_handler.hpp
@@ -14,10 +14,10 @@ namespace command_handler
     {
     public:
         template<typename T>
-        boost::asio::awaitable<void> ProcessCommandsFromQueue(
-            const std::function<std::optional<T>()> GetCommandFromQueue,
-            const std::function<void()> PopCommandFromQueue,
-            const std::function<std::tuple<command_store::Status, std::string>(T&)> DispatchCommand)
+        boost::asio::awaitable<void>
+        CommandsProcessingTask(const std::function<std::optional<T>()> GetCommandFromQueue,
+                               const std::function<void()> PopCommandFromQueue,
+                               const std::function<std::tuple<command_store::Status, std::string>(T&)> DispatchCommand)
         {
             using namespace std::chrono_literals;
             const auto executor = co_await boost::asio::this_coro::executor;

--- a/src/agent/command_handler/include/command_handler.hpp
+++ b/src/agent/command_handler/include/command_handler.hpp
@@ -37,11 +37,11 @@ namespace command_handler
                 PopCommandFromQueue();
                 auto result = DispatchCommand(cmd.value());
 
-                cmd.value().m_status = std::get<0>(result);
-                cmd.value().m_result = std::get<1>(result);
+                cmd.value().CurrentStatus = std::get<0>(result);
+                cmd.value().Result = std::get<1>(result);
                 m_commandStore.UpdateCommand(cmd.value());
 
-                LogInfo("Done processing command: {}({})", cmd.value().m_command, cmd.value().m_module);
+                LogInfo("Done processing command: {}({})", cmd.value().Command, cmd.value().Module);
             }
         }
 

--- a/src/agent/command_store/CMakeLists.txt
+++ b/src/agent/command_store/CMakeLists.txt
@@ -16,7 +16,7 @@ include(../../cmake/ConfigureTarget.cmake)
 configure_target(CommandStore)
 
 target_include_directories(CommandStore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(CommandStore PUBLIC SQLiteManager PRIVATE Logger)
+target_link_libraries(CommandStore PUBLIC SQLiteManager ModuleCommand PRIVATE Logger)
 
 if(BUILD_TESTS)
     enable_testing()

--- a/src/agent/command_store/include/command.hpp
+++ b/src/agent/command_store/include/command.hpp
@@ -18,8 +18,8 @@ namespace command_store
     {
     public:
         CommandEntry()
-            : m_status(Status::UNKNOWN)
-            , m_time(0.0)
+            : CurrentStatus(Status::UNKNOWN)
+            , Time(0.0)
         {
         }
 
@@ -29,21 +29,21 @@ namespace command_store
                      const std::string& parameters,
                      const std::string& result,
                      Status status)
-            : m_id(id)
-            , m_module(module)
-            , m_command(command)
-            , m_parameters(parameters)
-            , m_result(result)
-            , m_status(status)
+            : Id(id)
+            , Module(module)
+            , Command(command)
+            , Parameters(parameters)
+            , Result(result)
+            , CurrentStatus(status)
         {
         }
 
-        std::string m_id;
-        std::string m_module;
-        std::string m_command;
-        std::string m_parameters;
-        std::string m_result;
-        Status m_status;
-        double m_time;
+        std::string Id;
+        std::string Module;
+        std::string Command;
+        std::string Parameters;
+        std::string Result;
+        Status CurrentStatus;
+        double Time;
     };
 } // namespace command_store

--- a/src/agent/command_store/include/command.hpp
+++ b/src/agent/command_store/include/command.hpp
@@ -14,21 +14,21 @@ namespace command_store
         UNKNOWN
     };
 
-    class Command
+    class CommandEntry
     {
     public:
-        Command()
+        CommandEntry()
             : m_status(Status::UNKNOWN)
             , m_time(0.0)
         {
         }
 
-        Command(const std::string& id,
-                const std::string& module,
-                const std::string& command,
-                const std::string& parameters,
-                const std::string& result,
-                Status status)
+        CommandEntry(const std::string& id,
+                     const std::string& module,
+                     const std::string& command,
+                     const std::string& parameters,
+                     const std::string& result,
+                     Status status)
             : m_id(id)
             , m_module(module)
             , m_command(command)

--- a/src/agent/command_store/include/command_store.hpp
+++ b/src/agent/command_store/include/command_store.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <command.hpp>
+#include <module_command/command_entry.hpp>
 #include <sqlite_manager.hpp>
 
 #include <memory>
@@ -18,16 +18,16 @@ namespace command_store
         std::unique_ptr<sqlite_manager::SQLiteManager> m_dataBase;
 
         double GetCurrentTimestampAsReal();
-        Status StatusFromInt(const int i);
+        module_command::Status StatusFromInt(const int i);
 
     public:
         CommandStore();
 
         bool Clear();
         int GetCount();
-        bool StoreCommand(const CommandEntry& cmd);
+        bool StoreCommand(const module_command::CommandEntry& cmd);
         bool DeleteCommand(const std::string& id);
-        std::optional<CommandEntry> GetCommand(const std::string& id);
-        bool UpdateCommand(const CommandEntry& cmd);
+        std::optional<module_command::CommandEntry> GetCommand(const std::string& id);
+        bool UpdateCommand(const module_command::CommandEntry& cmd);
     };
 } // namespace command_store

--- a/src/agent/command_store/include/command_store.hpp
+++ b/src/agent/command_store/include/command_store.hpp
@@ -25,9 +25,9 @@ namespace command_store
 
         bool Clear();
         int GetCount();
-        bool StoreCommand(const Command& cmd);
+        bool StoreCommand(const CommandEntry& cmd);
         bool DeleteCommand(const std::string& id);
-        std::optional<Command> GetCommand(const std::string& id);
-        bool UpdateCommand(const Command& cmd);
+        std::optional<CommandEntry> GetCommand(const std::string& id);
+        bool UpdateCommand(const CommandEntry& cmd);
     };
 } // namespace command_store

--- a/src/agent/command_store/src/command_store.cpp
+++ b/src/agent/command_store/src/command_store.cpp
@@ -81,7 +81,7 @@ namespace command_store
                MILLISECS_IN_A_SEC;
     }
 
-    bool CommandStore::StoreCommand(const Command& cmd)
+    bool CommandStore::StoreCommand(const CommandEntry& cmd)
     {
         std::vector<sqlite_manager::Column> fields;
         fields.emplace_back("id", sqlite_manager::ColumnType::TEXT, cmd.m_id);
@@ -120,7 +120,7 @@ namespace command_store
         return true;
     }
 
-    std::optional<Command> CommandStore::GetCommand(const std::string& id)
+    std::optional<CommandEntry> CommandStore::GetCommand(const std::string& id)
     {
         try
         {
@@ -132,7 +132,7 @@ namespace command_store
                 return std::nullopt;
             }
 
-            Command cmd;
+            CommandEntry cmd;
             for (const sqlite_manager::Column& col : cmdData[0])
             {
                 if (col.m_name == "id")
@@ -173,7 +173,7 @@ namespace command_store
         }
     }
 
-    bool CommandStore::UpdateCommand(const Command& cmd)
+    bool CommandStore::UpdateCommand(const CommandEntry& cmd)
     {
         std::vector<sqlite_manager::Column> fields;
         if (!cmd.m_module.empty())

--- a/src/agent/command_store/src/command_store.cpp
+++ b/src/agent/command_store/src/command_store.cpp
@@ -89,9 +89,10 @@ namespace command_store
         fields.emplace_back("command", sqlite_manager::ColumnType::TEXT, cmd.Command);
         fields.emplace_back("time", sqlite_manager::ColumnType::REAL, std::to_string(GetCurrentTimestampAsReal()));
         fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, cmd.Parameters);
-        fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.Result);
-        fields.emplace_back(
-            "status", sqlite_manager::ColumnType::INTEGER, std::to_string(static_cast<int>(cmd.CurrentStatus)));
+        fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.ExecutionResult.Message);
+        fields.emplace_back("status",
+                            sqlite_manager::ColumnType::INTEGER,
+                            std::to_string(static_cast<int>(cmd.ExecutionResult.ErrorCode)));
         try
         {
             m_dataBase->Insert(COMMANDSTORE_TABLE_NAME, fields);
@@ -153,11 +154,11 @@ namespace command_store
                 }
                 else if (col.Name == "result")
                 {
-                    cmd.Result = col.Value;
+                    cmd.ExecutionResult.Message = col.Value;
                 }
                 else if (col.Name == "status")
                 {
-                    cmd.CurrentStatus = StatusFromInt(std::stoi(col.Value));
+                    cmd.ExecutionResult.ErrorCode = StatusFromInt(std::stoi(col.Value));
                 }
                 else if (col.Name == "time")
                 {
@@ -182,11 +183,12 @@ namespace command_store
             fields.emplace_back("command", sqlite_manager::ColumnType::TEXT, cmd.Command);
         if (!cmd.Parameters.empty())
             fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, cmd.Parameters);
-        if (!cmd.Result.empty())
-            fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.Result);
-        if (cmd.CurrentStatus != module_command::Status::UNKNOWN)
-            fields.emplace_back(
-                "status", sqlite_manager::ColumnType::INTEGER, std::to_string(static_cast<int>(cmd.CurrentStatus)));
+        if (!cmd.ExecutionResult.Message.empty())
+            fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.ExecutionResult.Message);
+        if (cmd.ExecutionResult.ErrorCode != module_command::Status::UNKNOWN)
+            fields.emplace_back("status",
+                                sqlite_manager::ColumnType::INTEGER,
+                                std::to_string(static_cast<int>(cmd.ExecutionResult.ErrorCode)));
 
         sqlite_manager::Column condition("id", sqlite_manager::ColumnType::TEXT, cmd.Id);
         try

--- a/src/agent/command_store/src/command_store.cpp
+++ b/src/agent/command_store/src/command_store.cpp
@@ -8,15 +8,15 @@ namespace command_store
 {
     constexpr double MILLISECS_IN_A_SEC = 1000.0;
 
-    Status CommandStore::StatusFromInt(const int i)
+    module_command::Status CommandStore::StatusFromInt(const int i)
     {
         switch (i)
         {
-            case 0: return Status::SUCCESS; break;
-            case 1: return Status::FAILURE; break;
-            case 2: return Status::IN_PROGRESS; break;
-            case 3: return Status::TIMEOUT; break;
-            default: return Status::UNKNOWN; break;
+            case 0: return module_command::Status::SUCCESS; break;
+            case 1: return module_command::Status::FAILURE; break;
+            case 2: return module_command::Status::IN_PROGRESS; break;
+            case 3: return module_command::Status::TIMEOUT; break;
+            default: return module_command::Status::UNKNOWN; break;
         }
     }
 
@@ -81,7 +81,7 @@ namespace command_store
                MILLISECS_IN_A_SEC;
     }
 
-    bool CommandStore::StoreCommand(const CommandEntry& cmd)
+    bool CommandStore::StoreCommand(const module_command::CommandEntry& cmd)
     {
         std::vector<sqlite_manager::Column> fields;
         fields.emplace_back("id", sqlite_manager::ColumnType::TEXT, cmd.Id);
@@ -120,7 +120,7 @@ namespace command_store
         return true;
     }
 
-    std::optional<CommandEntry> CommandStore::GetCommand(const std::string& id)
+    std::optional<module_command::CommandEntry> CommandStore::GetCommand(const std::string& id)
     {
         try
         {
@@ -132,7 +132,7 @@ namespace command_store
                 return std::nullopt;
             }
 
-            CommandEntry cmd;
+            module_command::CommandEntry cmd;
             for (const sqlite_manager::Column& col : cmdData[0])
             {
                 if (col.Name == "id")
@@ -173,7 +173,7 @@ namespace command_store
         }
     }
 
-    bool CommandStore::UpdateCommand(const CommandEntry& cmd)
+    bool CommandStore::UpdateCommand(const module_command::CommandEntry& cmd)
     {
         std::vector<sqlite_manager::Column> fields;
         if (!cmd.Module.empty())
@@ -184,7 +184,7 @@ namespace command_store
             fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, cmd.Parameters);
         if (!cmd.Result.empty())
             fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.Result);
-        if (cmd.CurrentStatus != Status::UNKNOWN)
+        if (cmd.CurrentStatus != module_command::Status::UNKNOWN)
             fields.emplace_back(
                 "status", sqlite_manager::ColumnType::INTEGER, std::to_string(static_cast<int>(cmd.CurrentStatus)));
 

--- a/src/agent/command_store/src/command_store.cpp
+++ b/src/agent/command_store/src/command_store.cpp
@@ -84,14 +84,14 @@ namespace command_store
     bool CommandStore::StoreCommand(const CommandEntry& cmd)
     {
         std::vector<sqlite_manager::Column> fields;
-        fields.emplace_back("id", sqlite_manager::ColumnType::TEXT, cmd.m_id);
-        fields.emplace_back("module", sqlite_manager::ColumnType::TEXT, cmd.m_module);
-        fields.emplace_back("command", sqlite_manager::ColumnType::TEXT, cmd.m_command);
+        fields.emplace_back("id", sqlite_manager::ColumnType::TEXT, cmd.Id);
+        fields.emplace_back("module", sqlite_manager::ColumnType::TEXT, cmd.Module);
+        fields.emplace_back("command", sqlite_manager::ColumnType::TEXT, cmd.Command);
         fields.emplace_back("time", sqlite_manager::ColumnType::REAL, std::to_string(GetCurrentTimestampAsReal()));
-        fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, cmd.m_parameters);
-        fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.m_result);
+        fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, cmd.Parameters);
+        fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.Result);
         fields.emplace_back(
-            "status", sqlite_manager::ColumnType::INTEGER, std::to_string(static_cast<int>(cmd.m_status)));
+            "status", sqlite_manager::ColumnType::INTEGER, std::to_string(static_cast<int>(cmd.CurrentStatus)));
         try
         {
             m_dataBase->Insert(COMMANDSTORE_TABLE_NAME, fields);
@@ -137,31 +137,31 @@ namespace command_store
             {
                 if (col.m_name == "id")
                 {
-                    cmd.m_id = col.m_value;
+                    cmd.Id = col.m_value;
                 }
                 else if (col.m_name == "module")
                 {
-                    cmd.m_module = col.m_value;
+                    cmd.Module = col.m_value;
                 }
                 else if (col.m_name == "command")
                 {
-                    cmd.m_command = col.m_value;
+                    cmd.Command = col.m_value;
                 }
                 else if (col.m_name == "parameters")
                 {
-                    cmd.m_parameters = col.m_value;
+                    cmd.Parameters = col.m_value;
                 }
                 else if (col.m_name == "result")
                 {
-                    cmd.m_result = col.m_value;
+                    cmd.Result = col.m_value;
                 }
                 else if (col.m_name == "status")
                 {
-                    cmd.m_status = StatusFromInt(std::stoi(col.m_value));
+                    cmd.CurrentStatus = StatusFromInt(std::stoi(col.m_value));
                 }
                 else if (col.m_name == "time")
                 {
-                    cmd.m_time = std::stod(col.m_value);
+                    cmd.Time = std::stod(col.m_value);
                 }
             }
             return cmd;
@@ -176,19 +176,19 @@ namespace command_store
     bool CommandStore::UpdateCommand(const CommandEntry& cmd)
     {
         std::vector<sqlite_manager::Column> fields;
-        if (!cmd.m_module.empty())
-            fields.emplace_back("module", sqlite_manager::ColumnType::TEXT, cmd.m_module);
-        if (!cmd.m_command.empty())
-            fields.emplace_back("command", sqlite_manager::ColumnType::TEXT, cmd.m_command);
-        if (!cmd.m_parameters.empty())
-            fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, cmd.m_parameters);
-        if (!cmd.m_result.empty())
-            fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.m_result);
-        if (cmd.m_status != Status::UNKNOWN)
+        if (!cmd.Module.empty())
+            fields.emplace_back("module", sqlite_manager::ColumnType::TEXT, cmd.Module);
+        if (!cmd.Command.empty())
+            fields.emplace_back("command", sqlite_manager::ColumnType::TEXT, cmd.Command);
+        if (!cmd.Parameters.empty())
+            fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, cmd.Parameters);
+        if (!cmd.Result.empty())
+            fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.Result);
+        if (cmd.CurrentStatus != Status::UNKNOWN)
             fields.emplace_back(
-                "status", sqlite_manager::ColumnType::INTEGER, std::to_string(static_cast<int>(cmd.m_status)));
+                "status", sqlite_manager::ColumnType::INTEGER, std::to_string(static_cast<int>(cmd.CurrentStatus)));
 
-        sqlite_manager::Column condition("id", sqlite_manager::ColumnType::TEXT, cmd.m_id);
+        sqlite_manager::Column condition("id", sqlite_manager::ColumnType::TEXT, cmd.Id);
         try
         {
             m_dataBase->Update(COMMANDSTORE_TABLE_NAME, fields, {condition});

--- a/src/agent/command_store/src/command_store.cpp
+++ b/src/agent/command_store/src/command_store.cpp
@@ -135,33 +135,33 @@ namespace command_store
             CommandEntry cmd;
             for (const sqlite_manager::Column& col : cmdData[0])
             {
-                if (col.m_name == "id")
+                if (col.Name == "id")
                 {
-                    cmd.Id = col.m_value;
+                    cmd.Id = col.Value;
                 }
-                else if (col.m_name == "module")
+                else if (col.Name == "module")
                 {
-                    cmd.Module = col.m_value;
+                    cmd.Module = col.Value;
                 }
-                else if (col.m_name == "command")
+                else if (col.Name == "command")
                 {
-                    cmd.Command = col.m_value;
+                    cmd.Command = col.Value;
                 }
-                else if (col.m_name == "parameters")
+                else if (col.Name == "parameters")
                 {
-                    cmd.Parameters = col.m_value;
+                    cmd.Parameters = col.Value;
                 }
-                else if (col.m_name == "result")
+                else if (col.Name == "result")
                 {
-                    cmd.Result = col.m_value;
+                    cmd.Result = col.Value;
                 }
-                else if (col.m_name == "status")
+                else if (col.Name == "status")
                 {
-                    cmd.CurrentStatus = StatusFromInt(std::stoi(col.m_value));
+                    cmd.CurrentStatus = StatusFromInt(std::stoi(col.Value));
                 }
-                else if (col.m_name == "time")
+                else if (col.Name == "time")
                 {
-                    cmd.Time = std::stod(col.m_value);
+                    cmd.Time = std::stod(col.Value);
                 }
             }
             return cmd;

--- a/src/agent/command_store/tests/command_store_test.cpp
+++ b/src/agent/command_store/tests/command_store_test.cpp
@@ -24,18 +24,18 @@ TEST_F(CommandStoreTest, StoreCommandTest)
     m_commandStore->Clear();
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::Command cmd1(
+    command_store::CommandEntry cmd1(
         TESTID_5, "Module1", "{CommandTextHERE}", "Parameter1", "Result1", command_store::Status::IN_PROGRESS);
     bool retVal = m_commandStore->StoreCommand(cmd1);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::Command cmd2(
+    command_store::CommandEntry cmd2(
         TESTID_9, "Module2", R"({"Some"="thing"})", "Parameter2", "Result2", command_store::Status::IN_PROGRESS);
     retVal = m_commandStore->StoreCommand(cmd2);
     ASSERT_EQ(retVal, true);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::Command cmd3(
+    command_store::CommandEntry cmd3(
         TESTID_5, "Module3", "{CommandTextHERE}", "Parameter3", "Result3", command_store::Status::IN_PROGRESS);
     retVal = m_commandStore->StoreCommand(cmd3);
     ASSERT_EQ(retVal, false);
@@ -48,35 +48,35 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
     m_commandStore->Clear();
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::Command cmd1(
+    command_store::CommandEntry cmd1(
         TESTID_5, "Module1", "{CommandTextHERE}", "Parameter1", "Result1", command_store::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd1);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::Command cmd2(
+    command_store::CommandEntry cmd2(
         TESTID_9, "Module2", R"({"Some"="thing"})", "Parameter2", "Result2", command_store::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd2);
 
     ASSERT_EQ(m_commandStore->GetCount(), 2);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::Command cmdUpdate(TESTID_9,
-                                     "Updated Module",
-                                     "Updated Command",
-                                     "Updated Parameter",
-                                     "Updated Result",
-                                     command_store::Status::SUCCESS);
+    command_store::CommandEntry cmdUpdate(TESTID_9,
+                                          "Updated Module",
+                                          "Updated CommandEntry",
+                                          "Updated Parameter",
+                                          "Updated Result",
+                                          command_store::Status::SUCCESS);
 
     bool retVal = m_commandStore->UpdateCommand(cmdUpdate);
     ASSERT_EQ(retVal, true);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    std::optional<command_store::Command> retValue = m_commandStore->GetCommand(TESTID_9);
+    std::optional<command_store::CommandEntry> retValue = m_commandStore->GetCommand(TESTID_9);
     if (retValue.has_value())
     {
-        const command_store::Command& cmd = retValue.value();
+        const command_store::CommandEntry& cmd = retValue.value();
         ASSERT_EQ(cmd.m_id, TESTID_9);
         ASSERT_EQ(cmd.m_module, "Updated Module");
-        ASSERT_EQ(cmd.m_command, "Updated Command");
+        ASSERT_EQ(cmd.m_command, "Updated CommandEntry");
         ASSERT_EQ(cmd.m_parameters, "Updated Parameter");
         ASSERT_EQ(cmd.m_result, "Updated Result");
         ASSERT_EQ(cmd.m_status, command_store::Status::SUCCESS);
@@ -87,7 +87,8 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
     }
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::Command cmdUpdate2(TESTID_9, "", "", "", "Newly Updated Result", command_store::Status::UNKNOWN);
+    command_store::CommandEntry cmdUpdate2(
+        TESTID_9, "", "", "", "Newly Updated Result", command_store::Status::UNKNOWN);
 
     retVal = m_commandStore->UpdateCommand(cmdUpdate2);
     ASSERT_EQ(retVal, true);
@@ -96,10 +97,10 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
     retValue = m_commandStore->GetCommand(TESTID_9);
     if (retValue.has_value())
     {
-        const command_store::Command& cmd = retValue.value();
+        const command_store::CommandEntry& cmd = retValue.value();
         ASSERT_EQ(cmd.m_id, TESTID_9);
         ASSERT_EQ(cmd.m_module, "Updated Module");
-        ASSERT_EQ(cmd.m_command, "Updated Command");
+        ASSERT_EQ(cmd.m_command, "Updated CommandEntry");
         ASSERT_EQ(cmd.m_parameters, "Updated Parameter");
         ASSERT_EQ(cmd.m_result, "Newly Updated Result");
         ASSERT_EQ(cmd.m_status, command_store::Status::SUCCESS);
@@ -125,24 +126,24 @@ TEST_F(CommandStoreTest, GetCommandTest)
     m_commandStore->Clear();
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::Command cmd1(
+    command_store::CommandEntry cmd1(
         TESTID_5, "Module1", "{CommandTextHERE}", "Parameter1", "Result1", command_store::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd1);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::Command cmd2(
+    command_store::CommandEntry cmd2(
         TESTID_9, "Module2", "TestValue9", "Parameter2", "Result2", command_store::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd2);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::Command cmd3(
+    command_store::CommandEntry cmd3(
         TESTID_11, "Module3", "{CommandTextHERE}", "Parameter3", "Result3", command_store::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd3);
     ASSERT_EQ(m_commandStore->GetCount(), 3);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    std::optional<command_store::Command> retValue = m_commandStore->GetCommand(TESTID_9);
+    std::optional<command_store::CommandEntry> retValue = m_commandStore->GetCommand(TESTID_9);
     if (retValue.has_value())
     {
-        const command_store::Command& cmd = retValue.value();
+        const command_store::CommandEntry& cmd = retValue.value();
         ASSERT_EQ(cmd.m_id, TESTID_9);
         ASSERT_EQ(cmd.m_module, "Module2");
         ASSERT_EQ(cmd.m_command, "TestValue9");
@@ -152,7 +153,7 @@ TEST_F(CommandStoreTest, GetCommandTest)
     retValue = m_commandStore->GetCommand(TESTID_11);
     if (retValue.has_value())
     {
-        const command_store::Command& cmd = retValue.value();
+        const command_store::CommandEntry& cmd = retValue.value();
         ASSERT_EQ(cmd.m_id, TESTID_11);
         ASSERT_EQ(cmd.m_module, "Module3");
         ASSERT_EQ(cmd.m_command, "{CommandTextHERE}");

--- a/src/agent/command_store/tests/command_store_test.cpp
+++ b/src/agent/command_store/tests/command_store_test.cpp
@@ -24,19 +24,19 @@ TEST_F(CommandStoreTest, StoreCommandTest)
     m_commandStore->Clear();
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::CommandEntry cmd1(
-        TESTID_5, "Module1", "{CommandTextHERE}", "Parameter1", "Result1", command_store::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd1(
+        TESTID_5, "Module1", "{CommandTextHERE}", "Parameter1", "Result1", module_command::Status::IN_PROGRESS);
     bool retVal = m_commandStore->StoreCommand(cmd1);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::CommandEntry cmd2(
-        TESTID_9, "Module2", R"({"Some"="thing"})", "Parameter2", "Result2", command_store::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd2(
+        TESTID_9, "Module2", R"({"Some"="thing"})", "Parameter2", "Result2", module_command::Status::IN_PROGRESS);
     retVal = m_commandStore->StoreCommand(cmd2);
     ASSERT_EQ(retVal, true);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::CommandEntry cmd3(
-        TESTID_5, "Module3", "{CommandTextHERE}", "Parameter3", "Result3", command_store::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd3(
+        TESTID_5, "Module3", "{CommandTextHERE}", "Parameter3", "Result3", module_command::Status::IN_PROGRESS);
     retVal = m_commandStore->StoreCommand(cmd3);
     ASSERT_EQ(retVal, false);
 
@@ -48,38 +48,38 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
     m_commandStore->Clear();
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::CommandEntry cmd1(
-        TESTID_5, "Module1", "{CommandTextHERE}", "Parameter1", "Result1", command_store::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd1(
+        TESTID_5, "Module1", "{CommandTextHERE}", "Parameter1", "Result1", module_command::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd1);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::CommandEntry cmd2(
-        TESTID_9, "Module2", R"({"Some"="thing"})", "Parameter2", "Result2", command_store::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd2(
+        TESTID_9, "Module2", R"({"Some"="thing"})", "Parameter2", "Result2", module_command::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd2);
 
     ASSERT_EQ(m_commandStore->GetCount(), 2);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::CommandEntry cmdUpdate(TESTID_9,
-                                          "Updated Module",
-                                          "Updated CommandEntry",
-                                          "Updated Parameter",
-                                          "Updated Result",
-                                          command_store::Status::SUCCESS);
+    module_command::CommandEntry cmdUpdate(TESTID_9,
+                                           "Updated Module",
+                                           "Updated CommandEntry",
+                                           "Updated Parameter",
+                                           "Updated Result",
+                                           module_command::Status::SUCCESS);
 
     bool retVal = m_commandStore->UpdateCommand(cmdUpdate);
     ASSERT_EQ(retVal, true);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    std::optional<command_store::CommandEntry> retValue = m_commandStore->GetCommand(TESTID_9);
+    std::optional<module_command::CommandEntry> retValue = m_commandStore->GetCommand(TESTID_9);
     if (retValue.has_value())
     {
-        const command_store::CommandEntry& cmd = retValue.value();
+        const module_command::CommandEntry& cmd = retValue.value();
         ASSERT_EQ(cmd.Id, TESTID_9);
         ASSERT_EQ(cmd.Module, "Updated Module");
         ASSERT_EQ(cmd.Command, "Updated CommandEntry");
         ASSERT_EQ(cmd.Parameters, "Updated Parameter");
         ASSERT_EQ(cmd.Result, "Updated Result");
-        ASSERT_EQ(cmd.CurrentStatus, command_store::Status::SUCCESS);
+        ASSERT_EQ(cmd.CurrentStatus, module_command::Status::SUCCESS);
     }
     else
     {
@@ -87,8 +87,8 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
     }
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::CommandEntry cmdUpdate2(
-        TESTID_9, "", "", "", "Newly Updated Result", command_store::Status::UNKNOWN);
+    module_command::CommandEntry cmdUpdate2(
+        TESTID_9, "", "", "", "Newly Updated Result", module_command::Status::UNKNOWN);
 
     retVal = m_commandStore->UpdateCommand(cmdUpdate2);
     ASSERT_EQ(retVal, true);
@@ -97,13 +97,13 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
     retValue = m_commandStore->GetCommand(TESTID_9);
     if (retValue.has_value())
     {
-        const command_store::CommandEntry& cmd = retValue.value();
+        const module_command::CommandEntry& cmd = retValue.value();
         ASSERT_EQ(cmd.Id, TESTID_9);
         ASSERT_EQ(cmd.Module, "Updated Module");
         ASSERT_EQ(cmd.Command, "Updated CommandEntry");
         ASSERT_EQ(cmd.Parameters, "Updated Parameter");
         ASSERT_EQ(cmd.Result, "Newly Updated Result");
-        ASSERT_EQ(cmd.CurrentStatus, command_store::Status::SUCCESS);
+        ASSERT_EQ(cmd.CurrentStatus, module_command::Status::SUCCESS);
     }
     else
     {
@@ -126,24 +126,24 @@ TEST_F(CommandStoreTest, GetCommandTest)
     m_commandStore->Clear();
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::CommandEntry cmd1(
-        TESTID_5, "Module1", "{CommandTextHERE}", "Parameter1", "Result1", command_store::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd1(
+        TESTID_5, "Module1", "{CommandTextHERE}", "Parameter1", "Result1", module_command::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd1);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::CommandEntry cmd2(
-        TESTID_9, "Module2", "TestValue9", "Parameter2", "Result2", command_store::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd2(
+        TESTID_9, "Module2", "TestValue9", "Parameter2", "Result2", module_command::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd2);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    command_store::CommandEntry cmd3(
-        TESTID_11, "Module3", "{CommandTextHERE}", "Parameter3", "Result3", command_store::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd3(
+        TESTID_11, "Module3", "{CommandTextHERE}", "Parameter3", "Result3", module_command::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd3);
     ASSERT_EQ(m_commandStore->GetCount(), 3);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    std::optional<command_store::CommandEntry> retValue = m_commandStore->GetCommand(TESTID_9);
+    std::optional<module_command::CommandEntry> retValue = m_commandStore->GetCommand(TESTID_9);
     if (retValue.has_value())
     {
-        const command_store::CommandEntry& cmd = retValue.value();
+        const module_command::CommandEntry& cmd = retValue.value();
         ASSERT_EQ(cmd.Id, TESTID_9);
         ASSERT_EQ(cmd.Module, "Module2");
         ASSERT_EQ(cmd.Command, "TestValue9");
@@ -153,7 +153,7 @@ TEST_F(CommandStoreTest, GetCommandTest)
     retValue = m_commandStore->GetCommand(TESTID_11);
     if (retValue.has_value())
     {
-        const command_store::CommandEntry& cmd = retValue.value();
+        const module_command::CommandEntry& cmd = retValue.value();
         ASSERT_EQ(cmd.Id, TESTID_11);
         ASSERT_EQ(cmd.Module, "Module3");
         ASSERT_EQ(cmd.Command, "{CommandTextHERE}");

--- a/src/agent/command_store/tests/command_store_test.cpp
+++ b/src/agent/command_store/tests/command_store_test.cpp
@@ -74,12 +74,12 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
     if (retValue.has_value())
     {
         const command_store::CommandEntry& cmd = retValue.value();
-        ASSERT_EQ(cmd.m_id, TESTID_9);
-        ASSERT_EQ(cmd.m_module, "Updated Module");
-        ASSERT_EQ(cmd.m_command, "Updated CommandEntry");
-        ASSERT_EQ(cmd.m_parameters, "Updated Parameter");
-        ASSERT_EQ(cmd.m_result, "Updated Result");
-        ASSERT_EQ(cmd.m_status, command_store::Status::SUCCESS);
+        ASSERT_EQ(cmd.Id, TESTID_9);
+        ASSERT_EQ(cmd.Module, "Updated Module");
+        ASSERT_EQ(cmd.Command, "Updated CommandEntry");
+        ASSERT_EQ(cmd.Parameters, "Updated Parameter");
+        ASSERT_EQ(cmd.Result, "Updated Result");
+        ASSERT_EQ(cmd.CurrentStatus, command_store::Status::SUCCESS);
     }
     else
     {
@@ -98,12 +98,12 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
     if (retValue.has_value())
     {
         const command_store::CommandEntry& cmd = retValue.value();
-        ASSERT_EQ(cmd.m_id, TESTID_9);
-        ASSERT_EQ(cmd.m_module, "Updated Module");
-        ASSERT_EQ(cmd.m_command, "Updated CommandEntry");
-        ASSERT_EQ(cmd.m_parameters, "Updated Parameter");
-        ASSERT_EQ(cmd.m_result, "Newly Updated Result");
-        ASSERT_EQ(cmd.m_status, command_store::Status::SUCCESS);
+        ASSERT_EQ(cmd.Id, TESTID_9);
+        ASSERT_EQ(cmd.Module, "Updated Module");
+        ASSERT_EQ(cmd.Command, "Updated CommandEntry");
+        ASSERT_EQ(cmd.Parameters, "Updated Parameter");
+        ASSERT_EQ(cmd.Result, "Newly Updated Result");
+        ASSERT_EQ(cmd.CurrentStatus, command_store::Status::SUCCESS);
     }
     else
     {
@@ -144,9 +144,9 @@ TEST_F(CommandStoreTest, GetCommandTest)
     if (retValue.has_value())
     {
         const command_store::CommandEntry& cmd = retValue.value();
-        ASSERT_EQ(cmd.m_id, TESTID_9);
-        ASSERT_EQ(cmd.m_module, "Module2");
-        ASSERT_EQ(cmd.m_command, "TestValue9");
+        ASSERT_EQ(cmd.Id, TESTID_9);
+        ASSERT_EQ(cmd.Module, "Module2");
+        ASSERT_EQ(cmd.Command, "TestValue9");
     }
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
@@ -154,9 +154,9 @@ TEST_F(CommandStoreTest, GetCommandTest)
     if (retValue.has_value())
     {
         const command_store::CommandEntry& cmd = retValue.value();
-        ASSERT_EQ(cmd.m_id, TESTID_11);
-        ASSERT_EQ(cmd.m_module, "Module3");
-        ASSERT_EQ(cmd.m_command, "{CommandTextHERE}");
+        ASSERT_EQ(cmd.Id, TESTID_11);
+        ASSERT_EQ(cmd.Module, "Module3");
+        ASSERT_EQ(cmd.Command, "{CommandTextHERE}");
     }
 }
 

--- a/src/agent/command_store/tests/command_store_test.cpp
+++ b/src/agent/command_store/tests/command_store_test.cpp
@@ -78,8 +78,8 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
         ASSERT_EQ(cmd.Module, "Updated Module");
         ASSERT_EQ(cmd.Command, "Updated CommandEntry");
         ASSERT_EQ(cmd.Parameters, "Updated Parameter");
-        ASSERT_EQ(cmd.Result, "Updated Result");
-        ASSERT_EQ(cmd.CurrentStatus, module_command::Status::SUCCESS);
+        ASSERT_EQ(cmd.ExecutionResult.Message, "Updated Result");
+        ASSERT_EQ(cmd.ExecutionResult.ErrorCode, module_command::Status::SUCCESS);
     }
     else
     {
@@ -102,8 +102,8 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
         ASSERT_EQ(cmd.Module, "Updated Module");
         ASSERT_EQ(cmd.Command, "Updated CommandEntry");
         ASSERT_EQ(cmd.Parameters, "Updated Parameter");
-        ASSERT_EQ(cmd.Result, "Newly Updated Result");
-        ASSERT_EQ(cmd.CurrentStatus, module_command::Status::SUCCESS);
+        ASSERT_EQ(cmd.ExecutionResult.Message, "Newly Updated Result");
+        ASSERT_EQ(cmd.ExecutionResult.ErrorCode, module_command::Status::SUCCESS);
     }
     else
     {

--- a/src/agent/module_command/CMakeLists.txt
+++ b/src/agent/module_command/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(ModuleCommand)
+
+include(../../cmake/CommonSettings.cmake)
+set_common_settings()
+
+add_library(ModuleCommand INTERFACE)
+
+target_include_directories(ModuleCommand INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/src/agent/module_command/include/module_command/command_entry.hpp
+++ b/src/agent/module_command/include/module_command/command_entry.hpp
@@ -3,7 +3,7 @@
 #include <limits>
 #include <string>
 
-namespace command_store
+namespace module_command
 {
     enum class Status
     {
@@ -46,4 +46,4 @@ namespace command_store
         Status CurrentStatus;
         double Time;
     };
-} // namespace command_store
+} // namespace module_command

--- a/src/agent/module_command/include/module_command/command_entry.hpp
+++ b/src/agent/module_command/include/module_command/command_entry.hpp
@@ -14,27 +14,40 @@ namespace module_command
         UNKNOWN
     };
 
+    struct CommandExecutionResult
+    {
+        Status ErrorCode = Status::UNKNOWN;
+        std::string Message;
+
+        explicit CommandExecutionResult(Status code = Status::UNKNOWN, std::string message = "")
+            : ErrorCode(code)
+            , Message(std::move(message))
+        {
+        }
+    };
+
     class CommandEntry
     {
     public:
+        // Default constructor
         CommandEntry()
-            : CurrentStatus(Status::UNKNOWN)
-            , Time(0.0)
+            : Time(0.0)
+            , ExecutionResult(Status::UNKNOWN, "")
         {
         }
 
-        CommandEntry(const std::string& id,
-                     const std::string& module,
-                     const std::string& command,
-                     const std::string& parameters,
-                     const std::string& result,
+        CommandEntry(std::string id,
+                     std::string module,
+                     std::string command,
+                     std::string parameters,
+                     std::string result,
                      Status status)
-            : Id(id)
-            , Module(module)
-            , Command(command)
-            , Parameters(parameters)
-            , Result(result)
-            , CurrentStatus(status)
+            : Id(std::move(id))
+            , Module(std::move(module))
+            , Command(std::move(command))
+            , Parameters(std::move(parameters))
+            , Time(0.0)
+            , ExecutionResult(status, std::move(result))
         {
         }
 
@@ -42,8 +55,7 @@ namespace module_command
         std::string Module;
         std::string Command;
         std::string Parameters;
-        std::string Result;
-        Status CurrentStatus;
         double Time;
+        CommandExecutionResult ExecutionResult;
     };
 } // namespace module_command

--- a/src/agent/sqlite_manager/include/sqlite_manager.hpp
+++ b/src/agent/sqlite_manager/include/sqlite_manager.hpp
@@ -30,27 +30,27 @@ namespace sqlite_manager
                const bool notNull,
                const bool autoIncr,
                const bool primary = false)
-            : m_name(std::move(name))
-            , m_type(type)
-            , m_notNull(notNull)
-            , m_autoIncrement(autoIncr)
-            , m_primaryKey(primary)
+            : Name(std::move(name))
+            , Type(type)
+            , NotNull(notNull)
+            , AutoIncrement(autoIncr)
+            , PrimaryKey(primary)
         {
         }
 
         Column(std::string name, const ColumnType type, std::string value)
-            : m_name(std::move(name))
-            , m_type(type)
-            , m_value(std::move(value))
+            : Name(std::move(name))
+            , Type(type)
+            , Value(std::move(value))
         {
         }
 
-        std::string m_name;
-        ColumnType m_type;
-        bool m_notNull;
-        bool m_autoIncrement;
-        bool m_primaryKey;
-        std::string m_value;
+        std::string Name;
+        ColumnType Type;
+        bool NotNull;
+        bool AutoIncrement;
+        bool PrimaryKey;
+        std::string Value;
     };
 
     using Row = std::vector<Column>;

--- a/src/agent/sqlite_manager/src/sqlite_manager.cpp
+++ b/src/agent/sqlite_manager/src/sqlite_manager.cpp
@@ -36,11 +36,11 @@ namespace sqlite_manager
         std::vector<std::string> fields;
         for (const Column& col : cols)
         {
-            std::string field = fmt::format(
-                "{} {}{}", col.m_name, MAP_COL_TYPE_STRING.at(col.m_type), (col.m_notNull) ? " NOT NULL" : "");
-            if (col.m_primaryKey)
+            std::string field =
+                fmt::format("{} {}{}", col.Name, MAP_COL_TYPE_STRING.at(col.Type), (col.NotNull) ? " NOT NULL" : "");
+            if (col.PrimaryKey)
             {
-                pk.push_back(col.m_autoIncrement ? fmt::format("{} AUTOINCREMENT", col.m_name) : col.m_name);
+                pk.push_back(col.AutoIncrement ? fmt::format("{} AUTOINCREMENT", col.Name) : col.Name);
             }
             fields.push_back(field);
         }
@@ -59,13 +59,13 @@ namespace sqlite_manager
 
         for (const Column& col : cols)
         {
-            names.push_back(col.m_name);
-            if (col.m_type == ColumnType::TEXT)
+            names.push_back(col.Name);
+            if (col.Type == ColumnType::TEXT)
             {
-                values.push_back(fmt::format("'{}'", col.m_value));
+                values.push_back(fmt::format("'{}'", col.Value));
             }
             else
-                values.push_back(col.m_value);
+                values.push_back(col.Value);
         }
 
         std::string queryString =
@@ -118,7 +118,7 @@ namespace sqlite_manager
 
             for (auto& col : fields)
             {
-                fieldNames.push_back(col.m_name);
+                fieldNames.push_back(col.Name);
             }
             selectedFields = fmt::format("{}", fmt::join(fieldNames, ", "));
         }
@@ -129,10 +129,10 @@ namespace sqlite_manager
             std::vector<std::string> conditions;
             for (auto& col : selCriteria)
             {
-                if (col.m_type == ColumnType::TEXT)
-                    conditions.push_back(fmt::format("{} = '{}'", col.m_name, col.m_value));
+                if (col.Type == ColumnType::TEXT)
+                    conditions.push_back(fmt::format("{} = '{}'", col.Name, col.Value));
                 else
-                    conditions.push_back(fmt::format("{} = {}", col.m_name, col.m_value));
+                    conditions.push_back(fmt::format("{} = {}", col.Name, col.Value));
             }
             condition = fmt::format("WHERE {}", fmt::join(conditions, fmt::format(" {} ", MAP_LOGOP_STRING.at(logOp))));
         }
@@ -177,13 +177,13 @@ namespace sqlite_manager
             std::vector<std::string> critFields;
             for (auto& col : selCriteria)
             {
-                if (col.m_type == ColumnType::TEXT)
+                if (col.Type == ColumnType::TEXT)
                 {
-                    critFields.push_back(fmt::format("{}='{}'", col.m_name, col.m_value));
+                    critFields.push_back(fmt::format("{}='{}'", col.Name, col.Value));
                 }
                 else
                 {
-                    critFields.push_back(fmt::format("{}={}", col.m_name, col.m_value));
+                    critFields.push_back(fmt::format("{}={}", col.Name, col.Value));
                 }
             }
             whereClause =
@@ -209,13 +209,13 @@ namespace sqlite_manager
         std::vector<std::string> setFields;
         for (auto& col : fields)
         {
-            if (col.m_type == ColumnType::TEXT)
+            if (col.Type == ColumnType::TEXT)
             {
-                setFields.push_back(fmt::format("{}='{}'", col.m_name, col.m_value));
+                setFields.push_back(fmt::format("{}='{}'", col.Name, col.Value));
             }
             else
             {
-                setFields.push_back(fmt::format("{}={}", col.m_name, col.m_value));
+                setFields.push_back(fmt::format("{}={}", col.Name, col.Value));
             }
         }
         std::string updateValues = fmt::format("{}", fmt::join(setFields, ", "));
@@ -226,13 +226,13 @@ namespace sqlite_manager
             std::vector<std::string> conditions;
             for (auto& col : selCriteria)
             {
-                if (col.m_type == ColumnType::TEXT)
+                if (col.Type == ColumnType::TEXT)
                 {
-                    conditions.push_back(fmt::format("{}='{}'", col.m_name, col.m_value));
+                    conditions.push_back(fmt::format("{}='{}'", col.Name, col.Value));
                 }
                 else
                 {
-                    conditions.push_back(fmt::format("{}={}", col.m_name, col.m_value));
+                    conditions.push_back(fmt::format("{}={}", col.Name, col.Value));
                 }
             }
             whereClause =

--- a/src/agent/sqlite_manager/tests/sqlite_manager_test.cpp
+++ b/src/agent/sqlite_manager/tests/sqlite_manager_test.cpp
@@ -124,7 +124,7 @@ static void DumpResults(std::vector<sqlite_manager::Row>& ret)
     {
         for (const auto& field : row)
         {
-            std::cout << "[" << field.m_name << ": " << field.m_value << "]";
+            std::cout << "[" << field.Name << ": " << field.Value << "]";
         }
         std::cout << '\n';
     }

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -1,11 +1,11 @@
 #include <agent.hpp>
 #include <inventory.hpp>
 
-#include <command.hpp>
 #include <command_handler_utils.hpp>
 #include <http_client.hpp>
 #include <message.hpp>
 #include <message_queue_utils.hpp>
+#include <module_command/command_entry.hpp>
 #include <signal_handler.hpp>
 
 #include <memory>
@@ -47,10 +47,10 @@ void Agent::Run()
         [this]([[maybe_unused]] const std::string& response)
         { PopMessagesFromQueue(m_messageQueue, MessageType::STATELESS); }));
 
-    m_taskManager.EnqueueTask(m_commandHandler.CommandsProcessingTask<command_store::CommandEntry>(
+    m_taskManager.EnqueueTask(m_commandHandler.CommandsProcessingTask<module_command::CommandEntry>(
         [this]() { return GetCommandFromQueue(m_messageQueue); },
         [this]() { return PopCommandFromQueue(m_messageQueue); },
-        [this](command_store::CommandEntry& cmd)
+        [this](module_command::CommandEntry& cmd)
         { return DispatchCommand(cmd, m_moduleManager.GetModule(cmd.Module), m_messageQueue); }));
 
     m_moduleManager.AddModule(Inventory::Instance());

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -47,7 +47,7 @@ void Agent::Run()
         [this]([[maybe_unused]] const std::string& response)
         { PopMessagesFromQueue(m_messageQueue, MessageType::STATELESS); }));
 
-    m_taskManager.EnqueueTask(m_commandHandler.ProcessCommandsFromQueue<command_store::CommandEntry>(
+    m_taskManager.EnqueueTask(m_commandHandler.CommandsProcessingTask<command_store::CommandEntry>(
         [this]() { return GetCommandFromQueue(m_messageQueue); },
         [this]() { return PopCommandFromQueue(m_messageQueue); },
         [](command_store::CommandEntry& cmd) { return DispatchCommand(cmd); }));

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -47,10 +47,10 @@ void Agent::Run()
         [this]([[maybe_unused]] const std::string& response)
         { PopMessagesFromQueue(m_messageQueue, MessageType::STATELESS); }));
 
-    m_taskManager.EnqueueTask(m_commandHandler.ProcessCommandsFromQueue<command_store::Command>(
+    m_taskManager.EnqueueTask(m_commandHandler.ProcessCommandsFromQueue<command_store::CommandEntry>(
         [this]() { return GetCommandFromQueue(m_messageQueue); },
         [this]() { return PopCommandFromQueue(m_messageQueue); },
-        [](command_store::Command& cmd) { return DispatchCommand(cmd); }));
+        [](command_store::CommandEntry& cmd) { return DispatchCommand(cmd); }));
 
     m_moduleManager.AddModule(Inventory::Instance());
     m_moduleManager.Setup();

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -50,7 +50,8 @@ void Agent::Run()
     m_taskManager.EnqueueTask(m_commandHandler.CommandsProcessingTask<command_store::CommandEntry>(
         [this]() { return GetCommandFromQueue(m_messageQueue); },
         [this]() { return PopCommandFromQueue(m_messageQueue); },
-        [](command_store::CommandEntry& cmd) { return DispatchCommand(cmd); }));
+        [this](command_store::CommandEntry& cmd)
+        { return DispatchCommand(cmd, m_moduleManager.GetModule(cmd.Module), m_messageQueue); }));
 
     m_moduleManager.AddModule(Inventory::Instance());
     m_moduleManager.Setup();

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -1,9 +1,23 @@
 #include <command_handler_utils.hpp>
+
 #include <logger.hpp>
 
-std::tuple<command_store::Status, std::string> DispatchCommand(const command_store::CommandEntry& cmd)
+std::tuple<command_store::Status, std::string> DispatchCommand(const command_store::CommandEntry& commandEntry,
+                                                               std::shared_ptr<ModuleWrapper> module,
+                                                               std::shared_ptr<IMultiTypeQueue> messageQueue)
 {
-    // TO_DO: Implement real dispatch function.
-    LogInfo("Dispatching command {}({})", cmd.Command, cmd.Module);
-    return {command_store::Status::SUCCESS, "Successfully executed"};
+    if (!module)
+    {
+        LogError("Error dispatching command: module {} not found", commandEntry.Module);
+        return std::make_tuple(command_store::Status::FAILURE, "Module not found");
+    }
+
+    LogInfo("Dispatching command {}({})", commandEntry.Command, commandEntry.Module);
+
+    const auto result = module->Command(commandEntry.Command);
+
+    Message message {MessageType::STATEFUL, {{"data", result}, {"module", module->Name()}}};
+    messageQueue->push(message);
+
+    return std::make_tuple(command_store::Status::SUCCESS, result);
 }

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -2,7 +2,7 @@
 
 #include <logger.hpp>
 
-boost::asio::awaitable<std::tuple<module_command::Status, std::string>>
+boost::asio::awaitable<module_command::CommandExecutionResult>
 DispatchCommand(module_command::CommandEntry commandEntry,
                 std::shared_ptr<ModuleWrapper> module,
                 std::shared_ptr<IMultiTypeQueue> messageQueue)
@@ -10,7 +10,7 @@ DispatchCommand(module_command::CommandEntry commandEntry,
     if (!module)
     {
         LogError("Error dispatching command: module {} not found", commandEntry.Module);
-        co_return std::make_tuple(module_command::Status::FAILURE, "Module not found");
+        co_return module_command::CommandExecutionResult {module_command::Status::FAILURE, "Module not found"};
     }
 
     LogInfo("Dispatching command {}({})", commandEntry.Command, commandEntry.Module);
@@ -25,5 +25,5 @@ DispatchCommand(module_command::CommandEntry commandEntry,
     Message message {MessageType::STATEFUL, {resultJson}, "CommandHandler"};
     messageQueue->push(message);
 
-    co_return std::make_tuple(static_cast<module_command::Status>(result.ErrorCode), result.Message);
+    co_return result;
 }

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -18,11 +18,12 @@ DispatchCommand(command_store::CommandEntry commandEntry,
     const auto result = co_await module->Command(commandEntry.Command);
 
     nlohmann::json resultJson;
-    resultJson["result"] = result;
+    resultJson["error"] = result.ErrorCode;
+    resultJson["message"] = result.Message;
     resultJson["id"] = commandEntry.Id;
 
     Message message {MessageType::STATEFUL, {resultJson}, "CommandHandler"};
     messageQueue->push(message);
 
-    co_return std::make_tuple(command_store::Status::SUCCESS, result);
+    co_return std::make_tuple(static_cast<command_store::Status>(result.ErrorCode), result.Message);
 }

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -4,6 +4,6 @@
 std::tuple<command_store::Status, std::string> DispatchCommand(const command_store::CommandEntry& cmd)
 {
     // TO_DO: Implement real dispatch function.
-    LogInfo("Dispatching command {}({})", cmd.m_command, cmd.m_module);
+    LogInfo("Dispatching command {}({})", cmd.Command, cmd.Module);
     return {command_store::Status::SUCCESS, "Successfully executed"};
 }

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -2,15 +2,15 @@
 
 #include <logger.hpp>
 
-boost::asio::awaitable<std::tuple<command_store::Status, std::string>>
-DispatchCommand(command_store::CommandEntry commandEntry,
+boost::asio::awaitable<std::tuple<module_command::Status, std::string>>
+DispatchCommand(module_command::CommandEntry commandEntry,
                 std::shared_ptr<ModuleWrapper> module,
                 std::shared_ptr<IMultiTypeQueue> messageQueue)
 {
     if (!module)
     {
         LogError("Error dispatching command: module {} not found", commandEntry.Module);
-        co_return std::make_tuple(command_store::Status::FAILURE, "Module not found");
+        co_return std::make_tuple(module_command::Status::FAILURE, "Module not found");
     }
 
     LogInfo("Dispatching command {}({})", commandEntry.Command, commandEntry.Module);
@@ -25,5 +25,5 @@ DispatchCommand(command_store::CommandEntry commandEntry,
     Message message {MessageType::STATEFUL, {resultJson}, "CommandHandler"};
     messageQueue->push(message);
 
-    co_return std::make_tuple(static_cast<command_store::Status>(result.ErrorCode), result.Message);
+    co_return std::make_tuple(static_cast<module_command::Status>(result.ErrorCode), result.Message);
 }

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -2,22 +2,26 @@
 
 #include <logger.hpp>
 
-std::tuple<command_store::Status, std::string> DispatchCommand(const command_store::CommandEntry& commandEntry,
-                                                               std::shared_ptr<ModuleWrapper> module,
-                                                               std::shared_ptr<IMultiTypeQueue> messageQueue)
+boost::asio::awaitable<std::tuple<command_store::Status, std::string>>
+DispatchCommand(command_store::CommandEntry commandEntry,
+                std::shared_ptr<ModuleWrapper> module,
+                std::shared_ptr<IMultiTypeQueue> messageQueue)
 {
     if (!module)
     {
         LogError("Error dispatching command: module {} not found", commandEntry.Module);
-        return std::make_tuple(command_store::Status::FAILURE, "Module not found");
+        co_return std::make_tuple(command_store::Status::FAILURE, "Module not found");
     }
 
     LogInfo("Dispatching command {}({})", commandEntry.Command, commandEntry.Module);
 
-    const auto result = module->Command(commandEntry.Command);
+    const auto result = co_await module->Command(commandEntry.Command);
 
-    Message message {MessageType::STATEFUL, {{"data", result}, {"module", module->Name()}}};
+    nlohmann::json resultJson;
+    resultJson["data"] = result;
+
+    Message message {MessageType::STATEFUL, {{resultJson, {"module", module->Name()}}}};
     messageQueue->push(message);
 
-    return std::make_tuple(command_store::Status::SUCCESS, result);
+    co_return std::make_tuple(command_store::Status::SUCCESS, result);
 }

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -15,7 +15,7 @@ DispatchCommand(module_command::CommandEntry commandEntry,
 
     LogInfo("Dispatching command {}({})", commandEntry.Command, commandEntry.Module);
 
-    const auto result = co_await module->Command(commandEntry.Command);
+    const auto result = co_await module->ExecuteCommand(commandEntry.Command);
 
     nlohmann::json resultJson;
     resultJson["error"] = result.ErrorCode;

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -18,9 +18,10 @@ DispatchCommand(command_store::CommandEntry commandEntry,
     const auto result = co_await module->Command(commandEntry.Command);
 
     nlohmann::json resultJson;
-    resultJson["data"] = result;
+    resultJson["result"] = result;
+    resultJson["id"] = commandEntry.Id;
 
-    Message message {MessageType::STATEFUL, {{resultJson, {"module", module->Name()}}}};
+    Message message {MessageType::STATEFUL, {resultJson}, "CommandHandler"};
     messageQueue->push(message);
 
     co_return std::make_tuple(command_store::Status::SUCCESS, result);

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -1,7 +1,7 @@
 #include <command_handler_utils.hpp>
 #include <logger.hpp>
 
-std::tuple<command_store::Status, std::string> DispatchCommand(const command_store::Command& cmd)
+std::tuple<command_store::Status, std::string> DispatchCommand(const command_store::CommandEntry& cmd)
 {
     // TO_DO: Implement real dispatch function.
     LogInfo("Dispatching command {}({})", cmd.m_command, cmd.m_module);

--- a/src/agent/src/command_handler_utils.hpp
+++ b/src/agent/src/command_handler_utils.hpp
@@ -5,9 +5,12 @@
 #include <moduleWrapper.hpp>
 #include <multitype_queue.hpp>
 
+#include <boost/asio/awaitable.hpp>
+
 #include <memory>
 #include <tuple>
 
-std::tuple<command_store::Status, std::string> DispatchCommand(const command_store::CommandEntry& commandEntry,
-                                                               std::shared_ptr<ModuleWrapper> module,
-                                                               std::shared_ptr<IMultiTypeQueue> messageQueue);
+boost::asio::awaitable<std::tuple<command_store::Status, std::string>>
+DispatchCommand(command_store::CommandEntry commandEntry,
+                std::shared_ptr<ModuleWrapper> module,
+                std::shared_ptr<IMultiTypeQueue> messageQueue);

--- a/src/agent/src/command_handler_utils.hpp
+++ b/src/agent/src/command_handler_utils.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <command.hpp>
+#include <module_command/command_entry.hpp>
 
 #include <moduleWrapper.hpp>
 #include <multitype_queue.hpp>
@@ -10,7 +10,7 @@
 #include <memory>
 #include <tuple>
 
-boost::asio::awaitable<std::tuple<command_store::Status, std::string>>
-DispatchCommand(command_store::CommandEntry commandEntry,
+boost::asio::awaitable<std::tuple<module_command::Status, std::string>>
+DispatchCommand(module_command::CommandEntry commandEntry,
                 std::shared_ptr<ModuleWrapper> module,
                 std::shared_ptr<IMultiTypeQueue> messageQueue);

--- a/src/agent/src/command_handler_utils.hpp
+++ b/src/agent/src/command_handler_utils.hpp
@@ -4,4 +4,4 @@
 
 #include <tuple>
 
-std::tuple<command_store::Status, std::string> DispatchCommand(const command_store::Command&);
+std::tuple<command_store::Status, std::string> DispatchCommand(const command_store::CommandEntry&);

--- a/src/agent/src/command_handler_utils.hpp
+++ b/src/agent/src/command_handler_utils.hpp
@@ -10,7 +10,7 @@
 #include <memory>
 #include <tuple>
 
-boost::asio::awaitable<std::tuple<module_command::Status, std::string>>
+boost::asio::awaitable<module_command::CommandExecutionResult>
 DispatchCommand(module_command::CommandEntry commandEntry,
                 std::shared_ptr<ModuleWrapper> module,
                 std::shared_ptr<IMultiTypeQueue> messageQueue);

--- a/src/agent/src/command_handler_utils.hpp
+++ b/src/agent/src/command_handler_utils.hpp
@@ -2,6 +2,12 @@
 
 #include <command.hpp>
 
+#include <moduleWrapper.hpp>
+#include <multitype_queue.hpp>
+
+#include <memory>
 #include <tuple>
 
-std::tuple<command_store::Status, std::string> DispatchCommand(const command_store::CommandEntry&);
+std::tuple<command_store::Status, std::string> DispatchCommand(const command_store::CommandEntry& commandEntry,
+                                                               std::shared_ptr<ModuleWrapper> module,
+                                                               std::shared_ptr<IMultiTypeQueue> messageQueue);

--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -46,7 +46,7 @@ void PushCommandsToQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, const 
     }
 }
 
-std::optional<command_store::CommandEntry> GetCommandFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue)
+std::optional<module_command::CommandEntry> GetCommandFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue)
 {
     if (multiTypeQueue->isEmpty(MessageType::COMMAND))
     {
@@ -90,7 +90,7 @@ std::optional<command_store::CommandEntry> GetCommandFromQueue(std::shared_ptr<I
         }
     }
 
-    command_store::CommandEntry cmd(id, module, command, parameters, "", command_store::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd(id, module, command, parameters, "", module_command::Status::IN_PROGRESS);
 
     return cmd;
 }

--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -90,9 +90,7 @@ std::optional<command_store::CommandEntry> GetCommandFromQueue(std::shared_ptr<I
         }
     }
 
-    command_store::Status status = command_store::Status::IN_PROGRESS;
-
-    command_store::CommandEntry cmd(id, module, command, parameters, "", status);
+    command_store::CommandEntry cmd(id, module, command, parameters, "", command_store::Status::IN_PROGRESS);
 
     return cmd;
 }

--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -46,7 +46,7 @@ void PushCommandsToQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, const 
     }
 }
 
-std::optional<command_store::Command> GetCommandFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue)
+std::optional<command_store::CommandEntry> GetCommandFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue)
 {
     if (multiTypeQueue->isEmpty(MessageType::COMMAND))
     {
@@ -92,7 +92,7 @@ std::optional<command_store::Command> GetCommandFromQueue(std::shared_ptr<IMulti
 
     command_store::Status status = command_store::Status::IN_PROGRESS;
 
-    command_store::Command cmd(id, module, command, parameters, "", status);
+    command_store::CommandEntry cmd(id, module, command, parameters, "", status);
 
     return cmd;
 }

--- a/src/agent/src/message_queue_utils.hpp
+++ b/src/agent/src/message_queue_utils.hpp
@@ -18,6 +18,6 @@ void PopMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, Messa
 
 void PushCommandsToQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, const std::string& commands);
 
-std::optional<command_store::Command> GetCommandFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue);
+std::optional<command_store::CommandEntry> GetCommandFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue);
 
 void PopCommandFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue);

--- a/src/agent/src/message_queue_utils.hpp
+++ b/src/agent/src/message_queue_utils.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <command.hpp>
 #include <message.hpp>
+#include <module_command/command_entry.hpp>
 
 #include <boost/asio/awaitable.hpp>
 
@@ -18,6 +18,6 @@ void PopMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, Messa
 
 void PushCommandsToQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, const std::string& commands);
 
-std::optional<command_store::CommandEntry> GetCommandFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue);
+std::optional<module_command::CommandEntry> GetCommandFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue);
 
 void PopCommandFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue);

--- a/src/agent/tests/message_queue_utils_test.cpp
+++ b/src/agent/tests/message_queue_utils_test.cpp
@@ -119,8 +119,8 @@ TEST_F(MessageQueueUtilsTest, GetCommandFromQueueTest)
     ASSERT_EQ(cmd.has_value() ? cmd.value().Module : "", "origin_test");
     ASSERT_EQ(cmd.has_value() ? cmd.value().Command : "", "command_test");
     ASSERT_EQ(cmd.has_value() ? cmd.value().Parameters : "", "parameters_test");
-    ASSERT_EQ(cmd.has_value() ? cmd.value().CurrentStatus : command_store::Status::UNKNOWN,
-              command_store::Status::IN_PROGRESS);
+    ASSERT_EQ(cmd.has_value() ? cmd.value().CurrentStatus : module_command::Status::UNKNOWN,
+              module_command::Status::IN_PROGRESS);
 }
 
 int main(int argc, char** argv)

--- a/src/agent/tests/message_queue_utils_test.cpp
+++ b/src/agent/tests/message_queue_utils_test.cpp
@@ -119,7 +119,7 @@ TEST_F(MessageQueueUtilsTest, GetCommandFromQueueTest)
     ASSERT_EQ(cmd.has_value() ? cmd.value().Module : "", "origin_test");
     ASSERT_EQ(cmd.has_value() ? cmd.value().Command : "", "command_test");
     ASSERT_EQ(cmd.has_value() ? cmd.value().Parameters : "", "parameters_test");
-    ASSERT_EQ(cmd.has_value() ? cmd.value().CurrentStatus : module_command::Status::UNKNOWN,
+    ASSERT_EQ(cmd.has_value() ? cmd.value().ExecutionResult.ErrorCode : module_command::Status::UNKNOWN,
               module_command::Status::IN_PROGRESS);
 }
 

--- a/src/agent/tests/message_queue_utils_test.cpp
+++ b/src/agent/tests/message_queue_utils_test.cpp
@@ -115,11 +115,11 @@ TEST_F(MessageQueueUtilsTest, GetCommandFromQueueTest)
 
     auto cmd = GetCommandFromQueue(mockQueue);
 
-    ASSERT_EQ(cmd.has_value() ? cmd.value().m_id : "", "112233");
-    ASSERT_EQ(cmd.has_value() ? cmd.value().m_module : "", "origin_test");
-    ASSERT_EQ(cmd.has_value() ? cmd.value().m_command : "", "command_test");
-    ASSERT_EQ(cmd.has_value() ? cmd.value().m_parameters : "", "parameters_test");
-    ASSERT_EQ(cmd.has_value() ? cmd.value().m_status : command_store::Status::UNKNOWN,
+    ASSERT_EQ(cmd.has_value() ? cmd.value().Id : "", "112233");
+    ASSERT_EQ(cmd.has_value() ? cmd.value().Module : "", "origin_test");
+    ASSERT_EQ(cmd.has_value() ? cmd.value().Command : "", "command_test");
+    ASSERT_EQ(cmd.has_value() ? cmd.value().Parameters : "", "parameters_test");
+    ASSERT_EQ(cmd.has_value() ? cmd.value().CurrentStatus : command_store::Status::UNKNOWN,
               command_store::Status::IN_PROGRESS);
 }
 

--- a/src/modules/include/moduleManager.hpp
+++ b/src/modules/include/moduleManager.hpp
@@ -15,7 +15,7 @@ concept Module = requires(T t, const configuration::ConfigurationParser& configu
     { t.Start() } -> std::same_as<void>;
     { t.Setup(configurationParser) } -> std::same_as<void>;
     { t.Stop() } -> std::same_as<void>;
-    { t.Command(query) } -> std::same_as<std::string>;
+    { t.ExecuteCommand(query) } -> std::same_as<std::string>;
     { t.Name() } -> std::same_as<std::string>;
     { t.SetMessageQueue(queue) } -> std::same_as<void>;
 };
@@ -42,9 +42,9 @@ public:
             .Start = [&module]() { module.Start(); },
             .Setup = [&module](const configuration::ConfigurationParser& configurationParser) { module.Setup(configurationParser); },
             .Stop = [&module]() { module.Stop(); },
-            .Command = [&module](std::string query) -> Co_CommandExecutionResult
+            .ExecuteCommand = [&module](std::string query) -> Co_CommandExecutionResult
             {
-                co_return co_await module.Command(query);
+                co_return co_await module.ExecuteCommand(query);
             },
             .Name = [&module]() { return module.Name(); }
         });

--- a/src/modules/include/moduleManager.hpp
+++ b/src/modules/include/moduleManager.hpp
@@ -42,7 +42,7 @@ public:
             .Start = [&module]() { module.Start(); },
             .Setup = [&module](const configuration::ConfigurationParser& configurationParser) { module.Setup(configurationParser); },
             .Stop = [&module]() { module.Stop(); },
-            .Command = [&module](std::string query) -> boost::asio::awaitable<std::string>
+            .Command = [&module](std::string query) -> boost::asio::awaitable<CommandExecutionResult>
             {
                 co_return co_await module.Command(query);
             },

--- a/src/modules/include/moduleManager.hpp
+++ b/src/modules/include/moduleManager.hpp
@@ -7,6 +7,7 @@
 #include <multitype_queue.hpp>
 #include <moduleWrapper.hpp>
 
+#include <boost/asio/awaitable.hpp>
 
 template<typename T>
 concept Module = requires(T t, const configuration::ConfigurationParser& configurationParser, const std::string & query,
@@ -41,7 +42,10 @@ public:
             .Start = [&module]() { module.Start(); },
             .Setup = [&module](const configuration::ConfigurationParser& configurationParser) { module.Setup(configurationParser); },
             .Stop = [&module]() { module.Stop(); },
-            .Command = [&module](const std::string & query) { return module.Command(query); },
+            .Command = [&module](std::string query) -> boost::asio::awaitable<std::string>
+            {
+                co_return co_await module.Command(query);
+            },
             .Name = [&module]() { return module.Name(); }
         });
 

--- a/src/modules/include/moduleManager.hpp
+++ b/src/modules/include/moduleManager.hpp
@@ -42,7 +42,7 @@ public:
             .Start = [&module]() { module.Start(); },
             .Setup = [&module](const configuration::ConfigurationParser& configurationParser) { module.Setup(configurationParser); },
             .Stop = [&module]() { module.Stop(); },
-            .Command = [&module](std::string query) -> boost::asio::awaitable<CommandExecutionResult>
+            .Command = [&module](std::string query) -> Co_CommandExecutionResult
             {
                 co_return co_await module.Command(query);
             },

--- a/src/modules/include/moduleWrapper.hpp
+++ b/src/modules/include/moduleWrapper.hpp
@@ -1,14 +1,17 @@
 #pragma once
 
+#include <configuration_parser.hpp>
+
+#include <boost/asio/awaitable.hpp>
+
 #include <functional>
 #include <string>
-#include <configuration_parser.hpp>
 
 
 struct ModuleWrapper {
     std::function<void()> Start;
     std::function<void(const configuration::ConfigurationParser&)> Setup;
     std::function<void()> Stop;
-    std::function<std::string(const std::string&)> Command;
+    std::function<boost::asio::awaitable<std::string>(std::string)> Command;
     std::function<std::string()> Name;
 };

--- a/src/modules/include/moduleWrapper.hpp
+++ b/src/modules/include/moduleWrapper.hpp
@@ -14,6 +14,6 @@ struct ModuleWrapper {
     std::function<void()> Start;
     std::function<void(const configuration::ConfigurationParser&)> Setup;
     std::function<void()> Stop;
-    std::function<Co_CommandExecutionResult(std::string)> Command;
+    std::function<Co_CommandExecutionResult(std::string)> ExecuteCommand;
     std::function<std::string()> Name;
 };

--- a/src/modules/include/moduleWrapper.hpp
+++ b/src/modules/include/moduleWrapper.hpp
@@ -7,11 +7,15 @@
 #include <functional>
 #include <string>
 
+struct CommandExecutionResult {
+    int ErrorCode = 0;
+    std::string Message = "";
+};
 
 struct ModuleWrapper {
     std::function<void()> Start;
     std::function<void(const configuration::ConfigurationParser&)> Setup;
     std::function<void()> Stop;
-    std::function<boost::asio::awaitable<std::string>(std::string)> Command;
+    std::function<boost::asio::awaitable<CommandExecutionResult>(std::string)> Command;
     std::function<std::string()> Name;
 };

--- a/src/modules/include/moduleWrapper.hpp
+++ b/src/modules/include/moduleWrapper.hpp
@@ -1,18 +1,14 @@
 #pragma once
 
 #include <configuration_parser.hpp>
+#include <module_command/command_entry.hpp>
 
 #include <boost/asio/awaitable.hpp>
 
 #include <functional>
 #include <string>
 
-struct CommandExecutionResult {
-    int ErrorCode = 0;
-    std::string Message = "";
-};
-
-using Co_CommandExecutionResult = boost::asio::awaitable<CommandExecutionResult>;
+using Co_CommandExecutionResult = boost::asio::awaitable<module_command::CommandExecutionResult>;
 
 struct ModuleWrapper {
     std::function<void()> Start;

--- a/src/modules/include/moduleWrapper.hpp
+++ b/src/modules/include/moduleWrapper.hpp
@@ -12,10 +12,12 @@ struct CommandExecutionResult {
     std::string Message = "";
 };
 
+using Co_CommandExecutionResult = boost::asio::awaitable<CommandExecutionResult>;
+
 struct ModuleWrapper {
     std::function<void()> Start;
     std::function<void(const configuration::ConfigurationParser&)> Setup;
     std::function<void()> Stop;
-    std::function<boost::asio::awaitable<CommandExecutionResult>(std::string)> Command;
+    std::function<Co_CommandExecutionResult(std::string)> Command;
     std::function<std::string()> Name;
 };

--- a/src/modules/inventory/CMakeLists.txt
+++ b/src/modules/inventory/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(Inventory PUBLIC
     pthreads_op
     ConfigurationParser
     MultiTypeQueue
+    ModuleCommand
     Logger)
 
 include(../../cmake/ConfigureTarget.cmake)

--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -29,7 +29,7 @@ class Inventory {
         void Start();
         void Setup(const configuration::ConfigurationParser& configurationParser);
         void Stop();
-        boost::asio::awaitable<CommandExecutionResult> Command(const std::string query);
+        Co_CommandExecutionResult Command(const std::string query);
         const std::string& Name() const { return m_moduleName; };
         void SetMessageQueue(const std::shared_ptr<IMultiTypeQueue> queue);
 

--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -14,6 +14,8 @@
 #include <inventoryNormalizer.hpp>
 #include <multitype_queue.hpp>
 
+#include <boost/asio/awaitable.hpp>
+
 class Inventory {
     public:
         static Inventory& Instance()
@@ -25,7 +27,7 @@ class Inventory {
         void Start();
         void Setup(const configuration::ConfigurationParser& configurationParser);
         void Stop();
-        std::string Command(const std::string & query);
+        boost::asio::awaitable<std::string> Command(const std::string query);
         const std::string& Name() const { return m_moduleName; };
         void SetMessageQueue(const std::shared_ptr<IMultiTypeQueue> queue);
 

--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -14,6 +14,8 @@
 #include <inventoryNormalizer.hpp>
 #include <multitype_queue.hpp>
 
+#include <moduleWrapper.hpp>
+
 #include <boost/asio/awaitable.hpp>
 
 class Inventory {
@@ -27,7 +29,7 @@ class Inventory {
         void Start();
         void Setup(const configuration::ConfigurationParser& configurationParser);
         void Stop();
-        boost::asio::awaitable<std::string> Command(const std::string query);
+        boost::asio::awaitable<CommandExecutionResult> Command(const std::string query);
         const std::string& Name() const { return m_moduleName; };
         void SetMessageQueue(const std::shared_ptr<IMultiTypeQueue> queue);
 

--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -29,7 +29,7 @@ class Inventory {
         void Start();
         void Setup(const configuration::ConfigurationParser& configurationParser);
         void Stop();
-        Co_CommandExecutionResult Command(const std::string query);
+        Co_CommandExecutionResult ExecuteCommand(const std::string query);
         const std::string& Name() const { return m_moduleName; };
         void SetMessageQueue(const std::shared_ptr<IMultiTypeQueue> queue);
 

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -59,7 +59,7 @@ void Inventory::Stop() {
     Inventory::Instance().Destroy();
 }
 
-Co_CommandExecutionResult Inventory::Command(const std::string query) {
+Co_CommandExecutionResult Inventory::ExecuteCommand(const std::string query) {
     LogInfo("Query: ",query);
     co_return module_command::CommandExecutionResult{module_command::Status::SUCCESS, "OK"};
 }

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -59,9 +59,9 @@ void Inventory::Stop() {
     Inventory::Instance().Destroy();
 }
 
-std::string Inventory::Command(const std::string & query) {
+boost::asio::awaitable<std::string> Inventory::Command(const std::string query) {
     LogInfo("Query: ",query);
-    return "OK";
+    co_return "OK";
 }
 
 void Inventory::SetMessageQueue(const std::shared_ptr<IMultiTypeQueue> queue) {

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -59,6 +59,7 @@ void Inventory::Stop() {
     Inventory::Instance().Destroy();
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 Co_CommandExecutionResult Inventory::ExecuteCommand(const std::string query) {
     LogInfo("Query: ",query);
     co_return module_command::CommandExecutionResult{module_command::Status::SUCCESS, "OK"};

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -61,7 +61,7 @@ void Inventory::Stop() {
 
 Co_CommandExecutionResult Inventory::Command(const std::string query) {
     LogInfo("Query: ",query);
-    co_return CommandExecutionResult{0,"OK"};
+    co_return module_command::CommandExecutionResult{module_command::Status::SUCCESS, "OK"};
 }
 
 void Inventory::SetMessageQueue(const std::shared_ptr<IMultiTypeQueue> queue) {

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -59,9 +59,9 @@ void Inventory::Stop() {
     Inventory::Instance().Destroy();
 }
 
-boost::asio::awaitable<std::string> Inventory::Command(const std::string query) {
+boost::asio::awaitable<CommandExecutionResult> Inventory::Command(const std::string query) {
     LogInfo("Query: ",query);
-    co_return "OK";
+    co_return CommandExecutionResult{0,"OK"};
 }
 
 void Inventory::SetMessageQueue(const std::shared_ptr<IMultiTypeQueue> queue) {

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -59,7 +59,7 @@ void Inventory::Stop() {
     Inventory::Instance().Destroy();
 }
 
-boost::asio::awaitable<CommandExecutionResult> Inventory::Command(const std::string query) {
+Co_CommandExecutionResult Inventory::Command(const std::string query) {
     LogInfo("Query: ",query);
     co_return CommandExecutionResult{0,"OK"};
 }

--- a/src/modules/tests/moduleManager_test.cpp
+++ b/src/modules/tests/moduleManager_test.cpp
@@ -10,7 +10,7 @@ public:
     MOCK_METHOD(void, Start, (), ());
     MOCK_METHOD(int, Setup, (const configuration::ConfigurationParser&), ());
     MOCK_METHOD(void, Stop, (), ());
-    MOCK_METHOD(std::string, Command, (const std::string&), ());
+    MOCK_METHOD(boost::asio::awaitable<std::string>, Command, (const std::string&), ());
     MOCK_METHOD(std::string, Name, (), (const));
     MOCK_METHOD(void, SetMessageQueue, (const std::shared_ptr<IMultiTypeQueue>));
 };

--- a/src/modules/tests/moduleManager_test.cpp
+++ b/src/modules/tests/moduleManager_test.cpp
@@ -10,7 +10,7 @@ public:
     MOCK_METHOD(void, Start, (), ());
     MOCK_METHOD(int, Setup, (const configuration::ConfigurationParser&), ());
     MOCK_METHOD(void, Stop, (), ());
-    MOCK_METHOD(boost::asio::awaitable<std::string>, Command, (const std::string&), ());
+    MOCK_METHOD(boost::asio::awaitable<CommandExecutionResult>, Command, (const std::string&), ());
     MOCK_METHOD(std::string, Name, (), (const));
     MOCK_METHOD(void, SetMessageQueue, (const std::shared_ptr<IMultiTypeQueue>));
 };

--- a/src/modules/tests/moduleManager_test.cpp
+++ b/src/modules/tests/moduleManager_test.cpp
@@ -10,7 +10,7 @@ public:
     MOCK_METHOD(void, Start, (), ());
     MOCK_METHOD(int, Setup, (const configuration::ConfigurationParser&), ());
     MOCK_METHOD(void, Stop, (), ());
-    MOCK_METHOD(boost::asio::awaitable<CommandExecutionResult>, Command, (const std::string&), ());
+    MOCK_METHOD(boost::asio::awaitable<module_command::CommandExecutionResult>, Command, (const std::string&), ());
     MOCK_METHOD(std::string, Name, (), (const));
     MOCK_METHOD(void, SetMessageQueue, (const std::shared_ptr<IMultiTypeQueue>));
 };

--- a/src/modules/tests/moduleManager_test.cpp
+++ b/src/modules/tests/moduleManager_test.cpp
@@ -10,7 +10,7 @@ public:
     MOCK_METHOD(void, Start, (), ());
     MOCK_METHOD(int, Setup, (const configuration::ConfigurationParser&), ());
     MOCK_METHOD(void, Stop, (), ());
-    MOCK_METHOD(boost::asio::awaitable<module_command::CommandExecutionResult>, Command, (const std::string&), ());
+    MOCK_METHOD(boost::asio::awaitable<module_command::CommandExecutionResult>, ExecuteCommand, (const std::string&), ());
     MOCK_METHOD(std::string, Name, (), (const));
     MOCK_METHOD(void, SetMessageQueue, (const std::shared_ptr<IMultiTypeQueue>));
 };


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/146|

## Description

This pull request integrates the command handler with the module manager, allowing to send commands to the corresponding modules, and introduces updates and refactoring to the command handling and storage mechanisms within the Wazuh agent. The functions executing commands have been modified to use awaitables (so they are effectively coroutines). Some other small refactorings are made.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X