### PR TITLE
feat: CLI output as normal text

### DIFF
--- a/src/agent/src/process_options.cpp
+++ b/src/agent/src/process_options.cpp
@@ -2,6 +2,7 @@
 
 #include <agent.hpp>
 #include <agent_registration.hpp>
+#include <fmt/format.h>
 
 #include <iostream>
 #include <string>
@@ -19,15 +20,15 @@ void RegisterAgent(const std::string& user,
         http_client::HttpClient httpClient;
         if (reg.Register(httpClient))
         {
-            LogInfo("wazuh-agent registered.");
+            std::cout << "wazuh-agent registered\n";
         }
         else
         {
-            LogError("wazuh-agent registration fail.");
+            std::cout << "wazuh-agent registration failed\n";
         }
     }
     else
     {
-        LogError("{}, {}, and {} args are mandatory", OPT_USER, OPT_PASSWORD, OPT_KEY);
+        std::cout << fmt::format("{}, {}, and {} args are mandatory\n", OPT_USER, OPT_PASSWORD, OPT_KEY);
     }
 }

--- a/src/agent/src/process_options_unix.cpp
+++ b/src/agent/src/process_options_unix.cpp
@@ -22,15 +22,13 @@ void RestartAgent(const std::string& configFile)
 
 void StartAgent([[maybe_unused]] const std::string& configFile)
 {
-    LogInfo("Starting wazuh-agent");
-
     pid_t pid = unix_daemon::PIDFileHandler::ReadPIDFromFile();
     if (pid != 0)
     {
-        LogInfo("wazuh-agent already running");
+        std::cout << "wazuh-agent already running\n";
         return;
     }
-
+    LogInfo("Starting wazuh-agent");
     unix_daemon::PIDFileHandler handler = unix_daemon::GeneratePIDFile();
     Agent agent(configFile);
     agent.Run();

--- a/src/common/logger/src/logger_linux.cpp
+++ b/src/common/logger/src/logger_linux.cpp
@@ -4,7 +4,7 @@
 
 Logger::Logger()
 {
-    auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    auto console_sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
     auto logger = std::make_shared<spdlog::logger>("wazuh-agent", console_sink);
 
     spdlog::set_default_logger(logger);

--- a/src/common/logger/tests/logger_test.cpp
+++ b/src/common/logger/tests/logger_test.cpp
@@ -62,7 +62,7 @@ TEST_F(LoggerConstructorTest, LinuxLoggerConstructor)
 
     auto sinks = current_logger->sinks();
     ASSERT_FALSE(sinks.empty());
-    auto systemd_sink = std::dynamic_pointer_cast<spdlog::sinks::stdout_color_sink_mt>(sinks[0]);
+    auto systemd_sink = std::dynamic_pointer_cast<spdlog::sinks::stderr_color_sink_mt>(sinks[0]);
     EXPECT_NE(systemd_sink, nullptr);
 }
 
@@ -75,7 +75,7 @@ TEST_F(LoggerConstructorTest, LinuxLoggerConstructorFail)
 
     auto sinks = current_logger->sinks();
     ASSERT_FALSE(sinks.empty());
-    auto systemd_sink = std::dynamic_pointer_cast<spdlog::sinks::syslog_sink_mt>(sinks[0]);
+    auto systemd_sink = std::dynamic_pointer_cast<spdlog::sinks::stdout_color_sink_mt>(sinks[0]);
     EXPECT_EQ(systemd_sink, nullptr);
 }
 #endif // __linux__


### PR DESCRIPTION
|Related issue|
|---|
|[245](https://github.com/wazuh/wazuh-agent/issues/245)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Set the standard CLI output as normal text (no logging format) via stdout.

- Compilation without warnings in every supported platform
  - [x] Linux
