### PR TITLE
Handle agent centralized configuration commands

### DIFF
--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -49,7 +49,22 @@ list(APPEND SOURCES
 
 add_library(Agent ${SOURCES})
 target_include_directories(Agent PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(Agent PUBLIC ConfigurationParser Communicator AgentInfo CommandHandler MultiTypeQueue ModuleManager ModuleCommand PRIVATE OpenSSL::SSL OpenSSL::Crypto Boost::asio Boost::beast)
+target_link_libraries(Agent
+    PUBLIC
+    ConfigurationParser
+    Communicator
+    AgentInfo
+    CommandHandler
+    MultiTypeQueue
+    ModuleManager
+    ModuleCommand
+    CentralizedConfiguration
+    PRIVATE
+    OpenSSL::SSL
+    OpenSSL::Crypto
+    Boost::asio
+    Boost::beast
+)
 
 include(../cmake/ConfigureTarget.cmake)
 configure_target(Agent)

--- a/src/agent/configuration_parser/CMakeLists.txt
+++ b/src/agent/configuration_parser/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(toml11 CONFIG REQUIRED)
 
 add_library(ConfigurationParser src/configuration_parser.cpp)
 target_include_directories(ConfigurationParser PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(ConfigurationParser PRIVATE toml11::toml11 Logger)
+target_link_libraries(ConfigurationParser PUBLIC toml11::toml11 Logger)
 
 include(../../cmake/ConfigureTarget.cmake)
 configure_target(ConfigurationParser)

--- a/src/agent/include/agent.hpp
+++ b/src/agent/include/agent.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <agent_info.hpp>
+#include <centralized_configuration.hpp>
 #include <command_handler.hpp>
 #include <communicator.hpp>
 #include <configuration_parser.hpp>
@@ -32,4 +33,5 @@ private:
     communicator::Communicator m_communicator;
     command_handler::CommandHandler m_commandHandler;
     ModuleManager m_moduleManager;
+    centralized_configuration::CentralizedConfiguration m_centralizedConfiguration;
 };

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -55,6 +55,7 @@ void Agent::Run()
         { return DispatchCommand(cmd, m_moduleManager.GetModule(cmd.Module), m_messageQueue); }));
 
     m_moduleManager.AddModule(Inventory::Instance());
+    m_moduleManager.AddModule(m_centralizedConfiguration);
     m_moduleManager.Setup();
     m_taskManager.EnqueueTask([this]() { m_moduleManager.Start(); });
 

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -23,6 +23,15 @@ Agent::Agent(const std::string& configPath, std::unique_ptr<ISignalHandler> sign
                      { return m_configurationParser.GetConfig<std::string>(std::move(table), std::move(key)); })
     , m_moduleManager(m_messageQueue, m_configurationParser)
 {
+    m_centralizedConfiguration.SetGroupIdFunction([this](const std::vector<std::string>& groups)
+                                                  { return m_agentInfo.SetGroups(groups); });
+
+    m_centralizedConfiguration.GetGroupIdFunction([this]() { return m_agentInfo.GetGroups(); });
+
+    m_centralizedConfiguration.SetDownloadGroupFilesFunction(
+        [this](const std::string& groupId, const std::string& destinationPath)
+        { return m_communicator.GetGroupConfigurationFromManager(groupId, destinationPath); });
+
     m_taskManager.Start(std::thread::hardware_concurrency());
 }
 

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -5,6 +5,7 @@ project(ModuleManager)
 include(../cmake/CommonSettings.cmake)
 set_common_settings()
 
+add_subdirectory(centralized_configuration)
 add_subdirectory(inventory)
 
 add_library(ModuleManager src/moduleManager.cpp)

--- a/src/modules/centralized_configuration/CMakeLists.txt
+++ b/src/modules/centralized_configuration/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(${CMAKE_SOURCE_DIR}/common/logger/include)
 
 add_library(CentralizedConfiguration src/centralized_configuration.cpp)
 target_include_directories(CentralizedConfiguration PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(CentralizedConfiguration PUBLIC ConfigurationParser)
+target_link_libraries(CentralizedConfiguration PUBLIC ConfigurationParser ModuleManager)
 
 include(../../cmake/ConfigureTarget.cmake)
 configure_target(CentralizedConfiguration)

--- a/src/modules/centralized_configuration/CMakeLists.txt
+++ b/src/modules/centralized_configuration/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(CentralizedConfiguration)
+
+include(../../cmake/CommonSettings.cmake)
+set_common_settings()
+
+include_directories(${CMAKE_SOURCE_DIR}/common/logger/include)
+
+add_library(CentralizedConfiguration src/centralized_configuration.cpp)
+target_include_directories(CentralizedConfiguration PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+include(../../cmake/ConfigureTarget.cmake)
+configure_target(CentralizedConfiguration)
+
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/src/modules/centralized_configuration/CMakeLists.txt
+++ b/src/modules/centralized_configuration/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(${CMAKE_SOURCE_DIR}/common/logger/include)
 
 add_library(CentralizedConfiguration src/centralized_configuration.cpp)
 target_include_directories(CentralizedConfiguration PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(CentralizedConfiguration PUBLIC ConfigurationParser ModuleManager)
+target_link_libraries(CentralizedConfiguration PUBLIC ConfigurationParser ModuleManager MultiTypeQueue)
 
 include(../../cmake/ConfigureTarget.cmake)
 configure_target(CentralizedConfiguration)

--- a/src/modules/centralized_configuration/CMakeLists.txt
+++ b/src/modules/centralized_configuration/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(${CMAKE_SOURCE_DIR}/common/logger/include)
 
 add_library(CentralizedConfiguration src/centralized_configuration.cpp)
 target_include_directories(CentralizedConfiguration PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(CentralizedConfiguration PUBLIC ConfigurationParser)
 
 include(../../cmake/ConfigureTarget.cmake)
 configure_target(CentralizedConfiguration)

--- a/src/modules/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/modules/centralized_configuration/include/centralized_configuration.hpp
@@ -14,6 +14,7 @@ namespace centralized_configuration
     {
     public:
         using SetGroupIdFunctionType = std::function<void(const std::vector<std::string>&)>;
+        using GetGroupIdFunctionType = std::function<std::vector<std::string>()>;
         using DownloadGroupFilesFunctionType = std::function<bool(const std::string&, const std::string&)>;
 
         void Start() const;
@@ -23,10 +24,12 @@ namespace centralized_configuration
         std::string Name() const;
 
         void SetGroupIdFunction(SetGroupIdFunctionType setGroupIdFunction);
+        void GetGroupIdFunction(GetGroupIdFunctionType getGroupIdFunction);
         void SetDownloadGroupFilesFunction(DownloadGroupFilesFunctionType downloadGroupFilesFunction);
 
     private:
         SetGroupIdFunctionType m_setGroupIdFunction;
+        GetGroupIdFunctionType m_getGroupIdFunction;
         DownloadGroupFilesFunctionType m_downloadGroupFilesFunction;
     };
 } // namespace centralized_configuration

--- a/src/modules/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/modules/centralized_configuration/include/centralized_configuration.hpp
@@ -13,17 +13,20 @@ namespace centralized_configuration
     class CentralizedConfiguration
     {
     public:
+        using SetGroupIdFunctionType = std::function<void(const std::vector<std::string>&)>;
+        using DownloadGroupFilesFunctionType = std::function<bool(const std::string&, const std::string&)>;
+
         void Start() const;
         void Setup(const configuration::ConfigurationParser&) const;
         void Stop() const;
         Co_CommandExecutionResult ExecuteCommand(std::string command);
         std::string Name() const;
 
-        void SetGroupIdFunction(std::function<void(const std::vector<std::string>&)> setGroupIdFunction);
-        void SetDownloadGroupFilesFunction(std::function<bool(const std::string&, const std::string&)> downloadGroupFilesFunction);
+        void SetGroupIdFunction(SetGroupIdFunctionType setGroupIdFunction);
+        void SetDownloadGroupFilesFunction(DownloadGroupFilesFunctionType downloadGroupFilesFunction);
 
     private:
-        std::function<void(const std::vector<std::string>&)> m_setGroupIdFunction;
-        std::function<bool(const std::string&, const std::string&)> m_downloadGroupFilesFunction;
+        SetGroupIdFunctionType m_setGroupIdFunction;
+        DownloadGroupFilesFunctionType m_downloadGroupFilesFunction;
     };
 } // namespace centralized_configuration

--- a/src/modules/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/modules/centralized_configuration/include/centralized_configuration.hpp
@@ -2,6 +2,7 @@
 
 #include <configuration_parser.hpp>
 #include <moduleWrapper.hpp>
+#include <multitype_queue.hpp>
 
 #include <filesystem>
 #include <functional>
@@ -22,6 +23,7 @@ namespace centralized_configuration
         void Stop() const;
         Co_CommandExecutionResult ExecuteCommand(std::string command);
         std::string Name() const;
+        void SetMessageQueue(const std::shared_ptr<IMultiTypeQueue>);
 
         void SetGroupIdFunction(SetGroupIdFunctionType setGroupIdFunction);
         void GetGroupIdFunction(GetGroupIdFunctionType getGroupIdFunction);

--- a/src/modules/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/modules/centralized_configuration/include/centralized_configuration.hpp
@@ -3,6 +3,7 @@
 #include <configuration_parser.hpp>
 #include <moduleWrapper.hpp>
 
+#include <filesystem>
 #include <functional>
 #include <string>
 #include <vector>
@@ -19,8 +20,10 @@ namespace centralized_configuration
         std::string Name() const;
 
         void SetGroupIdFunction(std::function<void(const std::vector<std::string>&)> setGroupIdFunction);
+        void SetDownloadGroupFilesFunction(std::function<bool(const std::string&, const std::string&)> downloadGroupFilesFunction);
 
     private:
         std::function<void(const std::vector<std::string>&)> m_setGroupIdFunction;
+        std::function<bool(const std::string&, const std::string&)> m_downloadGroupFilesFunction;
     };
 } // namespace centralized_configuration

--- a/src/modules/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/modules/centralized_configuration/include/centralized_configuration.hpp
@@ -14,19 +14,76 @@ namespace centralized_configuration
     class CentralizedConfiguration
     {
     public:
-        using SetGroupIdFunctionType = std::function<void(const std::vector<std::string>&)>;
+        using SetGroupIdFunctionType = std::function<void(const std::vector<std::string>& groupList)>;
         using GetGroupIdFunctionType = std::function<std::vector<std::string>()>;
-        using DownloadGroupFilesFunctionType = std::function<bool(const std::string&, const std::string&)>;
+        using DownloadGroupFilesFunctionType = std::function<bool(const std::string& group, const std::string& dstFilePath)>;
 
+        /**
+         * @brief Starts the centralized configuration process.
+         * @details This is a no-op function, required by the ModuleWrapper interface
+         * to be used within the ModuleManager.
+         */
         void Start() const;
-        void Setup(const configuration::ConfigurationParser&) const;
-        void Stop() const;
-        Co_CommandExecutionResult ExecuteCommand(std::string command);
-        std::string Name() const;
-        void SetMessageQueue(const std::shared_ptr<IMultiTypeQueue>);
 
+        /**
+         * @brief Configures the centralized configuration system.
+         * @param configParser The configuration parser containing settings to be applied.
+         * @details This is a no-op function, required by the ModuleWrapper interface
+         * to be used within the ModuleManager.
+         */
+        void Setup(const configuration::ConfigurationParser&) const;
+
+        /**
+         * @brief Stops the centralized configuration process.
+         * @details This is a no-op function, required by the ModuleWrapper interface
+         * to be used within the ModuleManager.
+         */
+        void Stop() const;
+
+        /**
+         * @brief Executes a command for the centralized configuration system.
+         * @param command A string containing a JSON command to execute.
+         * @details Required by the ModuleWrapper interface to be used within the ModuleManager
+         * @return Co_CommandExecutionResult The result of executing the command, either success or failure.
+         */
+        Co_CommandExecutionResult ExecuteCommand(std::string command);
+
+        /**
+         * @brief Gets the name of the centralized configuration system.
+         * @details Required by the ModuleWrapper interface to be used within the ModuleManager
+         * @return A string representing the name.
+         */
+        std::string Name() const;
+
+        /**
+         * @brief Sets the message queue for the system.
+         * @param queue A shared pointer to the message queue used for communication.
+         * @details This is a no-op function, required by the ModuleWrapper interface
+         * to be used within the ModuleManager.
+         */
+        void SetMessageQueue(const std::shared_ptr<IMultiTypeQueue> queue);
+
+        /**
+         * @brief Sets the function to assign group IDs.
+         * @details The "set-group" commands requires such function to be set.
+         * @param setGroupIdFunction A function to set group IDs.
+         */
         void SetGroupIdFunction(SetGroupIdFunctionType setGroupIdFunction);
+
+        /**
+         * @brief Sets the function to retrieve group IDs.
+         * @details The "update-group" commands requires such function to be set.
+         * @param getGroupIdFunction A function to get group IDs.
+         */
         void GetGroupIdFunction(GetGroupIdFunctionType getGroupIdFunction);
+
+        /**
+         * @brief Sets the function to download group configuration files.
+         * @details Configures how and where to download group configuration files.
+         * These will be used to set and update the Agent groups via the "set-group" and "update-group"
+         * commands.
+         * @param downloadGroupFilesFunction A function to download files for a given group ID.
+         */
         void SetDownloadGroupFilesFunction(DownloadGroupFilesFunctionType downloadGroupFilesFunction);
 
     private:

--- a/src/modules/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/modules/centralized_configuration/include/centralized_configuration.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <configuration_parser.hpp>
+#include <moduleWrapper.hpp>
 
 #include <functional>
 #include <string>
@@ -13,6 +14,7 @@ namespace centralized_configuration
         void Start() const;
         void Setup(const configuration::ConfigurationParser&) const;
         void Stop() const;
+        Co_CommandExecutionResult ExecuteCommand(std::string command);
         std::string Name() const;
     };
 } // namespace centralized_configuration

--- a/src/modules/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/modules/centralized_configuration/include/centralized_configuration.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace centralized_configuration
+{
+    class CentralizedConfiguration
+    {
+    };
+} // namespace centralized_configuration

--- a/src/modules/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/modules/centralized_configuration/include/centralized_configuration.hpp
@@ -1,8 +1,14 @@
 #pragma once
 
+#include <string>
+
 namespace centralized_configuration
 {
     class CentralizedConfiguration
     {
+    public:
+        void Start() const;
+        void Stop() const;
+        std::string Name() const;
     };
 } // namespace centralized_configuration

--- a/src/modules/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/modules/centralized_configuration/include/centralized_configuration.hpp
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <string>
+#include <vector>
 
 namespace centralized_configuration
 {
@@ -16,5 +17,10 @@ namespace centralized_configuration
         void Stop() const;
         Co_CommandExecutionResult ExecuteCommand(std::string command);
         std::string Name() const;
+
+        void SetGroupIdFunction(std::function<void(const std::vector<std::string>&)> setGroupIdFunction);
+
+    private:
+        std::function<void(const std::vector<std::string>&)> m_setGroupIdFunction;
     };
 } // namespace centralized_configuration

--- a/src/modules/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/modules/centralized_configuration/include/centralized_configuration.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <configuration_parser.hpp>
+
+#include <functional>
 #include <string>
 
 namespace centralized_configuration
@@ -8,6 +11,7 @@ namespace centralized_configuration
     {
     public:
         void Start() const;
+        void Setup(const configuration::ConfigurationParser&) const;
         void Stop() const;
         std::string Name() const;
     };

--- a/src/modules/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/modules/centralized_configuration/src/centralized_configuration.cpp
@@ -77,4 +77,9 @@ namespace centralized_configuration
     {
         m_setGroupIdFunction = std::move(setGroupIdFunction);
     }
+
+    void CentralizedConfiguration::SetDownloadGroupFilesFunction(std::function<bool(const std::string&, const std::string&)> downloadGroupFilesFunction)
+    {
+        m_downloadGroupFilesFunction = std::move(downloadGroupFilesFunction);
+    }
 } // namespace centralized_configuration

--- a/src/modules/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/modules/centralized_configuration/src/centralized_configuration.cpp
@@ -25,10 +25,24 @@ namespace centralized_configuration
 
         if (commnandAsJson["command"] == "set-group")
         {
-            co_return module_command::CommandExecutionResult{
-                module_command::Status::SUCCESS,
-                "CentralizedConfiguration group set"
-            };
+            if (m_setGroupIdFunction)
+            {
+                std::vector<std::string> groupIds;
+
+                m_setGroupIdFunction(groupIds);
+
+                co_return module_command::CommandExecutionResult{
+                    module_command::Status::SUCCESS,
+                    "CentralizedConfiguration group set"
+                };
+            }
+            else
+            {
+                co_return module_command::CommandExecutionResult{
+                    module_command::Status::FAILURE,
+                    "CentralizedConfiguration group set failed, no function set"
+                };
+            }
         }
         else if (commnandAsJson["command"] == "update-group")
         {
@@ -47,5 +61,10 @@ namespace centralized_configuration
     std::string CentralizedConfiguration::Name() const
     {
         return "CentralizedConfiguration";
+    }
+
+    void CentralizedConfiguration::SetGroupIdFunction(std::function<void(const std::vector<std::string>&)> setGroupIdFunction)
+    {
+        m_setGroupIdFunction = std::move(setGroupIdFunction);
     }
 } // namespace centralized_configuration

--- a/src/modules/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/modules/centralized_configuration/src/centralized_configuration.cpp
@@ -73,12 +73,12 @@ namespace centralized_configuration
         return "CentralizedConfiguration";
     }
 
-    void CentralizedConfiguration::SetGroupIdFunction(std::function<void(const std::vector<std::string>&)> setGroupIdFunction)
+    void CentralizedConfiguration::SetGroupIdFunction(SetGroupIdFunctionType setGroupIdFunction)
     {
         m_setGroupIdFunction = std::move(setGroupIdFunction);
     }
 
-    void CentralizedConfiguration::SetDownloadGroupFilesFunction(std::function<bool(const std::string&, const std::string&)> downloadGroupFilesFunction)
+    void CentralizedConfiguration::SetDownloadGroupFilesFunction(DownloadGroupFilesFunctionType downloadGroupFilesFunction)
     {
         m_downloadGroupFilesFunction = std::move(downloadGroupFilesFunction);
     }

--- a/src/modules/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/modules/centralized_configuration/src/centralized_configuration.cpp
@@ -1,2 +1,17 @@
 #include <centralized_configuration.hpp>
 
+namespace centralized_configuration
+{
+    void CentralizedConfiguration::Start() const
+    {
+    }
+
+    void CentralizedConfiguration::Stop() const
+    {
+    }
+
+    std::string CentralizedConfiguration::Name() const
+    {
+        return "CentralizedConfiguration";
+    }
+} // namespace centralized_configuration

--- a/src/modules/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/modules/centralized_configuration/src/centralized_configuration.cpp
@@ -4,6 +4,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include <filesystem>
+
 namespace centralized_configuration
 {
     void CentralizedConfiguration::Start() const
@@ -27,11 +29,21 @@ namespace centralized_configuration
 
             if (commnandAsJson["command"] == "set-group")
             {
-                if (m_setGroupIdFunction)
+                if (m_setGroupIdFunction && m_downloadGroupFilesFunction)
                 {
-                    std::vector<std::string> groupIds;
+                    const auto groupIds = commnandAsJson["groups"].get<std::vector<std::string>>();
 
                     m_setGroupIdFunction(groupIds);
+
+                    for (const auto& groupId : groupIds)
+                    {
+                        m_downloadGroupFilesFunction(
+                            groupId,
+                            std::filesystem::temp_directory_path().string()
+                        );
+                    }
+
+                    // TODO validate groupFiles, apply configuration
 
                     co_return module_command::CommandExecutionResult{
                         module_command::Status::SUCCESS,

--- a/src/modules/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/modules/centralized_configuration/src/centralized_configuration.cpp
@@ -1,0 +1,2 @@
+#include <centralized_configuration.hpp>
+

--- a/src/modules/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/modules/centralized_configuration/src/centralized_configuration.cpp
@@ -1,5 +1,7 @@
 #include <centralized_configuration.hpp>
 
+#include <module_command/command_entry.hpp>
+
 namespace centralized_configuration
 {
     void CentralizedConfiguration::Start() const
@@ -12,6 +14,15 @@ namespace centralized_configuration
 
     void CentralizedConfiguration::Stop() const
     {
+    }
+
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    Co_CommandExecutionResult CentralizedConfiguration::ExecuteCommand(const std::string)
+    {
+        co_return module_command::CommandExecutionResult{
+            module_command::Status::FAILURE,
+            "Not yet implemented"
+        };
     }
 
     std::string CentralizedConfiguration::Name() const

--- a/src/modules/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/modules/centralized_configuration/src/centralized_configuration.cpp
@@ -21,34 +21,44 @@ namespace centralized_configuration
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     Co_CommandExecutionResult CentralizedConfiguration::ExecuteCommand(const std::string command)
     {
-        const auto commnandAsJson = nlohmann::json::parse(command);
-
-        if (commnandAsJson["command"] == "set-group")
+        try
         {
-            if (m_setGroupIdFunction)
+            const auto commnandAsJson = nlohmann::json::parse(command);
+
+            if (commnandAsJson["command"] == "set-group")
             {
-                std::vector<std::string> groupIds;
+                if (m_setGroupIdFunction)
+                {
+                    std::vector<std::string> groupIds;
 
-                m_setGroupIdFunction(groupIds);
+                    m_setGroupIdFunction(groupIds);
 
+                    co_return module_command::CommandExecutionResult{
+                        module_command::Status::SUCCESS,
+                        "CentralizedConfiguration group set"
+                    };
+                }
+                else
+                {
+                    co_return module_command::CommandExecutionResult{
+                        module_command::Status::FAILURE,
+                        "CentralizedConfiguration group set failed, no function set"
+                    };
+                }
+            }
+            else if (commnandAsJson["command"] == "update-group")
+            {
                 co_return module_command::CommandExecutionResult{
                     module_command::Status::SUCCESS,
-                    "CentralizedConfiguration group set"
-                };
-            }
-            else
-            {
-                co_return module_command::CommandExecutionResult{
-                    module_command::Status::FAILURE,
-                    "CentralizedConfiguration group set failed, no function set"
+                    "CentralizedConfiguration group updated"
                 };
             }
         }
-        else if (commnandAsJson["command"] == "update-group")
+        catch (const nlohmann::json::exception&)
         {
             co_return module_command::CommandExecutionResult{
-                module_command::Status::SUCCESS,
-                "CentralizedConfiguration group updated"
+                module_command::Status::FAILURE,
+                "CentralizedConfiguration error while parsing command"
             };
         }
 

--- a/src/modules/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/modules/centralized_configuration/src/centralized_configuration.cpp
@@ -107,6 +107,10 @@ namespace centralized_configuration
         return "CentralizedConfiguration";
     }
 
+    void CentralizedConfiguration::SetMessageQueue(const std::shared_ptr<IMultiTypeQueue>)
+    {
+    }
+
     void CentralizedConfiguration::SetGroupIdFunction(SetGroupIdFunctionType setGroupIdFunction)
     {
         m_setGroupIdFunction = std::move(setGroupIdFunction);

--- a/src/modules/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/modules/centralized_configuration/src/centralized_configuration.cpp
@@ -6,6 +6,10 @@ namespace centralized_configuration
     {
     }
 
+    void CentralizedConfiguration::Setup(const configuration::ConfigurationParser&) const
+    {
+    }
+
     void CentralizedConfiguration::Stop() const
     {
     }

--- a/src/modules/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/modules/centralized_configuration/src/centralized_configuration.cpp
@@ -2,6 +2,8 @@
 
 #include <module_command/command_entry.hpp>
 
+#include <nlohmann/json.hpp>
+
 namespace centralized_configuration
 {
     void CentralizedConfiguration::Start() const
@@ -17,11 +19,28 @@ namespace centralized_configuration
     }
 
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    Co_CommandExecutionResult CentralizedConfiguration::ExecuteCommand(const std::string)
+    Co_CommandExecutionResult CentralizedConfiguration::ExecuteCommand(const std::string command)
     {
+        const auto commnandAsJson = nlohmann::json::parse(command);
+
+        if (commnandAsJson["command"] == "set-group")
+        {
+            co_return module_command::CommandExecutionResult{
+                module_command::Status::SUCCESS,
+                "CentralizedConfiguration group set"
+            };
+        }
+        else if (commnandAsJson["command"] == "update-group")
+        {
+            co_return module_command::CommandExecutionResult{
+                module_command::Status::SUCCESS,
+                "CentralizedConfiguration group updated"
+            };
+        }
+
         co_return module_command::CommandExecutionResult{
             module_command::Status::FAILURE,
-            "Not yet implemented"
+            "CentralizedConfiguration command not recognized"
         };
     }
 

--- a/src/modules/centralized_configuration/tests/CMakeLists.txt
+++ b/src/modules/centralized_configuration/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+find_package(GTest CONFIG REQUIRED)
+
+add_executable(centralized_configuration_test centralized_configuration_tests.cpp)
+configure_target(centralized_configuration_test)
+target_include_directories(centralized_configuration_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_link_libraries(centralized_configuration_test PRIVATE CentralizedConfiguration GTest::gtest GTest::gmock)
+add_test(NAME CentralizedConfiguration COMMAND centralized_configuration_test)

--- a/src/modules/centralized_configuration/tests/centralized_configuration_tests.cpp
+++ b/src/modules/centralized_configuration/tests/centralized_configuration_tests.cpp
@@ -14,6 +14,24 @@ using centralized_configuration::CentralizedConfiguration;
 namespace
 {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
+    boost::asio::awaitable<void> TestExecuteCommandSetGroup(CentralizedConfiguration& centralizedConfiguration)
+    {
+        const std::string command = R"({"command": "set-group"})";
+        const auto commandResult = co_await centralizedConfiguration.ExecuteCommand(command);
+
+        EXPECT_EQ(commandResult.ErrorCode, module_command::Status::SUCCESS);
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
+    boost::asio::awaitable<void> TestExecuteCommandUpdateGroup(CentralizedConfiguration& centralizedConfiguration)
+    {
+        const std::string command = R"({"command": "update-group"})";
+        const auto commandResult = co_await centralizedConfiguration.ExecuteCommand(command);
+
+        EXPECT_EQ(commandResult.ErrorCode, module_command::Status::SUCCESS);
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
     boost::asio::awaitable<void> TestExecuteCommandUnrecognized(CentralizedConfiguration& centralizedConfiguration)
     {
         const std::string command = R"({"command": "unknown-command"})";
@@ -50,6 +68,27 @@ TEST(CentralizedConfiguration, ExecuteCommandReturnsFailureOnUnrecognizedCommand
     boost::asio::co_spawn(
         io_context,
         TestExecuteCommandUnrecognized(centralizedConfiguration),
+        boost::asio::detached
+    );
+
+    io_context.run();
+}
+
+TEST(CentralizedConfiguration, ExecuteCommandHandlesRecognizedCommands)
+{
+    CentralizedConfiguration centralizedConfiguration;
+
+    boost::asio::io_context io_context;
+
+    boost::asio::co_spawn(
+        io_context,
+        TestExecuteCommandSetGroup(centralizedConfiguration),
+        boost::asio::detached
+    );
+
+    boost::asio::co_spawn(
+        io_context,
+        TestExecuteCommandUpdateGroup(centralizedConfiguration),
         boost::asio::detached
     );
 

--- a/src/modules/centralized_configuration/tests/centralized_configuration_tests.cpp
+++ b/src/modules/centralized_configuration/tests/centralized_configuration_tests.cpp
@@ -11,6 +11,14 @@ TEST(CentralizedConfiguration, Constructor)
     );
 }
 
+TEST(CentralizedConfiguration, ImplementsModuleWrapperInterface)
+{
+    CentralizedConfiguration centralizedConfiguration;
+    EXPECT_NO_THROW(centralizedConfiguration.Start());
+    EXPECT_NO_THROW(centralizedConfiguration.Stop());
+    EXPECT_NO_THROW(centralizedConfiguration.Name());
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/src/modules/centralized_configuration/tests/centralized_configuration_tests.cpp
+++ b/src/modules/centralized_configuration/tests/centralized_configuration_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <centralized_configuration.hpp>
+#include <configuration_parser.hpp>
 
 using centralized_configuration::CentralizedConfiguration;
 
@@ -17,6 +18,10 @@ TEST(CentralizedConfiguration, ImplementsModuleWrapperInterface)
     EXPECT_NO_THROW(centralizedConfiguration.Start());
     EXPECT_NO_THROW(centralizedConfiguration.Stop());
     EXPECT_NO_THROW(centralizedConfiguration.Name());
+
+    const std::string emptyConfig;
+    configuration::ConfigurationParser configurationParser(emptyConfig);
+    EXPECT_NO_THROW(centralizedConfiguration.Setup(configurationParser));
 }
 
 int main(int argc, char** argv)

--- a/src/modules/centralized_configuration/tests/centralized_configuration_tests.cpp
+++ b/src/modules/centralized_configuration/tests/centralized_configuration_tests.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+
+#include <centralized_configuration.hpp>
+
+using centralized_configuration::CentralizedConfiguration;
+
+TEST(CentralizedConfiguration, Constructor)
+{
+    EXPECT_NO_THROW(
+        [[maybe_unused]] CentralizedConfiguration centralizedConfiguration
+    );
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/222|

## Description

This PR introduces a CentralizedConfiguration class that will handle the incoming `set-group` and `update-group` commands.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
