### PR TITLE
Added the '--config-path' option for '--register-agent'

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -66,9 +66,10 @@ The following dependencies are required for this project:
     You can start and stop the agent, and get status with:
 
     ```bash
-    systemctl start wazuh-agent --run
-    systemctl stop wazuh-agent
-    systemctl is-active wazuh-agent
+    ./wazuh-agent --run
+    ./wazuh-agent --stop
+    ./wazuh-agent --restart
+    ./wazuh-agent --status
     ```
 
     **To run the agent as a systemd service**
@@ -94,15 +95,6 @@ The following dependencies are required for this project:
     systemctl stop wazuh-agent
     systemctl is-active wazuh-agent
     systemctl status wazuh-agent
-    ```
-
-    You can start and stop the agent, and get status from CLI:
-
-    ```bash
-    ./wazuh-agent --run
-    ./wazuh-agent --stop
-    ./wazuh-agent --restart
-    ./wazuh-agent --status
     ```
 
 6. **Run tests**

--- a/src/agent/include/agent_registration.hpp
+++ b/src/agent/include/agent_registration.hpp
@@ -21,7 +21,7 @@ namespace agent_registration
                           std::string password,
                           const std::string& key,
                           const std::string& name,
-                          const std::string& configPath);
+                          std::optional<std::string> configPath);
         bool Register(http_client::IHttpClient& httpClient);
 
     private:

--- a/src/agent/include/agent_registration.hpp
+++ b/src/agent/include/agent_registration.hpp
@@ -17,7 +17,11 @@ namespace agent_registration
     class AgentRegistration
     {
     public:
-        AgentRegistration(std::string user, std::string password, const std::string& key, const std::string& name);
+        AgentRegistration(std::string user,
+                          std::string password,
+                          const std::string& key,
+                          const std::string& name,
+                          const std::string& configPath);
         bool Register(http_client::IHttpClient& httpClient);
 
     private:

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -22,7 +22,8 @@ using logcollector::Logcollector;
 Agent::Agent(const std::string& configPath, std::unique_ptr<ISignalHandler> signalHandler)
     : m_messageQueue(std::make_shared<MultiTypeQueue>())
     , m_signalHandler(std::move(signalHandler))
-    , m_configurationParser(std::filesystem::path(configPath))
+    , m_configurationParser(configPath.empty() ? configuration::ConfigurationParser()
+                                               : configuration::ConfigurationParser(std::filesystem::path(configPath)))
     , m_communicator(std::make_unique<http_client::HttpClient>(),
                      m_agentInfo.GetUUID(),
                      m_agentInfo.GetKey(),

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -12,8 +12,12 @@ namespace agent_registration
     AgentRegistration::AgentRegistration(std::string user,
                                          std::string password,
                                          const std::string& key,
-                                         const std::string& name)
-        : m_managerIp(m_configurationParser.GetConfig<std::string>("agent", "manager_ip"))
+                                         const std::string& name,
+                                         const std::string& configPath)
+        : m_configurationParser(configPath.empty()
+                                    ? configuration::ConfigurationParser()
+                                    : configuration::ConfigurationParser(std::filesystem::path(configPath)))
+        , m_managerIp(m_configurationParser.GetConfig<std::string>("agent", "manager_ip"))
         , m_managerPort(m_configurationParser.GetConfig<std::string>("agent", "server_mgmt_api_port"))
         , m_user(std::move(user))
         , m_password(std::move(password))

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -13,10 +13,10 @@ namespace agent_registration
                                          std::string password,
                                          const std::string& key,
                                          const std::string& name,
-                                         const std::string& configPath)
-        : m_configurationParser(configPath.empty()
-                                    ? configuration::ConfigurationParser()
-                                    : configuration::ConfigurationParser(std::filesystem::path(configPath)))
+                                         std::optional<std::string> configPath)
+        : m_configurationParser(configPath.has_value() && !configPath->empty()
+                                    ? configuration::ConfigurationParser(std::filesystem::path(configPath.value()))
+                                    : configuration::ConfigurationParser())
         , m_managerIp(m_configurationParser.GetConfig<std::string>("agent", "manager_ip"))
         , m_managerPort(m_configurationParser.GetConfig<std::string>("agent", "server_mgmt_api_port"))
         , m_user(std::move(user))

--- a/src/agent/src/main.cpp
+++ b/src/agent/src/main.cpp
@@ -23,7 +23,8 @@ int main(int argc, char* argv[])
             RegisterAgent(cmdParser.GetOptionValue("--user"),
                           cmdParser.GetOptionValue("--password"),
                           cmdParser.GetOptionValue("--key"),
-                          cmdParser.GetOptionValue("--name"));
+                          cmdParser.GetOptionValue("--name"),
+                          configPath);
         }
         else if (cmdParser.OptionExists("--restart"))
         {

--- a/src/agent/src/process_options.cpp
+++ b/src/agent/src/process_options.cpp
@@ -9,11 +9,12 @@
 void RegisterAgent(const std::string& user,
                    const std::string& password,
                    const std::string& key,
-                   const std::string& name)
+                   const std::string& name,
+                   const std::string& configPath)
 {
     if (!user.empty() && !password.empty() && !key.empty())
     {
-        agent_registration::AgentRegistration reg(user, password, key, name);
+        agent_registration::AgentRegistration reg(user, password, key, name, configPath);
 
         http_client::HttpClient httpClient;
         if (reg.Register(httpClient))

--- a/src/agent/src/process_options.hpp
+++ b/src/agent/src/process_options.hpp
@@ -5,7 +5,8 @@
 void RegisterAgent(const std::string& user,
                    const std::string& password,
                    const std::string& key,
-                   const std::string& name);
+                   const std::string& name,
+                   const std::string& configPath);
 void RestartAgent([[maybe_unused]] const std::string& configPath);
 void StartAgent([[maybe_unused]] const std::string& configPath);
 void StartAgentDaemon([[maybe_unused]] const std::string& configPath);

--- a/src/agent/src/process_options_unix.cpp
+++ b/src/agent/src/process_options_unix.cpp
@@ -64,14 +64,13 @@ void PrintHelp()
     std::cout << "\n";
     std::cout << "Options:\n";
     std::cout << "     --run                Start wazuh-agent\n";
-    std::cout << "       [--config-path <path>]   Specify configuration file path (optional)\n";
     std::cout << "     --start              Start wazuh-agent daemon\n";
     std::cout << "     --status             Get wazuh-agent daemon status\n";
     std::cout << "     --stop               Stop wazuh-agent daemon\n";
     std::cout << "     --restart            Restart wazuh-agent daemon\n";
-    std::cout << "       [--config-path <path>]   Specify configuration file path (optional)\n";
     std::cout << "     --register-agent     Register wazuh-agent\n";
-    std::cout << "       [--config-path <path>]   Specify configuration file path (optional)\n";
+    std::cout << "     --config-path <path> Specify configuration file path (optional).\n";
+    std::cout << "                          Used with --start, --restart, or --register-agent.\n";
     std::cout << "     --help               This help message\n";
 }
 

--- a/src/agent/src/process_options_unix.cpp
+++ b/src/agent/src/process_options_unix.cpp
@@ -58,18 +58,20 @@ void StopAgent()
 
 void PrintHelp()
 {
-    LogInfo("Wazuh Agent help.");
-
     // TO DO
+    std::cout << "Wazuh Agent help.\n ";
     std::cout << "Usage: wazuh-agent [options]\n";
     std::cout << "\n";
     std::cout << "Options:\n";
     std::cout << "     --run                Start wazuh-agent\n";
+    std::cout << "       [--config-path <path>]   Specify configuration file path (optional)\n";
     std::cout << "     --start              Start wazuh-agent daemon\n";
     std::cout << "     --status             Get wazuh-agent daemon status\n";
     std::cout << "     --stop               Stop wazuh-agent daemon\n";
     std::cout << "     --restart            Restart wazuh-agent daemon\n";
+    std::cout << "       [--config-path <path>]   Specify configuration file path (optional)\n";
     std::cout << "     --register-agent     Register wazuh-agent\n";
+    std::cout << "       [--config-path <path>]   Specify configuration file path (optional)\n";
     std::cout << "     --help               This help message\n";
 }
 

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -68,7 +68,7 @@ protected:
     {
         agent = std::make_unique<AgentInfo>("agent_name", "agent_key", "agent_uuid");
         registration =
-            std::make_unique<agent_registration::AgentRegistration>("user", "password", "agent_key", "agent_name");
+            std::make_unique<agent_registration::AgentRegistration>("user", "password", "agent_key", "agent_name", "");
     }
 
     std::unique_ptr<AgentInfo> agent;

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -67,8 +67,8 @@ protected:
     void SetUp() override
     {
         agent = std::make_unique<AgentInfo>("agent_name", "agent_key", "agent_uuid");
-        registration =
-            std::make_unique<agent_registration::AgentRegistration>("user", "password", "agent_key", "agent_name", "");
+        registration = std::make_unique<agent_registration::AgentRegistration>(
+            "user", "password", "agent_key", "agent_name", std::nullopt);
     }
 
     std::unique_ptr<AgentInfo> agent;


### PR DESCRIPTION
|Related issue|
|---|
|#231|


## Description

This PR adds the --config-path option so that it can also be used when registering the agent.

It also adds the following fixes:

- Reorder the **Run the Agent** section in BUILD.md
- Add the --config-path option to PrinHelp function
- And adds a fix to prevent the agent from trying to read the “” file when the --config-path option is not used.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X