### PR TITLE
Fix crash hazard in Inventory module

### DIFF
--- a/src/common/data_provider/src/sysInfoLinux.cpp
+++ b/src/common/data_provider/src/sysInfoLinux.cpp
@@ -435,9 +435,9 @@ ProcessInfo portProcessInfo(const std::string& procPath, const std::deque<int64_
     auto findInode = [](const std::string & filePath) -> int64_t
     {
         constexpr size_t MAX_LENGTH {256};
-        char buffer[MAX_LENGTH];
+        char buffer[MAX_LENGTH] = "";
 
-        if (-1 == readlink(filePath.c_str(), buffer, MAX_LENGTH))
+        if (-1 == readlink(filePath.c_str(), buffer, MAX_LENGTH - 1))
         {
             throw std::system_error(errno, std::system_category(), "readlink");
         }

--- a/src/common/hashHelper/include/hashHelper.h
+++ b/src/common/hashHelper/include/hashHelper.h
@@ -107,6 +107,14 @@ namespace Utils
             }
             static void initializeContext(const HashType hashType, std::unique_ptr<EVP_MD_CTX, EvpContextDeleter>& spCtx)
             {
+                static auto cryptoInitialized { false };
+
+                if (!cryptoInitialized)
+                {
+                    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS | OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_NO_ATEXIT, nullptr);
+                    cryptoInitialized = true;
+                }
+
                 auto ret{0};
 
                 switch (hashType)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/26488|

This is a port of PR:
- https://github.com/wazuh/wazuh/pull/26647

It aims to fix the following bugs that may lead the agent to crash:

1. The hashing functions, which rely on OpenSSL (Crypto), delegate automatic initialization. This initialization installs a cleanup trigger for program shutdown. When this cleanup is executed, some threads may still be using OpenSSL, and this causes a segmentation fault.
   **Fix:** Manually initialize OpenSSL, and disable the cleanup trigger.
2. The DataProvider component (used by Inventory) has an uninitialized buffer, which can lead to buffer overrun.
   **Fix:** Zero-initialize the buffer.