### PR TITLE
Make logs friendlier when agent fails to connect to the manager

### DIFF
--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -47,6 +47,7 @@ namespace communicator
         std::mutex m_reAuthMutex;
         std::atomic<bool> m_isReAuthenticating = false;
 
+        long m_retryIntervalSecs = 30;
         std::string m_serverUrl;
         std::string m_registrationUrl;
         std::string m_uuid;

--- a/src/agent/communicator/include/http_client.hpp
+++ b/src/agent/communicator/include/http_client.hpp
@@ -28,6 +28,7 @@ namespace http_client
                               HttpRequestParams params,
                               std::function<boost::asio::awaitable<std::string>()> messageGetter,
                               std::function<void()> onUnauthorized,
+                              long connectionRetrySecs,
                               std::function<void(const std::string&)> onSuccess = {},
                               std::function<bool()> loopRequestCondition = {}) override;
 

--- a/src/agent/communicator/include/ihttp_client.hpp
+++ b/src/agent/communicator/include/ihttp_client.hpp
@@ -26,6 +26,7 @@ namespace http_client
                               HttpRequestParams params,
                               std::function<boost::asio::awaitable<std::string>()> messageGetter,
                               std::function<void()> onUnauthorized,
+                              long connectionRetrySecs,
                               std::function<void(const std::string&)> onSuccess = {},
                               std::function<bool()> loopRequestCondition = {}) = 0;
 

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -16,7 +16,8 @@
 namespace communicator
 {
     constexpr int TOKEN_PRE_EXPIRY_SECS = 2;
-    constexpr int A_SECOND_IN_MILLIS = 1000;
+    constexpr int CONNECTION_RETRY_MSECS = 30000;
+    constexpr int A_SEC_IN_MSECS = 1000;
 
     Communicator::Communicator(std::unique_ptr<http_client::IHttpClient> httpClient,
                                std::string uuid,
@@ -108,12 +109,12 @@ namespace communicator
                 const auto result = SendAuthenticationRequest();
                 if (result != boost::beast::http::status::ok)
                 {
-                    return std::chrono::milliseconds(A_SECOND_IN_MILLIS);
+                    return std::chrono::milliseconds(CONNECTION_RETRY_MSECS);
                 }
                 else
                 {
                     return std::chrono::milliseconds((GetTokenRemainingSecs() - TOKEN_PRE_EXPIRY_SECS) *
-                                                     A_SECOND_IN_MILLIS);
+                                                     A_SEC_IN_MSECS);
                 }
             }();
 

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -95,7 +95,7 @@ namespace communicator
         const auto reqParams =
             http_client::HttpRequestParams(boost::beast::http::verb::get, m_serverUrl, "/api/v1/commands");
         co_await m_httpClient->Co_PerformHttpRequest(
-            m_token, reqParams, {}, onAuthenticationFailed, onSuccess, loopCondition);
+            m_token, reqParams, {}, onAuthenticationFailed, m_retryIntervalSecs, onSuccess, loopCondition);
     }
 
     boost::asio::awaitable<void> Communicator::WaitForTokenExpirationAndAuthenticate()
@@ -156,7 +156,7 @@ namespace communicator
         const auto reqParams =
             http_client::HttpRequestParams(boost::beast::http::verb::post, m_serverUrl, "/api/v1/events/stateful");
         co_await m_httpClient->Co_PerformHttpRequest(
-            m_token, reqParams, getMessages, onAuthenticationFailed, onSuccess, loopCondition);
+            m_token, reqParams, getMessages, onAuthenticationFailed, m_retryIntervalSecs, onSuccess, loopCondition);
     }
 
     boost::asio::awaitable<void>
@@ -176,7 +176,7 @@ namespace communicator
         const auto reqParams =
             http_client::HttpRequestParams(boost::beast::http::verb::post, m_serverUrl, "/api/v1/events/stateless");
         co_await m_httpClient->Co_PerformHttpRequest(
-            m_token, reqParams, getMessages, onAuthenticationFailed, onSuccess, loopCondition);
+            m_token, reqParams, getMessages, onAuthenticationFailed, m_retryIntervalSecs, onSuccess, loopCondition);
     }
 
     void Communicator::TryReAuthenticate()

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -16,8 +16,7 @@
 namespace communicator
 {
     constexpr int TOKEN_PRE_EXPIRY_SECS = 2;
-    constexpr int CONNECTION_RETRY_MSECS = 30000;
-    constexpr int A_SEC_IN_MSECS = 1000;
+    constexpr int A_SECOND_IN_MILLIS = 1000;
 
     Communicator::Communicator(std::unique_ptr<http_client::IHttpClient> httpClient,
                                std::string uuid,
@@ -36,6 +35,8 @@ namespace communicator
             {
                 LogInfo("Using insecure connection.");
             }
+
+            m_retryIntervalSecs = std::stol(getStringConfigValue("agent", "retry_interval_secs"));
         }
     }
 
@@ -50,8 +51,7 @@ namespace communicator
         }
         else
         {
-            LogWarn("Failed to authenticate with the manager. Retrying in {} seconds",
-                    CONNECTION_RETRY_MSECS / A_SEC_IN_MSECS);
+            LogWarn("Failed to authenticate with the manager. Retrying in {} seconds", m_retryIntervalSecs);
             return boost::beast::http::status::unauthorized;
         }
 
@@ -111,12 +111,12 @@ namespace communicator
                 const auto result = SendAuthenticationRequest();
                 if (result != boost::beast::http::status::ok)
                 {
-                    return std::chrono::milliseconds(CONNECTION_RETRY_MSECS);
+                    return std::chrono::milliseconds(A_SECOND_IN_MILLIS);
                 }
                 else
                 {
                     return std::chrono::milliseconds((GetTokenRemainingSecs() - TOKEN_PRE_EXPIRY_SECS) *
-                                                     A_SEC_IN_MSECS);
+                                                     A_SECOND_IN_MILLIS);
                 }
             }();
 

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -46,10 +46,12 @@ namespace communicator
         if (token.has_value())
         {
             *m_token = token.value();
+            LogInfo("Successfully authenticated with the manager.");
         }
         else
         {
-            LogError("Failed to authenticate with the manager.");
+            LogWarn("Failed to authenticate with the manager. Retrying in {} seconds",
+                    CONNECTION_RETRY_MSECS / A_SEC_IN_MSECS);
             return boost::beast::http::status::unauthorized;
         }
 

--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -13,6 +13,8 @@
 
 namespace http_client
 {
+    constexpr int CONNECTION_RETRY_MSECS = 5000;
+
     HttpClient::HttpClient(std::shared_ptr<IHttpResolverFactory> resolverFactory,
                            std::shared_ptr<IHttpSocketFactory> socketFactory)
     {
@@ -93,7 +95,7 @@ namespace http_client
             {
                 LogError("Connect failed: {}.", code.message());
                 socket->Close();
-                const auto duration = std::chrono::milliseconds(1000);
+                const auto duration = std::chrono::milliseconds(CONNECTION_RETRY_MSECS);
                 timer.expires_after(duration);
                 co_await timer.async_wait(boost::asio::use_awaitable);
                 continue;
@@ -150,7 +152,7 @@ namespace http_client
             LogDebug("Response code: {}.", res.result_int());
             LogDebug("Response body: {}.", boost::beast::buffers_to_string(res.body().data()));
 
-            const auto duration = std::chrono::milliseconds(1000);
+            const auto duration = std::chrono::milliseconds(CONNECTION_RETRY_MSECS);
             timer.expires_after(duration);
             co_await timer.async_wait(boost::asio::use_awaitable);
         } while (loopRequestCondition != nullptr && loopRequestCondition());

--- a/src/agent/communicator/tests/communicator_test.cpp
+++ b/src/agent/communicator/tests/communicator_test.cpp
@@ -54,12 +54,13 @@ TEST(CommunicatorTest, StatefulMessageProcessingTask_Success)
         EXPECT_EQ(message, "message-content");
     };
 
-    EXPECT_CALL(*mockHttpClient, Co_PerformHttpRequest(_, _, _, _, _, _))
+    EXPECT_CALL(*mockHttpClient, Co_PerformHttpRequest(_, _, _, _, _, _, _))
         .WillOnce(Invoke(
             [](std::shared_ptr<std::string>,
                http_client::HttpRequestParams,
                std::function<boost::asio::awaitable<std::string>()> pGetMessages,
                std::function<void()>,
+               [[maybe_unused]] long connectionRetrySecs,
                std::function<void(const std::string&)> pOnSuccess,
                [[maybe_unused]] std::function<bool()> loopRequestCondition) -> boost::asio::awaitable<void>
             {
@@ -99,12 +100,13 @@ TEST(CommunicatorTest, WaitForTokenExpirationAndAuthenticate_FailedAuthenticatio
             }));
 
     // A following call to Co_PerformHttpRequest should not have a token
-    EXPECT_CALL(*mockHttpClientPtr, Co_PerformHttpRequest(_, _, _, _, _, _))
+    EXPECT_CALL(*mockHttpClientPtr, Co_PerformHttpRequest(_, _, _, _, _, _, _))
         .WillOnce(Invoke(
             [](std::shared_ptr<std::string> token,
                http_client::HttpRequestParams,
                [[maybe_unused]] std::function<boost::asio::awaitable<std::string>()> getMessages,
                [[maybe_unused]] std::function<void()> onUnauthorized,
+               [[maybe_unused]] long connectionRetrySecs,
                [[maybe_unused]] std::function<void(const std::string&)> onSuccess,
                [[maybe_unused]] std::function<bool()> loopCondition) -> boost::asio::awaitable<void>
             {
@@ -148,12 +150,13 @@ TEST(CommunicatorTest, StatelessMessageProcessingTask_CallsWithValidToken)
     EXPECT_CALL(*mockHttpClientPtr, AuthenticateWithUuidAndKey(_, _, _)).WillOnce(Return(mockedToken));
 
     std::string capturedToken;
-    EXPECT_CALL(*mockHttpClientPtr, Co_PerformHttpRequest(_, _, _, _, _, _))
+    EXPECT_CALL(*mockHttpClientPtr, Co_PerformHttpRequest(_, _, _, _, _, _, _))
         .WillOnce(Invoke(
             [&capturedToken](std::shared_ptr<std::string> token,
                              http_client::HttpRequestParams,
                              [[maybe_unused]] std::function<boost::asio::awaitable<std::string>()> getMessages,
                              [[maybe_unused]] std::function<void()> onUnauthorized,
+                             [[maybe_unused]] long connectionRetrySecs,
                              [[maybe_unused]] std::function<void(const std::string&)> onSuccess,
                              [[maybe_unused]] std::function<bool()> loopCondition) -> boost::asio::awaitable<void>
             {

--- a/src/agent/communicator/tests/http_client_test.cpp
+++ b/src/agent/communicator/tests/http_client_test.cpp
@@ -220,8 +220,13 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_Success)
 
     const auto reqParams = http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/");
 
-    auto task = client->Co_PerformHttpRequest(
-        std::make_shared<std::string>("token"), reqParams, getMessages, onUnauthorized, onSuccess, nullptr);
+    auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
+                                              reqParams,
+                                              getMessages,
+                                              onUnauthorized,
+                                              5, // NOLINT
+                                              onSuccess,
+                                              nullptr);
 
     boost::asio::io_context ioContext;
     boost::asio::co_spawn(ioContext, std::move(task), boost::asio::detached);
@@ -260,8 +265,13 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_CallbacksNotCalledIfCannotConnect)
     };
 
     const auto reqParams = http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/");
-    auto task = client->Co_PerformHttpRequest(
-        std::make_shared<std::string>("token"), reqParams, getMessages, onUnauthorized, onSuccess, nullptr);
+    auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
+                                              reqParams,
+                                              getMessages,
+                                              onUnauthorized,
+                                              5, // NOLINT
+                                              onSuccess,
+                                              nullptr);
 
     boost::asio::io_context ioContext;
     boost::asio::co_spawn(ioContext, std::move(task), boost::asio::detached);
@@ -301,8 +311,13 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncWriteFails
     };
 
     const auto reqParams = http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/");
-    auto task = client->Co_PerformHttpRequest(
-        std::make_shared<std::string>("token"), reqParams, getMessages, onUnauthorized, onSuccess, nullptr);
+    auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
+                                              reqParams,
+                                              getMessages,
+                                              onUnauthorized,
+                                              5, // NOLINT
+                                              onSuccess,
+                                              nullptr);
 
     boost::asio::io_context ioContext;
     boost::asio::co_spawn(ioContext, std::move(task), boost::asio::detached);
@@ -344,8 +359,13 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncReadFails)
     };
 
     const auto reqParams = http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/");
-    auto task = client->Co_PerformHttpRequest(
-        std::make_shared<std::string>("token"), reqParams, getMessages, onUnauthorized, onSuccess, nullptr);
+    auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
+                                              reqParams,
+                                              getMessages,
+                                              onUnauthorized,
+                                              5, // NOLINT
+                                              onSuccess,
+                                              nullptr);
 
     boost::asio::io_context ioContext;
     boost::asio::co_spawn(ioContext, std::move(task), boost::asio::detached);
@@ -386,8 +406,13 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_UnauthorizedCalledWhenAuthorization
     };
 
     const auto reqParams = http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/");
-    auto task = client->Co_PerformHttpRequest(
-        std::make_shared<std::string>("token"), reqParams, getMessages, onUnauthorized, onSuccess, nullptr);
+    auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
+                                              reqParams,
+                                              getMessages,
+                                              onUnauthorized,
+                                              5, // NOLINT
+                                              onSuccess,
+                                              nullptr);
 
     boost::asio::io_context ioContext;
     boost::asio::co_spawn(ioContext, std::move(task), boost::asio::detached);

--- a/src/agent/communicator/tests/mocks/mock_http_client.hpp
+++ b/src/agent/communicator/tests/mocks/mock_http_client.hpp
@@ -16,6 +16,7 @@ public:
                  http_client::HttpRequestParams params,
                  std::function<boost::asio::awaitable<std::string>()> messageGetter,
                  std::function<void()> onUnauthorized,
+                 long connectionRetrySecs,
                  std::function<void(const std::string&)> onSuccess,
                  std::function<bool()> loopRequestCondition),
                 (override));

--- a/src/agent/configuration_parser/src/configuration_parser.cpp
+++ b/src/agent/configuration_parser/src/configuration_parser.cpp
@@ -23,6 +23,7 @@ namespace configuration
                 agent:
                     server_url: https://localhost:27000
                     registration_url: https://localhost:55000
+                    retry_interval_secs: 30
                 inventory:
                     enabled: true
                     interval: 3600

--- a/src/agent/src/process_options_unix.cpp
+++ b/src/agent/src/process_options_unix.cpp
@@ -23,11 +23,17 @@ void RestartAgent(const std::string& configFile)
 void StartAgent([[maybe_unused]] const std::string& configFile)
 {
     pid_t pid = unix_daemon::PIDFileHandler::ReadPIDFromFile();
-    if (pid != 0)
+    if (pid > 0)
     {
         std::cout << "wazuh-agent already running\n";
         return;
     }
+    else if (pid < 0)
+    {
+        std::cout << "Error reading pid file\n";
+        return;
+    }
+
     LogInfo("Starting wazuh-agent");
     unix_daemon::PIDFileHandler handler = unix_daemon::GeneratePIDFile();
     Agent agent(configFile);
@@ -43,6 +49,13 @@ void StopAgent()
 {
     LogInfo("Stopping wazuh-agent");
     pid_t pid = unix_daemon::PIDFileHandler::ReadPIDFromFile();
+
+    if (pid < 0)
+    {
+        std::cout << "Error reading pid file\n";
+        return;
+    }
+
     if (!kill(pid, SIGTERM))
     {
         LogInfo("Wazuh-agent terminated");

--- a/src/agent/src/unix_daemon.cpp
+++ b/src/agent/src/unix_daemon.cpp
@@ -86,7 +86,6 @@ namespace unix_daemon
 
         if (!file.is_open())
         {
-            LogCritical("Error opening file: {}({}) {}", filename.c_str(), errno, std::strerror(errno));
             return 0;
         }
 
@@ -95,8 +94,8 @@ namespace unix_daemon
 
         if (file.fail())
         {
-            LogCritical("Error reading PID file: {}({})", filename.c_str(), errno, std::strerror(errno));
-            return 0;
+            LogError("Error reading PID file: {}({})", filename.c_str(), errno, std::strerror(errno));
+            return -1;
         }
 
         return value;

--- a/src/agent/src/unix_daemon.hpp
+++ b/src/agent/src/unix_daemon.hpp
@@ -6,9 +6,11 @@
 
 namespace unix_daemon
 {
+    /// @brief A class for handling PID files.
     class PIDFileHandler
     {
     public:
+        /// @brief Constructor for the PIDFileHandler class.
         PIDFileHandler();
         ~PIDFileHandler();
 
@@ -18,16 +20,34 @@ namespace unix_daemon
         PIDFileHandler(PIDFileHandler&&) = default;
         PIDFileHandler& operator=(PIDFileHandler&&) = default;
 
+        /// @brief Reads the PID file and returns its value.
+        /// @return The value read from the PID file or 0 if the file does not exist.
         static pid_t ReadPIDFromFile();
 
     private:
+        /// @brief Creates a directory relative to the current path.
+        /// @param relativePath  the path of the directory to create.
+        /// @return True if the directory was created successfully, false otherwise.
         bool createDirectory(const std::string_view relativePath) const;
+
+        /// @brief Writes the current process' PID to the PID file.
+        /// @return True if the PID was written successfully, false otherwise.
         bool writePIDFile() const;
+
+        /// @brief Removes the PID file.
+        /// @return True if the file was removed successfully, false otherwise.
         bool removePIDFile() const;
 
+        /// @brief Uses the readlink() function to read the path of the current executable file.
+        /// @return A string representing the current process' executable path.
         static std::string GetExecutablePath();
     };
 
+    /// @brief Returns the current status of the daemon.
+    /// @return A string representing the daemon's status.
     std::string GetDaemonStatus();
+
+    /// @brief Generates a PID file for the daemon.
+    /// @return A PIDFileHandler object that will delete the generated PID file on destruction (RAII style).
     PIDFileHandler GeneratePIDFile();
 } // namespace unix_daemon

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -28,6 +28,7 @@ public:
                  http_client::HttpRequestParams params,
                  std::function<boost::asio::awaitable<std::string>()> messageGetter,
                  std::function<void()> onUnauthorized,
+                 long connectionRetrySecs,
                  std::function<void(const std::string&)> onSuccess,
                  std::function<bool()> loopRequestCondition),
                 (override));

--- a/src/common/logger/src/logger_linux.cpp
+++ b/src/common/logger/src/logger_linux.cpp
@@ -1,5 +1,6 @@
 #include <logger.hpp>
 
+#include <spdlog/cfg/env.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 #include <memory>
@@ -10,5 +11,6 @@ Logger::Logger()
     auto logger = std::make_shared<spdlog::logger>("wazuh-agent", console_sink);
 
     spdlog::set_default_logger(logger);
-    spdlog::set_level(spdlog::level::trace);
+    spdlog::set_level(spdlog::level::info);
+    spdlog::cfg::load_env_levels();
 }

--- a/src/common/logger/src/logger_macos.cpp
+++ b/src/common/logger/src/logger_macos.cpp
@@ -1,5 +1,6 @@
 #include <logger.hpp>
 
+#include <spdlog/cfg/env.h>
 #include <spdlog/sinks/syslog_sink.h>
 
 #include <memory>
@@ -10,5 +11,6 @@ Logger::Logger()
     auto logger = std::make_shared<spdlog::logger>("wazuh-agent", sink);
 
     spdlog::set_default_logger(logger);
-    spdlog::set_level(spdlog::level::trace);
+    spdlog::set_level(spdlog::level::info);
+    spdlog::cfg::load_env_levels();
 }

--- a/src/common/logger/src/logger_win.cpp
+++ b/src/common/logger/src/logger_win.cpp
@@ -1,5 +1,6 @@
 #include <logger.hpp>
 
+#include <spdlog/cfg/env.h>
 #include <spdlog/sinks/win_eventlog_sink.h>
 
 #include <memory>
@@ -10,5 +11,6 @@ Logger::Logger()
     auto logger = std::make_shared<spdlog::logger>("wazuh-agent", sink);
 
     spdlog::set_default_logger(logger);
-    spdlog::set_level(spdlog::level::trace);
+    spdlog::set_level(spdlog::level::info);
+    spdlog::cfg::load_env_levels();
 }

--- a/src/common/logger/tests/logger_test.cpp
+++ b/src/common/logger/tests/logger_test.cpp
@@ -64,7 +64,7 @@ TEST_F(LoggerConstructorTest, LinuxLoggerConstructor)
     auto current_logger = spdlog::default_logger();
     EXPECT_EQ(current_logger->name(), "wazuh-agent");
 
-    EXPECT_EQ(spdlog::get_level(), spdlog::level::trace);
+    EXPECT_EQ(spdlog::get_level(), spdlog::level::info);
 
     auto sinks = current_logger->sinks();
     ASSERT_FALSE(sinks.empty());
@@ -77,7 +77,7 @@ TEST_F(LoggerConstructorTest, LinuxLoggerConstructorFail)
     auto current_logger = spdlog::default_logger();
     EXPECT_EQ(current_logger->name(), "wazuh-agent");
 
-    EXPECT_EQ(spdlog::get_level(), spdlog::level::trace);
+    EXPECT_EQ(spdlog::get_level(), spdlog::level::info);
 
     auto sinks = current_logger->sinks();
     ASSERT_FALSE(sinks.empty());
@@ -92,7 +92,7 @@ TEST_F(LoggerConstructorTest, WindowsLoggerConstructor)
     auto current_logger = spdlog::default_logger();
     EXPECT_EQ(current_logger->name(), "wazuh-agent");
 
-    EXPECT_EQ(spdlog::get_level(), spdlog::level::trace);
+    EXPECT_EQ(spdlog::get_level(), spdlog::level::info);
 
     auto sinks = current_logger->sinks();
     ASSERT_FALSE(sinks.empty());
@@ -107,7 +107,7 @@ TEST_F(LoggerConstructorTest, MacOSLoggerConstructor)
     auto current_logger = spdlog::default_logger();
     EXPECT_EQ(current_logger->name(), "wazuh-agent");
 
-    EXPECT_EQ(spdlog::get_level(), spdlog::level::trace);
+    EXPECT_EQ(spdlog::get_level(), spdlog::level::info);
 
     auto sinks = current_logger->sinks();
     ASSERT_FALSE(sinks.empty());


### PR DESCRIPTION
|Related issue|
|---|
|[255](https://github.com/wazuh/wazuh-agent/issues/255)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Make output more friendly when the agent fails to connect to the manager

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
