### PR TITLE
Centralizedconfiguration uses the parameter list as a group list when executing commands.

### DIFF
--- a/src/agent/centralized_configuration/CMakeLists.txt
+++ b/src/agent/centralized_configuration/CMakeLists.txt
@@ -6,12 +6,13 @@ include(../../cmake/CommonSettings.cmake)
 set_common_settings()
 
 find_package(Boost REQUIRED COMPONENTS asio)
+find_package(nlohmann_json REQUIRED)
 
 include_directories(${CMAKE_SOURCE_DIR}/common/logger/include)
 
 add_library(CentralizedConfiguration src/centralized_configuration.cpp)
 target_include_directories(CentralizedConfiguration PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(CentralizedConfiguration PUBLIC ModuleCommand Boost::asio)
+target_link_libraries(CentralizedConfiguration PUBLIC ModuleCommand Boost::asio nlohmann_json::nlohmann_json)
 
 include(../../cmake/ConfigureTarget.cmake)
 configure_target(CentralizedConfiguration)

--- a/src/agent/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/agent/centralized_configuration/include/centralized_configuration.hpp
@@ -22,9 +22,11 @@ namespace centralized_configuration
         /**
          * @brief Executes a command for the centralized configuration system.
          * @param command A string containing a JSON command to execute.
+         * @param parameters A vector of strings containing the parameters of the command to be executed.
          * @return An awaitable with the result of executing the command, either success or failure.
          */
-        boost::asio::awaitable<module_command::CommandExecutionResult> ExecuteCommand(std::string command);
+        boost::asio::awaitable<module_command::CommandExecutionResult>
+        ExecuteCommand(std::string command, std::vector<std::string> parameters);
 
         /**
          * @brief Sets the function to assign group IDs.

--- a/src/agent/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/agent/centralized_configuration/include/centralized_configuration.hpp
@@ -4,6 +4,8 @@
 
 #include <boost/asio/awaitable.hpp>
 
+#include <nlohmann/json.hpp>
+
 #include <filesystem>
 #include <functional>
 #include <string>
@@ -22,11 +24,11 @@ namespace centralized_configuration
         /**
          * @brief Executes a command for the centralized configuration system.
          * @param command A string containing a JSON command to execute.
-         * @param parameters A vector of strings containing the parameters of the command to be executed.
+         * @param parameters A json object containing the parameters of the command to be executed.
          * @return An awaitable with the result of executing the command, either success or failure.
          */
-        boost::asio::awaitable<module_command::CommandExecutionResult>
-        ExecuteCommand(std::string command, std::vector<std::string> parameters);
+        boost::asio::awaitable<module_command::CommandExecutionResult> ExecuteCommand(std::string command,
+                                                                                      nlohmann::json parameters);
 
         /**
          * @brief Sets the function to assign group IDs.

--- a/src/agent/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/agent/centralized_configuration/src/centralized_configuration.cpp
@@ -3,13 +3,12 @@
 #include <nlohmann/json.hpp>
 
 #include <filesystem>
-#include <vector>
 
 namespace centralized_configuration
 {
     boost::asio::awaitable<module_command::CommandExecutionResult> CentralizedConfiguration::ExecuteCommand(
-        const std::string command,                 // NOLINT(performance-unnecessary-value-param)
-        const std::vector<std::string> parameters) // NOLINT(performance-unnecessary-value-param)
+        const std::string command,       // NOLINT(performance-unnecessary-value-param)
+        const nlohmann::json parameters) // NOLINT(performance-unnecessary-value-param)
     {
         try
         {
@@ -23,8 +22,7 @@ namespace centralized_configuration
                             module_command::Status::FAILURE,
                             "CentralizedConfiguration group set failed, no group list"};
 
-                    const auto parametersAsJson = nlohmann::json::parse(parameters[0]);
-                    const auto groupIds = parametersAsJson.get<std::vector<std::string>>();
+                    const auto groupIds = parameters[0].get<std::vector<std::string>>();
 
                     m_setGroupIdFunction(groupIds);
 

--- a/src/agent/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/agent/centralized_configuration/src/centralized_configuration.cpp
@@ -3,11 +3,13 @@
 #include <nlohmann/json.hpp>
 
 #include <filesystem>
+#include <vector>
 
 namespace centralized_configuration
 {
-    boost::asio::awaitable<module_command::CommandExecutionResult>
-    CentralizedConfiguration::ExecuteCommand(const std::string command) // NOLINT(performance-unnecessary-value-param)
+    boost::asio::awaitable<module_command::CommandExecutionResult> CentralizedConfiguration::ExecuteCommand(
+        const std::string command,                                  // NOLINT(performance-unnecessary-value-param)
+        [[maybe_unused]] const std::vector<std::string> parameters) // NOLINT(performance-unnecessary-value-param)
     {
         try
         {

--- a/src/agent/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/agent/centralized_configuration/src/centralized_configuration.cpp
@@ -8,18 +8,23 @@
 namespace centralized_configuration
 {
     boost::asio::awaitable<module_command::CommandExecutionResult> CentralizedConfiguration::ExecuteCommand(
-        const std::string command,                                  // NOLINT(performance-unnecessary-value-param)
-        [[maybe_unused]] const std::vector<std::string> parameters) // NOLINT(performance-unnecessary-value-param)
+        const std::string command,                 // NOLINT(performance-unnecessary-value-param)
+        const std::vector<std::string> parameters) // NOLINT(performance-unnecessary-value-param)
     {
         try
         {
-            const auto commnandAsJson = nlohmann::json::parse(command);
 
-            if (commnandAsJson["command"] == "set-group")
+            if (command == "set-group")
             {
                 if (m_setGroupIdFunction && m_downloadGroupFilesFunction)
                 {
-                    const auto groupIds = commnandAsJson["groups"].get<std::vector<std::string>>();
+                    if (parameters.empty())
+                        co_return module_command::CommandExecutionResult {
+                            module_command::Status::FAILURE,
+                            "CentralizedConfiguration group set failed, no group list"};
+
+                    const auto parametersAsJson = nlohmann::json::parse(parameters[0]);
+                    const auto groupIds = parametersAsJson.get<std::vector<std::string>>();
 
                     m_setGroupIdFunction(groupIds);
 
@@ -39,7 +44,7 @@ namespace centralized_configuration
                         module_command::Status::FAILURE, "CentralizedConfiguration group set failed, no function set"};
                 }
             }
-            else if (commnandAsJson["command"] == "update-group")
+            else if (command == "update-group")
             {
                 if (m_getGroupIdFunction && m_downloadGroupFilesFunction)
                 {
@@ -64,8 +69,8 @@ namespace centralized_configuration
         }
         catch (const nlohmann::json::exception&)
         {
-            co_return module_command::CommandExecutionResult {module_command::Status::FAILURE,
-                                                              "CentralizedConfiguration error while parsing command"};
+            co_return module_command::CommandExecutionResult {
+                module_command::Status::FAILURE, "CentralizedConfiguration error while parsing parameters"};
         }
 
         co_return module_command::CommandExecutionResult {module_command::Status::FAILURE,

--- a/src/agent/centralized_configuration/tests/centralized_configuration_tests.cpp
+++ b/src/agent/centralized_configuration/tests/centralized_configuration_tests.cpp
@@ -8,6 +8,8 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/use_awaitable.hpp>
 
+#include <nlohmann/json.hpp>
+
 using centralized_configuration::CentralizedConfiguration;
 
 namespace
@@ -15,7 +17,7 @@ namespace
     // NOLINTBEGIN(cppcoreguidelines-avoid-reference-coroutine-parameters)
     boost::asio::awaitable<void> TestExecuteCommand(CentralizedConfiguration& centralizedConfiguration,
                                                     const std::string& command,
-                                                    const std::vector<std::string>& parameters,
+                                                    const nlohmann::json& parameters,
                                                     module_command::Status expectedErrorCode)
     {
         const auto commandResult = co_await centralizedConfiguration.ExecuteCommand(command, parameters);
@@ -96,7 +98,7 @@ TEST(CentralizedConfiguration, ExecuteCommandHandlesRecognizedCommands)
             centralizedConfiguration.SetDownloadGroupFilesFunction([](const std::string&, const std::string&)
                                                                    { return true; });
 
-            const std::vector<std::string> groupsList = {R"(["group1", "group2"])"};
+            const nlohmann::json groupsList = nlohmann::json::parse(R"([["group1", "group2"]])");
 
             co_await TestExecuteCommand(
                 centralizedConfiguration, "set-group", groupsList, module_command::Status::SUCCESS);
@@ -121,7 +123,7 @@ TEST(CentralizedConfiguration, SetFunctionsAreCalledAndReturnsCorrectResultsForS
         {
             CentralizedConfiguration centralizedConfiguration;
 
-            const std::vector<std::string> groupsList = {R"(["group1", "group2"])"};
+            const nlohmann::json groupsList = nlohmann::json::parse(R"([["group1", "group2"]])");
 
             co_await TestExecuteCommand(
                 centralizedConfiguration, "set-group", groupsList, module_command::Status::FAILURE);

--- a/src/agent/command_store/src/command_store.cpp
+++ b/src/agent/command_store/src/command_store.cpp
@@ -4,6 +4,8 @@
 
 #include <chrono>
 
+#include <nlohmann/json.hpp>
+
 namespace command_store
 {
     constexpr double MILLISECS_IN_A_SEC = 1000.0;
@@ -88,7 +90,10 @@ namespace command_store
         fields.emplace_back("module", sqlite_manager::ColumnType::TEXT, cmd.Module);
         fields.emplace_back("command", sqlite_manager::ColumnType::TEXT, cmd.Command);
         fields.emplace_back("time", sqlite_manager::ColumnType::REAL, std::to_string(GetCurrentTimestampAsReal()));
-        fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, cmd.Parameters);
+
+        nlohmann::json serializedJsonArray = cmd.Parameters;
+        fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, serializedJsonArray.dump());
+
         fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.ExecutionResult.Message);
         fields.emplace_back("status",
                             sqlite_manager::ColumnType::INTEGER,
@@ -150,7 +155,8 @@ namespace command_store
                 }
                 else if (col.Name == "parameters")
                 {
-                    cmd.Parameters = col.Value;
+                    const auto deserializedJsonArray = nlohmann::json::parse(col.Value);
+                    cmd.Parameters = deserializedJsonArray.get<decltype(cmd.Parameters)>();
                 }
                 else if (col.Name == "result")
                 {
@@ -182,7 +188,10 @@ namespace command_store
         if (!cmd.Command.empty())
             fields.emplace_back("command", sqlite_manager::ColumnType::TEXT, cmd.Command);
         if (!cmd.Parameters.empty())
-            fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, cmd.Parameters);
+        {
+            const nlohmann::json serializedJsonArray = cmd.Parameters;
+            fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, serializedJsonArray.dump());
+        }
         if (!cmd.ExecutionResult.Message.empty())
             fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.ExecutionResult.Message);
         if (cmd.ExecutionResult.ErrorCode != module_command::Status::UNKNOWN)

--- a/src/agent/command_store/src/command_store.cpp
+++ b/src/agent/command_store/src/command_store.cpp
@@ -90,10 +90,7 @@ namespace command_store
         fields.emplace_back("module", sqlite_manager::ColumnType::TEXT, cmd.Module);
         fields.emplace_back("command", sqlite_manager::ColumnType::TEXT, cmd.Command);
         fields.emplace_back("time", sqlite_manager::ColumnType::REAL, std::to_string(GetCurrentTimestampAsReal()));
-
-        nlohmann::json serializedJsonArray = cmd.Parameters;
-        fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, serializedJsonArray.dump());
-
+        fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, cmd.Parameters.dump());
         fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.ExecutionResult.Message);
         fields.emplace_back("status",
                             sqlite_manager::ColumnType::INTEGER,
@@ -155,8 +152,7 @@ namespace command_store
                 }
                 else if (col.Name == "parameters")
                 {
-                    const auto deserializedJsonArray = nlohmann::json::parse(col.Value);
-                    cmd.Parameters = deserializedJsonArray.get<decltype(cmd.Parameters)>();
+                    cmd.Parameters = nlohmann::json::parse(col.Value);
                 }
                 else if (col.Name == "result")
                 {
@@ -188,10 +184,7 @@ namespace command_store
         if (!cmd.Command.empty())
             fields.emplace_back("command", sqlite_manager::ColumnType::TEXT, cmd.Command);
         if (!cmd.Parameters.empty())
-        {
-            const nlohmann::json serializedJsonArray = cmd.Parameters;
-            fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, serializedJsonArray.dump());
-        }
+            fields.emplace_back("parameters", sqlite_manager::ColumnType::TEXT, cmd.Parameters.dump());
         if (!cmd.ExecutionResult.Message.empty())
             fields.emplace_back("result", sqlite_manager::ColumnType::TEXT, cmd.ExecutionResult.Message);
         if (cmd.ExecutionResult.ErrorCode != module_command::Status::UNKNOWN)

--- a/src/agent/module_command/CMakeLists.txt
+++ b/src/agent/module_command/CMakeLists.txt
@@ -5,6 +5,9 @@ project(ModuleCommand)
 include(../../cmake/CommonSettings.cmake)
 set_common_settings()
 
+find_package(nlohmann_json REQUIRED)
+
 add_library(ModuleCommand INTERFACE)
 
 target_include_directories(ModuleCommand INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(ModuleCommand INTERFACE nlohmann_json::nlohmann_json)

--- a/src/agent/module_command/include/module_command/command_entry.hpp
+++ b/src/agent/module_command/include/module_command/command_entry.hpp
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <string>
+#include <vector>
 
 namespace module_command
 {
@@ -39,7 +40,7 @@ namespace module_command
         CommandEntry(std::string id,
                      std::string module,
                      std::string command,
-                     std::string parameters,
+                     std::vector<std::string> parameters,
                      std::string result,
                      Status status)
             : Id(std::move(id))
@@ -54,7 +55,7 @@ namespace module_command
         std::string Id;
         std::string Module;
         std::string Command;
-        std::string Parameters;
+        std::vector<std::string> Parameters;
         double Time;
         CommandExecutionResult ExecutionResult;
     };

--- a/src/agent/module_command/include/module_command/command_entry.hpp
+++ b/src/agent/module_command/include/module_command/command_entry.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <nlohmann/json.hpp>
+
 #include <limits>
 #include <string>
-#include <vector>
 
 namespace module_command
 {
@@ -40,7 +41,7 @@ namespace module_command
         CommandEntry(std::string id,
                      std::string module,
                      std::string command,
-                     std::vector<std::string> parameters,
+                     nlohmann::json parameters,
                      std::string result,
                      Status status)
             : Id(std::move(id))
@@ -55,7 +56,7 @@ namespace module_command
         std::string Id;
         std::string Module;
         std::string Command;
-        std::vector<std::string> Parameters;
+        nlohmann::json Parameters;
         double Time;
         CommandExecutionResult ExecutionResult;
     };

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -71,8 +71,8 @@ void Agent::Run()
             {
                 return DispatchCommand(
                     cmd,
-                    [this](std::string command)
-                    { return m_centralizedConfiguration.ExecuteCommand(std::move(command)); },
+                    [this](std::string command, std::vector<std::string> parameters)
+                    { return m_centralizedConfiguration.ExecuteCommand(std::move(command), std::move(parameters)); },
                     m_messageQueue);
             }
             return DispatchCommand(cmd, m_moduleManager.GetModule(cmd.Module), m_messageQueue);

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -71,7 +71,7 @@ void Agent::Run()
             {
                 return DispatchCommand(
                     cmd,
-                    [this](std::string command, std::vector<std::string> parameters)
+                    [this](std::string command, nlohmann::json parameters)
                     { return m_centralizedConfiguration.ExecuteCommand(std::move(command), std::move(parameters)); },
                     m_messageQueue);
             }

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -7,6 +7,8 @@
 #include <boost/system/system_error.hpp>
 #include <logger.hpp>
 
+#include <nlohmann/json.hpp>
+
 #include <chrono>
 #include <functional>
 
@@ -68,7 +70,7 @@ namespace
 boost::asio::awaitable<module_command::CommandExecutionResult>
 DispatchCommand(module_command::CommandEntry commandEntry,
                 std::function<boost::asio::awaitable<module_command::CommandExecutionResult>(
-                    std::string command, std::vector<std::string> parameters)> executeFunction,
+                    std::string command, nlohmann::json parameters)> executeFunction,
                 std::shared_ptr<IMultiTypeQueue> messageQueue)
 {
     using namespace boost::asio::experimental::awaitable_operators;
@@ -107,8 +109,7 @@ DispatchCommand(module_command::CommandEntry commandEntry,
         co_return module_command::CommandExecutionResult {module_command::Status::FAILURE, "Module not found"};
     }
 
-    auto moduleExecuteFunction = [module](const std::string& command,
-                                          [[maybe_unused]] const std::vector<std::string>& parameters)
+    auto moduleExecuteFunction = [module](const std::string& command, [[maybe_unused]] const nlohmann::json& parameters)
         -> boost::asio::awaitable<module_command::CommandExecutionResult>
     {
         return module->ExecuteCommand(command);

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -7,8 +7,6 @@
 #include <boost/system/system_error.hpp>
 #include <logger.hpp>
 
-#include <nlohmann/json.hpp>
-
 #include <chrono>
 #include <functional>
 

--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -107,10 +107,11 @@ DispatchCommand(module_command::CommandEntry commandEntry,
         co_return module_command::CommandExecutionResult {module_command::Status::FAILURE, "Module not found"};
     }
 
-    auto moduleExecuteFunction = [module](const std::string& command, [[maybe_unused]] const nlohmann::json& parameters)
-        -> boost::asio::awaitable<module_command::CommandExecutionResult>
+    auto moduleExecuteFunction =
+        [module](const std::string& command,
+                 const nlohmann::json& parameters) -> boost::asio::awaitable<module_command::CommandExecutionResult>
     {
-        return module->ExecuteCommand(command);
+        return module->ExecuteCommand(command, parameters);
     };
 
     co_return co_await DispatchCommand(commandEntry, moduleExecuteFunction, messageQueue);

--- a/src/agent/src/command_handler_utils.hpp
+++ b/src/agent/src/command_handler_utils.hpp
@@ -10,12 +10,11 @@
 #include <functional>
 #include <memory>
 #include <tuple>
-#include <vector>
 
 boost::asio::awaitable<module_command::CommandExecutionResult>
 DispatchCommand(module_command::CommandEntry commandEntry,
                 std::function<boost::asio::awaitable<module_command::CommandExecutionResult>(
-                    std::string command, std::vector<std::string> parameters)> executeFunction,
+                    std::string command, nlohmann::json parameters)> executeFunction,
                 std::shared_ptr<IMultiTypeQueue> messageQueue);
 
 boost::asio::awaitable<module_command::CommandExecutionResult>

--- a/src/agent/src/command_handler_utils.hpp
+++ b/src/agent/src/command_handler_utils.hpp
@@ -10,11 +10,13 @@
 #include <functional>
 #include <memory>
 #include <tuple>
+#include <vector>
 
-boost::asio::awaitable<module_command::CommandExecutionResult> DispatchCommand(
-    module_command::CommandEntry commandEntry,
-    std::function<boost::asio::awaitable<module_command::CommandExecutionResult>(std::string command)> executeFunction,
-    std::shared_ptr<IMultiTypeQueue> messageQueue);
+boost::asio::awaitable<module_command::CommandExecutionResult>
+DispatchCommand(module_command::CommandEntry commandEntry,
+                std::function<boost::asio::awaitable<module_command::CommandExecutionResult>(
+                    std::string command, std::vector<std::string> parameters)> executeFunction,
+                std::shared_ptr<IMultiTypeQueue> messageQueue);
 
 boost::asio::awaitable<module_command::CommandExecutionResult>
 DispatchCommand(module_command::CommandEntry commandEntry,

--- a/src/agent/src/command_handler_utils.hpp
+++ b/src/agent/src/command_handler_utils.hpp
@@ -7,6 +7,8 @@
 
 #include <boost/asio/awaitable.hpp>
 
+#include <nlohmann/json.hpp>
+
 #include <functional>
 #include <memory>
 #include <tuple>

--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -59,7 +59,7 @@ std::optional<module_command::CommandEntry> GetCommandFromQueue(std::shared_ptr<
     std::string id;
     std::string module;
     std::string command;
-    std::string parameters;
+    std::vector<std::string> parameters;
 
     if (jsonData.contains("id") && jsonData["id"].is_string())
     {
@@ -81,11 +81,7 @@ std::optional<module_command::CommandEntry> GetCommandFromQueue(std::shared_ptr<
                     if (arg.is_string())
                         command = arg.get<std::string>();
                     break;
-                default:
-                    if (!parameters.empty())
-                        parameters += " ";
-                    parameters += arg.is_string() ? arg.get<std::string>() : arg.dump();
-                    break;
+                default: parameters.push_back(arg.dump()); break;
             }
         }
     }

--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -59,7 +59,7 @@ std::optional<module_command::CommandEntry> GetCommandFromQueue(std::shared_ptr<
     std::string id;
     std::string module;
     std::string command;
-    std::vector<std::string> parameters;
+    nlohmann::json parameters = nlohmann::json::array();
 
     if (jsonData.contains("id") && jsonData["id"].is_string())
     {
@@ -81,7 +81,7 @@ std::optional<module_command::CommandEntry> GetCommandFromQueue(std::shared_ptr<
                     if (arg.is_string())
                         command = arg.get<std::string>();
                     break;
-                default: parameters.push_back(arg.dump()); break;
+                default: parameters.push_back(arg); break;
             }
         }
     }

--- a/src/agent/tests/message_queue_utils_test.cpp
+++ b/src/agent/tests/message_queue_utils_test.cpp
@@ -118,7 +118,8 @@ TEST_F(MessageQueueUtilsTest, GetCommandFromQueueTest)
     ASSERT_EQ(cmd.has_value() ? cmd.value().Id : "", "112233");
     ASSERT_EQ(cmd.has_value() ? cmd.value().Module : "", "origin_test");
     ASSERT_EQ(cmd.has_value() ? cmd.value().Command : "", "command_test");
-    ASSERT_EQ(cmd.has_value() ? cmd.value().Parameters : "", "parameters_test");
+    ASSERT_EQ(cmd.has_value() ? cmd.value().Parameters : std::vector<std::string> {""},
+              std::vector<std::string> {"\"parameters_test\""});
     ASSERT_EQ(cmd.has_value() ? cmd.value().ExecutionResult.ErrorCode : module_command::Status::UNKNOWN,
               module_command::Status::IN_PROGRESS);
 }

--- a/src/agent/tests/message_queue_utils_test.cpp
+++ b/src/agent/tests/message_queue_utils_test.cpp
@@ -118,8 +118,8 @@ TEST_F(MessageQueueUtilsTest, GetCommandFromQueueTest)
     ASSERT_EQ(cmd.has_value() ? cmd.value().Id : "", "112233");
     ASSERT_EQ(cmd.has_value() ? cmd.value().Module : "", "origin_test");
     ASSERT_EQ(cmd.has_value() ? cmd.value().Command : "", "command_test");
-    ASSERT_EQ(cmd.has_value() ? cmd.value().Parameters : std::vector<std::string> {""},
-              std::vector<std::string> {"\"parameters_test\""});
+    ASSERT_EQ(cmd.has_value() ? cmd.value().Parameters : nlohmann::json::array({""}),
+              nlohmann::json::array({"parameters_test"}));
     ASSERT_EQ(cmd.has_value() ? cmd.value().ExecutionResult.ErrorCode : module_command::Status::UNKNOWN,
               module_command::Status::IN_PROGRESS);
 }

--- a/src/modules/include/moduleManager.hpp
+++ b/src/modules/include/moduleManager.hpp
@@ -33,9 +33,9 @@ public:
             .Start = [&module]() { module.Start(); },
             .Setup = [&module](const configuration::ConfigurationParser& configurationParser) { module.Setup(configurationParser); },
             .Stop = [&module]() { module.Stop(); },
-            .ExecuteCommand = [&module](std::string query, nlohmann::json parameters) -> Co_CommandExecutionResult
+            .ExecuteCommand = [&module](std::string command, nlohmann::json parameters) -> Co_CommandExecutionResult
             {
-                co_return co_await module.ExecuteCommand(query, parameters);
+                co_return co_await module.ExecuteCommand(command, parameters);
             },
             .Name = [&module]() { return module.Name(); }
         });

--- a/src/modules/include/moduleManager.hpp
+++ b/src/modules/include/moduleManager.hpp
@@ -33,9 +33,9 @@ public:
             .Start = [&module]() { module.Start(); },
             .Setup = [&module](const configuration::ConfigurationParser& configurationParser) { module.Setup(configurationParser); },
             .Stop = [&module]() { module.Stop(); },
-            .ExecuteCommand = [&module](std::string query) -> Co_CommandExecutionResult
+            .ExecuteCommand = [&module](std::string query, nlohmann::json parameters) -> Co_CommandExecutionResult
             {
-                co_return co_await module.ExecuteCommand(query);
+                co_return co_await module.ExecuteCommand(query, parameters);
             },
             .Name = [&module]() { return module.Name(); }
         });

--- a/src/modules/include/moduleWrapper.hpp
+++ b/src/modules/include/moduleWrapper.hpp
@@ -5,6 +5,8 @@
 
 #include <boost/asio/awaitable.hpp>
 
+#include <nlohmann/json.hpp>
+
 #include <functional>
 #include <string>
 
@@ -14,6 +16,6 @@ struct ModuleWrapper {
     std::function<void()> Start;
     std::function<void(const configuration::ConfigurationParser&)> Setup;
     std::function<void()> Stop;
-    std::function<Co_CommandExecutionResult(std::string)> ExecuteCommand;
+    std::function<Co_CommandExecutionResult(std::string, nlohmann::json)> ExecuteCommand;
     std::function<std::string()> Name;
 };

--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -29,7 +29,7 @@ class Inventory {
         void Start();
         void Setup(const configuration::ConfigurationParser& configurationParser);
         void Stop();
-        Co_CommandExecutionResult ExecuteCommand(const std::string query, [[maybe_unused]] const nlohmann::json parameters);
+        Co_CommandExecutionResult ExecuteCommand(const std::string command, const nlohmann::json parameters);
         const std::string& Name() const { return m_moduleName; };
         void SetPushMessageFunction(const std::function<int(Message)>& pushMessage);
 

--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -29,7 +29,7 @@ class Inventory {
         void Start();
         void Setup(const configuration::ConfigurationParser& configurationParser);
         void Stop();
-        Co_CommandExecutionResult ExecuteCommand(const std::string query);
+        Co_CommandExecutionResult ExecuteCommand(const std::string query, [[maybe_unused]] const nlohmann::json parameters);
         const std::string& Name() const { return m_moduleName; };
         void SetPushMessageFunction(const std::function<int(Message)>& pushMessage);
 

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -57,7 +57,7 @@ void Inventory::Stop() {
 }
 
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
-Co_CommandExecutionResult Inventory::ExecuteCommand(const std::string query) {
+Co_CommandExecutionResult Inventory::ExecuteCommand(const std::string query, [[maybe_unused]] const nlohmann::json parameters) {
     LogInfo("Query: {}", query);
     co_return module_command::CommandExecutionResult{module_command::Status::SUCCESS, "OK"};
 }

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -57,8 +57,8 @@ void Inventory::Stop() {
 }
 
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
-Co_CommandExecutionResult Inventory::ExecuteCommand(const std::string query, [[maybe_unused]] const nlohmann::json parameters) {
-    LogInfo("Query: {}", query);
+Co_CommandExecutionResult Inventory::ExecuteCommand(const std::string command, [[maybe_unused]] const nlohmann::json parameters) {
+    LogInfo("Command: {}", command);
     co_return module_command::CommandExecutionResult{module_command::Status::SUCCESS, "OK"};
 }
 

--- a/src/modules/logcollector/include/logcollector.hpp
+++ b/src/modules/logcollector/include/logcollector.hpp
@@ -30,8 +30,9 @@ public:
 
     /// @brief Executes a command
     /// @param query Command to execute
+    /// @param parameters A json object containing the parameters of the command to be executed
     /// @return Awaitable (coroutine) which will return the result of the command execution
-    Co_CommandExecutionResult ExecuteCommand(const std::string query);
+    Co_CommandExecutionResult ExecuteCommand(const std::string query, [[maybe_unused]] const nlohmann::json parameters);
 
     /// @brief Gets the name of the Logcollector module
     /// @return Name of the module

--- a/src/modules/logcollector/include/logcollector.hpp
+++ b/src/modules/logcollector/include/logcollector.hpp
@@ -29,10 +29,10 @@ public:
     void Stop();
 
     /// @brief Executes a command
-    /// @param query Command to execute
+    /// @param command Command to execute
     /// @param parameters A json object containing the parameters of the command to be executed
     /// @return Awaitable (coroutine) which will return the result of the command execution
-    Co_CommandExecutionResult ExecuteCommand(const std::string query, [[maybe_unused]] const nlohmann::json parameters);
+    Co_CommandExecutionResult ExecuteCommand(const std::string command, const nlohmann::json parameters);
 
     /// @brief Gets the name of the Logcollector module
     /// @return Name of the module

--- a/src/modules/logcollector/src/logcollector.cpp
+++ b/src/modules/logcollector/src/logcollector.cpp
@@ -65,8 +65,8 @@ void Logcollector::Stop() {
 }
 
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
-Co_CommandExecutionResult Logcollector::ExecuteCommand(const std::string query, [[maybe_unused]] const nlohmann::json parameters) {
-    LogInfo("Logcollector query: ", query);
+Co_CommandExecutionResult Logcollector::ExecuteCommand(const std::string command, [[maybe_unused]] const nlohmann::json parameters) {
+    LogInfo("Logcollector command: ", command);
     co_return module_command::CommandExecutionResult{module_command::Status::SUCCESS, "OK"};
 }
 

--- a/src/modules/logcollector/src/logcollector.cpp
+++ b/src/modules/logcollector/src/logcollector.cpp
@@ -65,7 +65,7 @@ void Logcollector::Stop() {
 }
 
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
-Co_CommandExecutionResult Logcollector::ExecuteCommand(const std::string query) {
+Co_CommandExecutionResult Logcollector::ExecuteCommand(const std::string query, [[maybe_unused]] const nlohmann::json parameters) {
     LogInfo("Logcollector query: ", query);
     co_return module_command::CommandExecutionResult{module_command::Status::SUCCESS, "OK"};
 }

--- a/src/modules/tests/moduleManager_test.cpp
+++ b/src/modules/tests/moduleManager_test.cpp
@@ -8,7 +8,7 @@ public:
     MOCK_METHOD(void, Start, (), ());
     MOCK_METHOD(void, Setup, (const configuration::ConfigurationParser&), ());
     MOCK_METHOD(void, Stop, (), ());
-    MOCK_METHOD(boost::asio::awaitable<module_command::CommandExecutionResult>, ExecuteCommand, (const std::string&), ());
+    MOCK_METHOD(boost::asio::awaitable<module_command::CommandExecutionResult>, ExecuteCommand, (const std::string&, const nlohmann::json&), ());
     MOCK_METHOD(std::string, Name, (), (const));
     MOCK_METHOD(void, SetPushMessageFunction, (const std::function<int(Message)>));
 };


### PR DESCRIPTION
|Related issue|
|---|
|#234|


## Description

This PR allows the CentralizedConfiguration component to receive the parameter list(group list) for command execution.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X