### PR TITLE
Make jwt-cpp dependency use nlohmann json instead of picojson

### DIFF
--- a/src/agent/communicator/CMakeLists.txt
+++ b/src/agent/communicator/CMakeLists.txt
@@ -14,7 +14,8 @@ find_package(nlohmann_json CONFIG REQUIRED)
 find_path(JWT_CPP_INCLUDE_DIRS "jwt-cpp/base.h")
 
 add_library(Communicator src/communicator.cpp src/http_client.cpp src/http_request_params.cpp)
-target_include_directories(Communicator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include SYSTEM INTERFACE ${JWT_CPP_INCLUDE_DIRS})
+target_include_directories(Communicator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include SYSTEM PRIVATE ${JWT_CPP_INCLUDE_DIRS})
+target_compile_definitions(Communicator PRIVATE -DJWT_DISABLE_PICOJSON=ON)
 target_link_libraries(Communicator PUBLIC Boost::asio Boost::beast Boost::system PRIVATE Boost::url OpenSSL::SSL OpenSSL::Crypto Logger nlohmann_json::nlohmann_json)
 
 include(../../cmake/ConfigureTarget.cmake)

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -6,6 +6,7 @@
 #include <boost/beast.hpp>
 #include <boost/url.hpp>
 #include <jwt-cpp/jwt.h>
+#include <jwt-cpp/traits/nlohmann-json/traits.h>
 
 #include <algorithm>
 #include <chrono>
@@ -55,7 +56,7 @@ namespace communicator
             return boost::beast::http::status::unauthorized;
         }
 
-        if (const auto decoded = jwt::decode(*m_token); decoded.has_payload_claim("exp"))
+        if (const auto decoded = jwt::decode<jwt::traits::nlohmann_json>(*m_token); decoded.has_payload_claim("exp"))
         {
             const auto exp_claim = decoded.get_payload_claim("exp");
             const auto exp_time = exp_claim.as_date();

--- a/src/agent/communicator/tests/CMakeLists.txt
+++ b/src/agent/communicator/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ find_package(GTest CONFIG REQUIRED)
 
 add_executable(communicator_test communicator_test.cpp)
 configure_target(communicator_test)
+target_include_directories(communicator_test SYSTEM PRIVATE ${JWT_CPP_INCLUDE_DIRS})
+target_compile_definitions(communicator_test PRIVATE -DJWT_DISABLE_PICOJSON=ON)
 target_link_libraries(communicator_test PUBLIC Communicator GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
 add_test(NAME CommunicatorTest COMMAND communicator_test)
 

--- a/src/agent/communicator/tests/communicator_test.cpp
+++ b/src/agent/communicator/tests/communicator_test.cpp
@@ -5,6 +5,7 @@
 #include <ihttp_client.hpp>
 
 #include <jwt-cpp/jwt.h>
+#include <jwt-cpp/traits/nlohmann-json/traits.h>
 
 #include "mocks/mock_http_client.hpp"
 
@@ -27,10 +28,10 @@ namespace
         const auto now = std::chrono::system_clock::now();
         const auto exp = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count() + 3600;
 
-        return jwt::create()
+        return jwt::create<jwt::traits::nlohmann_json>()
             .set_issuer("auth0")
             .set_type("JWS")
-            .set_payload_claim("exp", jwt::claim(std::to_string(exp)))
+            .set_payload_claim("exp", jwt::basic_claim<jwt::traits::nlohmann_json>(std::to_string(exp)))
             .sign(jwt::algorithm::hs256 {"secret"});
     }
 } // namespace

--- a/src/ports-overlay/jwt-cpp/portfile.cmake
+++ b/src/ports-overlay/jwt-cpp/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Thalhammer/jwt-cpp
+    REF "v${VERSION}"
+    SHA512 b6fdb93e3f2f065a2eb45fe16cb076a932b8d4bfad2251bd66d2be40d8afaf5c27a9cf17aaea61d8bfa3f5ff9ed3b45f90962dc14d72704ac5b9d717c12cc79f
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+    -DJWT_DISABLE_PICOJSON=ON
+    -DJWT_BUILD_EXAMPLES=OFF
+)
+
+# Copy the header files
+file(GLOB HEADER_FILES ${SOURCE_PATH}/include/jwt-cpp/*)
+file(COPY ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/jwt-cpp)

--- a/src/ports-overlay/jwt-cpp/vcpkg.json
+++ b/src/ports-overlay/jwt-cpp/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "jwt-cpp",
+  "version-semver": "0.7.0",
+  "description": "A header only library for creating and validating json web tokens in c++",
+  "homepage": "https://github.com/Thalhammer/jwt-cpp",
+  "license": "MIT"
+}

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -111,6 +111,7 @@
         "baseline": "f7423ee180c4b7f40d43402c2feb3859161ef625"
       },
       "overlay-ports": [
+        "./ports-overlay/jwt-cpp",
         "./ports-overlay/procps",
         "./ports-overlay/libdb",
         "./ports-overlay/librpm"


### PR DESCRIPTION
### Description

One of the Agent's dependencies, JWT-CPP, has a dependency on a JSON library. By default it uses Picojson, but it can be configured to use something else. Since we already have two json libraries in use (nlohmann and cjson) we will avoid adding a new one.

This also fixes a warning brought by picjson library that resulted in build errors due to `-Werror`.
