### PR TITLE
Specify ubuntu runner instead of using latest in coverage check

### DIFF
--- a/.github/workflows/coverage_check.yml
+++ b/.github/workflows/coverage_check.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Description

In relation to https://github.com/wazuh/wazuh-agent/pull/218 it was recently also noted that not all runners are using the same `latest`, some default to ubuntu-24 others to ubuntu-22. Since Github is in a transition period updating their runners, and they will be so until Oct 30th, we specify the runner in the coverage check to avoid failures.

See: https://github.com/actions/runner-images/issues/10636