### PR TITLE
Optional module compilation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -112,7 +112,7 @@ The following dependencies are required for this project:
 |`BUILD_TESTS`|Enable tests compilation|`OFF`|
 |`COVERAGE`|Enable coverage report|`OFF`|
 |`ENABLE_CLANG_TIDY`|Check code with _clang-tidy_|`ON`|
-|`ENABLE_MODULE_INVENTORY`|Enable _'Inventory'_ module compilation|`ON`|
+|`ENABLE_INVENTORY`|Enable Inventory module |`ON`|
 |`ENABLE_LOGCOLLECTOR`|Enable Logcollector module|`ON`|
 
 ## Notes

--- a/BUILD.md
+++ b/BUILD.md
@@ -112,6 +112,7 @@ The following dependencies are required for this project:
 |`BUILD_TESTS`|Enable tests compilation|`OFF`|
 |`COVERAGE`|Enable coverage report|`OFF`|
 |`ENABLE_CLANG_TIDY`|Check code with _clang-tidy_|`ON`|
+|`ENABLE_MODULE_INVENTORY`|Enable _'Inventory'_ module compilation|`ON`|
 |`ENABLE_LOGCOLLECTOR`|Enable Logcollector module|`ON`|
 
 ## Notes

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,9 +13,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     add_compile_options(/w)
 endif()
 
-# Enable/disable optional modules compilation
-option(ENABLE_MODULE_INVENTORY "Enable module Inventory" ON)
-
 add_subdirectory(common)
 add_subdirectory(modules)
 add_subdirectory(agent)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,9 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     add_compile_options(/w)
 endif()
 
+# Enable/disable optional modules compilation
+option(ENABLE_MODULE_INVENTORY "Enable module Inventory" ON)
+
 add_subdirectory(common)
 add_subdirectory(modules)
 add_subdirectory(agent)

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -1,5 +1,4 @@
 #include <agent.hpp>
-#include <inventory.hpp>
 
 #ifdef ENABLE_LOGCOLLECTOR
 #include <logcollector.hpp>
@@ -70,8 +69,6 @@ void Agent::Run()
         [this]() { return PopCommandFromQueue(m_messageQueue); },
         [this](module_command::CommandEntry& cmd)
         { return DispatchCommand(cmd, m_moduleManager.GetModule(cmd.Module), m_messageQueue); }));
-
-    m_moduleManager.AddModule(Inventory::Instance());
 
 #ifdef ENABLE_LOGCOLLECTOR
     m_moduleManager.AddModule(Logcollector::Instance());

--- a/src/cmake/CommonSettings.cmake
+++ b/src/cmake/CommonSettings.cmake
@@ -5,6 +5,7 @@ function(set_common_settings)
 
     option(BUILD_TESTS "Enable tests building" OFF)
     option(COVERAGE "Enable coverage report" OFF)
+    option(ENABLE_INVENTORY "Enable Inventory module" ON)
     option(ENABLE_LOGCOLLECTOR "Enable Logcollector module" ON)
 
     if(COVERAGE)
@@ -47,6 +48,10 @@ function(set_common_settings)
         add_compile_options(/Zc:preprocessor)
     else()
         set(CMAKE_CXX_FLAGS "-g3" PARENT_SCOPE)
+    endif()
+
+    if(ENABLE_INVENTORY)
+        add_definitions(-DENABLE_INVENTORY)
     endif()
 
     if(ENABLE_LOGCOLLECTOR)

--- a/src/cmake/config.cmake
+++ b/src/cmake/config.cmake
@@ -12,5 +12,3 @@ set(DEFAULT_FILE_WAIT 500)
 
 # Default Logcollector reload interval (sec)
 set(DEFAULT_RELOAD_INTERVAL 60)
-
-option(ENABLE_LOGCOLLECTOR "Enable Logcollector module" ON)

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -7,39 +7,35 @@ set_common_settings()
 
 add_subdirectory(centralized_configuration)
 
-if (ENABLE_LOGCOLLECTOR)
-    add_subdirectory(logcollector)
-endif()
-
 add_library(ModuleManager src/moduleManager.cpp)
 target_include_directories(ModuleManager PUBLIC include)
-
-# Enable/disable optional modules compilation
-option(ENABLE_MODULE_INVENTORY "Enable module Inventory" ON)
 
 message(STATUS "-------------------")
 message(STATUS "Wazuh agent modules")
 message(STATUS "-------------------")
-if(ENABLE_MODULE_INVENTORY)
-    message(STATUS "Inventory: enabled")
-    target_compile_definitions(ModuleManager PRIVATE ENABLE_MODULE_INVENTORY)
-    target_link_libraries(ModuleManager PRIVATE Inventory)
-    add_subdirectory(inventory)
-else()
-    message(STATUS "Inventory: disabled")
-endif()
+message(STATUS "Inventory:      ${ENABLE_INVENTORY}")
+message(STATUS "Logcollector:   ${ENABLE_LOGCOLLECTOR}")
 message(STATUS "-------------------")
 
-target_link_libraries(ModuleManager PUBLIC ConfigurationParser MultiTypeQueue Logger ModuleCommand)
+if(ENABLE_INVENTORY)
+    target_link_libraries(ModuleManager PRIVATE Inventory)
+    add_subdirectory(inventory)
+endif()
 
 if (ENABLE_LOGCOLLECTOR)
+    add_subdirectory(logcollector)
     target_link_libraries(ModuleManager PUBLIC Logcollector)
 endif()
+
+target_link_libraries(ModuleManager PUBLIC ConfigurationParser MultiTypeQueue PRIVATE Logger ModuleCommand)
 
 include(../cmake/ConfigureTarget.cmake)
 configure_target(ModuleManager)
 
 if(BUILD_TESTS)
     enable_testing()
-    add_subdirectory(tests)
+    # TO DO: Fix unit tests for Windows
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        add_subdirectory(tests)
+    endif()
 endif()

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -14,6 +14,9 @@ endif()
 add_library(ModuleManager src/moduleManager.cpp)
 target_include_directories(ModuleManager PUBLIC include)
 
+# Enable/disable optional modules compilation
+option(ENABLE_MODULE_INVENTORY "Enable module Inventory" ON)
+
 message(STATUS "-------------------")
 message(STATUS "Wazuh agent modules")
 message(STATUS "-------------------")

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -6,7 +6,6 @@ include(../cmake/CommonSettings.cmake)
 set_common_settings()
 
 add_subdirectory(centralized_configuration)
-add_subdirectory(inventory)
 
 if (ENABLE_LOGCOLLECTOR)
     add_subdirectory(logcollector)
@@ -14,7 +13,21 @@ endif()
 
 add_library(ModuleManager src/moduleManager.cpp)
 target_include_directories(ModuleManager PUBLIC include)
-target_link_libraries(ModuleManager PUBLIC Inventory)
+
+message(STATUS "-------------------")
+message(STATUS "Wazuh agent modules")
+message(STATUS "-------------------")
+if(ENABLE_MODULE_INVENTORY)
+    message(STATUS "Inventory: enabled")
+    target_compile_definitions(ModuleManager PRIVATE ENABLE_MODULE_INVENTORY)
+    target_link_libraries(ModuleManager PRIVATE Inventory)
+    add_subdirectory(inventory)
+else()
+    message(STATUS "Inventory: disabled")
+endif()
+message(STATUS "-------------------")
+
+target_link_libraries(ModuleManager PUBLIC ConfigurationParser MultiTypeQueue Logger ModuleCommand)
 
 if (ENABLE_LOGCOLLECTOR)
     target_link_libraries(ModuleManager PUBLIC Logcollector)

--- a/src/modules/include/moduleManager.hpp
+++ b/src/modules/include/moduleManager.hpp
@@ -9,17 +9,6 @@
 
 #include <boost/asio/awaitable.hpp>
 
-template<typename T>
-concept Module = requires(T t, const configuration::ConfigurationParser& configurationParser, const std::string & query,
-                             const std::function<int(Message)>& pushMessage) {
-    { t.Start() } -> std::same_as<void>;
-    { t.Setup(configurationParser) } -> std::same_as<void>;
-    { t.Stop() } -> std::same_as<void>;
-    { t.ExecuteCommand(query) } -> std::same_as<std::string>;
-    { t.Name() } -> std::same_as<std::string>;
-    { t.SetPushMessageFunction(pushMessage) } -> std::same_as<void>;
-};
-
 class ModuleManager {
 public:
     ModuleManager(const std::function<int(Message)>& pushMessage,

--- a/src/modules/include/moduleManager.hpp
+++ b/src/modules/include/moduleManager.hpp
@@ -53,6 +53,7 @@ public:
     }
 
     std::shared_ptr<ModuleWrapper> GetModule(const std::string & name);
+    void Init();
     void Start();
     void Setup();
     void Stop();

--- a/src/modules/include/moduleManager.hpp
+++ b/src/modules/include/moduleManager.hpp
@@ -11,21 +11,23 @@
 
 template<typename T>
 concept Module = requires(T t, const configuration::ConfigurationParser& configurationParser, const std::string & query,
-                             const std::shared_ptr<IMultiTypeQueue> queue) {
+                             const std::function<int(Message)>& pushMessage) {
     { t.Start() } -> std::same_as<void>;
     { t.Setup(configurationParser) } -> std::same_as<void>;
     { t.Stop() } -> std::same_as<void>;
     { t.ExecuteCommand(query) } -> std::same_as<std::string>;
     { t.Name() } -> std::same_as<std::string>;
-    { t.SetMessageQueue(queue) } -> std::same_as<void>;
+    { t.SetPushMessageFunction(pushMessage) } -> std::same_as<void>;
 };
 
 class ModuleManager {
 public:
-    ModuleManager(const std::shared_ptr<MultiTypeQueue>& messageQueue,
-                const configuration::ConfigurationParser& configurationParser)
-        : m_multiTypeQueue(messageQueue)
-        , m_configurationParser(configurationParser)
+    ModuleManager(const std::function<int(Message)>& pushMessage,
+                configuration::ConfigurationParser configurationParser,
+                const std::function<void(std::function<void()>)>& createTask)
+        : m_pushMessage(pushMessage)
+        , m_configurationParser(std::move(configurationParser))
+        , m_createTask(createTask)
     {}
     ~ModuleManager() = default;
 
@@ -36,7 +38,7 @@ public:
             throw std::runtime_error("Module '" + moduleName + "' already exists.");
         }
 
-        module.SetMessageQueue(m_multiTypeQueue);
+        module.SetPushMessageFunction(m_pushMessage);
 
         auto wrapper = std::make_shared<ModuleWrapper>(ModuleWrapper{
             .Start = [&module]() { module.Start(); },
@@ -52,15 +54,15 @@ public:
         m_modules[moduleName] = wrapper;
     }
 
+    void AddModules();
     std::shared_ptr<ModuleWrapper> GetModule(const std::string & name);
-    void Init();
     void Start();
     void Setup();
     void Stop();
 
 private:
     std::map<std::string, std::shared_ptr<ModuleWrapper>> m_modules;
-    std::vector<std::thread> m_threads;
-    std::shared_ptr<IMultiTypeQueue> m_multiTypeQueue;
+    std::function<int(Message)> m_pushMessage;
     configuration::ConfigurationParser m_configurationParser;
+    std::function<void(std::function<void()>)> m_createTask;
 };

--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -31,7 +31,7 @@ class Inventory {
         void Stop();
         Co_CommandExecutionResult ExecuteCommand(const std::string query);
         const std::string& Name() const { return m_moduleName; };
-        void SetMessageQueue(const std::shared_ptr<IMultiTypeQueue> queue);
+        void SetPushMessageFunction(const std::function<int(Message)>& pushMessage);
 
         void Init(const std::shared_ptr<ISysInfo>& spInfo,
                     const std::function<void(const std::string&)>& reportDiffFunction,
@@ -91,6 +91,5 @@ class Inventory {
         std::mutex                                  m_mutex;
         std::unique_ptr<InvNormalizer>              m_spNormalizer;
         std::string                                 m_scanTime;
-        std::shared_ptr<IMultiTypeQueue>            m_messageQueue;
-
+        std::function<int(Message)>                 m_pushMessage;
 };

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -62,8 +62,8 @@ Co_CommandExecutionResult Inventory::ExecuteCommand(const std::string query) {
     co_return module_command::CommandExecutionResult{module_command::Status::SUCCESS, "OK"};
 }
 
-void Inventory::SetMessageQueue(const std::shared_ptr<IMultiTypeQueue> queue) {
-    m_messageQueue = queue;
+void Inventory::SetPushMessageFunction(const std::function<int(Message)>& pushMessage) {
+    m_pushMessage = pushMessage;
 }
 
 void Inventory::SendDeltaEvent(const std::string& data) {
@@ -72,7 +72,7 @@ void Inventory::SendDeltaEvent(const std::string& data) {
     const Message statelessMessage{ MessageType::STATELESS, jsonData, Name() };
     const Message statefulMessage{ MessageType::STATEFUL, jsonData, Name() };
 
-    if(!m_messageQueue->push(statelessMessage)) {
+    if(!m_pushMessage(statelessMessage)) {
         LogWarn("Stateless event can't be pushed into the message queue: {}", data);
     }
     else {
@@ -80,7 +80,7 @@ void Inventory::SendDeltaEvent(const std::string& data) {
 
     }
 
-    if(!m_messageQueue->push(statefulMessage)) {
+    if(!m_pushMessage(statefulMessage)) {
         LogWarn("Stateful event can't be pushed into the message queue: {}", data);
     }
     else {

--- a/src/modules/logcollector/include/logcollector.hpp
+++ b/src/modules/logcollector/include/logcollector.hpp
@@ -37,9 +37,9 @@ public:
     /// @return Name of the module
     const std::string& Name() const { return m_moduleName; };
 
-    /// @brief Sets the message queue
-    /// @param queue Message queue
-    void SetMessageQueue(const std::shared_ptr<IMultiTypeQueue> queue);
+    /// @brief Sets the push message function
+    /// @param pushMessage Push message function
+    void SetPushMessageFunction(const std::function<int(Message)>& pushMessage);
 
     /// @brief Sends a message to que queue
     /// @param location Location of the message
@@ -90,8 +90,8 @@ private:
     /// @brief Is the module enabled
     bool m_enabled = true;
 
-    /// @brief Output message queue
-    std::shared_ptr<IMultiTypeQueue> m_messageQueue;
+    /// @brief Push message function
+    std::function<int(Message)> m_pushMessage;
 
     /// @brief Boost ASIO context
     boost::asio::io_context m_ioContext;

--- a/src/modules/logcollector/src/logcollector.cpp
+++ b/src/modules/logcollector/src/logcollector.cpp
@@ -70,8 +70,8 @@ Co_CommandExecutionResult Logcollector::ExecuteCommand(const std::string query) 
     co_return module_command::CommandExecutionResult{module_command::Status::SUCCESS, "OK"};
 }
 
-void Logcollector::SetMessageQueue(const std::shared_ptr<IMultiTypeQueue> queue) {
-    m_messageQueue = queue;
+void Logcollector::SetPushMessageFunction(const std::function<int(Message)>& pushMessage) {
+    m_pushMessage = pushMessage;
 }
 
 void Logcollector::SendMessage(const std::string& location, const std::string& log) {
@@ -83,7 +83,7 @@ void Logcollector::SendMessage(const std::string& location, const std::string& l
     event["original"] = log;
 
     auto message = Message(MessageType::STATELESS, data, m_moduleName);
-    m_messageQueue->push(message);
+    m_pushMessage(message);
 
     LogTrace("Message pushed: '{}':'{}'", location, log);
 }

--- a/src/modules/src/moduleManager.cpp
+++ b/src/modules/src/moduleManager.cpp
@@ -1,5 +1,9 @@
 #include <iostream>
+
+#ifdef ENABLE_MODULE_INVENTORY
 #include <inventory.hpp>
+#endif
+
 #include <moduleManager.hpp>
 
 std::shared_ptr<ModuleWrapper> ModuleManager::GetModule(const std::string & name) {
@@ -32,4 +36,16 @@ void ModuleManager::Stop() {
             thread.join();
         }
     }
+}
+
+void ModuleManager::Init() {
+
+#ifdef ENABLE_MODULE_INVENTORY
+    AddModule(Inventory::Instance());
+#endif
+
+    Setup();
+
+    Start();
+
 }

--- a/src/modules/src/moduleManager.cpp
+++ b/src/modules/src/moduleManager.cpp
@@ -1,15 +1,24 @@
 #include <iostream>
 
-#ifdef ENABLE_MODULE_INVENTORY
+#ifdef ENABLE_INVENTORY
 #include <inventory.hpp>
+#endif
+
+#ifdef ENABLE_LOGCOLLECTOR
+#include <logcollector.hpp>
+using logcollector::Logcollector;
 #endif
 
 #include <moduleManager.hpp>
 
 void ModuleManager::AddModules() {
 
-#ifdef ENABLE_MODULE_INVENTORY
+#ifdef ENABLE_INVENTORY
     AddModule(Inventory::Instance());
+#endif
+
+#ifdef ENABLE_LOGCOLLECTOR
+    AddModule(Logcollector::Instance());
 #endif
 
     Setup();

--- a/src/modules/src/moduleManager.cpp
+++ b/src/modules/src/moduleManager.cpp
@@ -6,6 +6,15 @@
 
 #include <moduleManager.hpp>
 
+void ModuleManager::AddModules() {
+
+#ifdef ENABLE_MODULE_INVENTORY
+    AddModule(Inventory::Instance());
+#endif
+
+    Setup();
+}
+
 std::shared_ptr<ModuleWrapper> ModuleManager::GetModule(const std::string & name) {
     auto it = m_modules.find(name);
     if (it != m_modules.end()) {
@@ -16,7 +25,7 @@ std::shared_ptr<ModuleWrapper> ModuleManager::GetModule(const std::string & name
 
 void ModuleManager::Start() {
     for (const auto &[_, module] : m_modules) {
-        m_threads.emplace_back([module]() { module->Start(); });
+        m_createTask([module]() { module->Start(); });
     }
 }
 
@@ -30,22 +39,4 @@ void ModuleManager::Stop() {
     for (const auto &[_, module] : m_modules) {
         module->Stop();
     }
-
-    for (auto &thread : m_threads) {
-        if (thread.joinable()) {
-            thread.join();
-        }
-    }
-}
-
-void ModuleManager::Init() {
-
-#ifdef ENABLE_MODULE_INVENTORY
-    AddModule(Inventory::Instance());
-#endif
-
-    Setup();
-
-    Start();
-
 }


### PR DESCRIPTION
|Related issue|
|---|
| #207 |

## Description

This PR implements selective compilation that allows including or excluding optional modules during the build process, using CMake to manage this configuration efficiently.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X