### PR TITLE
Add libbz2-dev as a dependency in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -21,7 +21,7 @@ The following dependencies are required for this project:
 
     ```bash
     sudo apt-get update
-    sudo apt-get install cmake make gcc git zip curl tar ninja-build pkg-config libsystemd-dev wget gnupg lsb-release software-properties-common
+    sudo apt-get install cmake make gcc git zip curl tar ninja-build pkg-config libsystemd-dev wget gnupg lsb-release software-properties-common libbz2-dev
     wget https://apt.llvm.org/llvm.sh
     chmod +x llvm.sh
     sudo ./llvm.sh 18


### PR DESCRIPTION
## Description

A library is missing as a dependency in `BUILD.md`. Since it's not included in every distribution, we need to add it.
