### PR TITLE
Fix compilation errors due to the linker

### DIFF
--- a/src/common/data_provider/CMakeLists.txt
+++ b/src/common/data_provider/CMakeLists.txt
@@ -184,8 +184,7 @@ endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 target_link_libraries(sysinfo PUBLIC
   networkHelper
   nlohmann_json::nlohmann_json
-  cjson
-  unofficial::sqlite3::sqlite3)
+  cjson)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   find_library(POPT_LIBRARY libpopt.a)
@@ -203,6 +202,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     ${LUA_LIBRARIES}
   )
 endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+
+target_link_libraries(sysinfo PUBLIC
+  unofficial::sqlite3::sqlite3)
 
 if(BUILD_TESTS)
   if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")


### PR DESCRIPTION
## Description

This PR reorders the target linked libraries in the data provider compilation to avoid problems using different linkers.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade