### PR TITLE
Support simultaneous command dispatch with timeout

### DIFF
--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -29,9 +29,17 @@ DispatchCommand(module_command::CommandEntry commandEntry,
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
     auto executeCommandTask = [module, commandEntry, result, commandCompleted, timer]() -> boost::asio::awaitable<void>
     {
-        *result = co_await module->ExecuteCommand(commandEntry.Command);
-        *commandCompleted = true;
-        timer->cancel();
+        try
+        {
+            *result = co_await module->ExecuteCommand(commandEntry.Command);
+            *commandCompleted = true;
+            timer->cancel();
+        }
+        catch (const std::exception& e)
+        {
+            result->ErrorCode = module_command::Status::FAILURE;
+            result->Message = "Error during command execution: " + std::string(e.what());
+        }
     };
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/146|

## Description

In this PR we add support for simultaneous command dispatch and timeouts.

The timeout on each command dispatch is accomplish by launching a timer coroutine alongside the command coroutine. Multiple simultaneous command dispatch is done by spawning coroutines with `co_spawn`.

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
