### PR TITLE
Catch exceptions thrown by parsing JSON and JWT

### DIFF
--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -90,7 +90,7 @@ namespace communicator
         std::atomic<bool> m_isReAuthenticating = false;
 
         /// @brief Time between authentication attemps in case of failure
-        long m_retryIntervalSecs = 30;
+        long m_retryIntervalSecs = 1;
 
         /// @brief The server URL
         std::string m_serverUrl;

--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -125,7 +125,7 @@ namespace http_client
             {
                 LogError("Error writing request ({}): {}.", std::to_string(ec.value()), ec.message());
                 socket->Close();
-                co_return;
+                continue;
             }
 
             boost::beast::http::response<boost::beast::http::dynamic_body> res;
@@ -135,7 +135,7 @@ namespace http_client
             {
                 LogError("Error reading response. Response code: {}.", res.result_int());
                 socket->Close();
-                co_return;
+                continue;
             }
 
             if (res.result() == boost::beast::http::status::ok)

--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -215,9 +215,18 @@ namespace http_client
             return std::nullopt;
         }
 
-        return nlohmann::json::parse(boost::beast::buffers_to_string(res.body().data()))
-            .at("token")
-            .get_ref<const std::string&>();
+        try
+        {
+            return nlohmann::json::parse(boost::beast::buffers_to_string(res.body().data()))
+                .at("token")
+                .get_ref<const std::string&>();
+        }
+        catch (const std::exception& e)
+        {
+            LogError("Error parsing token in response: {}.", e.what());
+        }
+
+        return std::nullopt;
     }
 
     std::optional<std::string> HttpClient::AuthenticateWithUserPassword(const std::string& serverUrl,
@@ -243,10 +252,19 @@ namespace http_client
             return std::nullopt;
         }
 
-        return nlohmann::json::parse(boost::beast::buffers_to_string(res.body().data()))
-            .at("data")
-            .at("token")
-            .get_ref<const std::string&>();
+        try
+        {
+            return nlohmann::json::parse(boost::beast::buffers_to_string(res.body().data()))
+                .at("data")
+                .at("token")
+                .get_ref<const std::string&>();
+        }
+        catch (const std::exception& e)
+        {
+            LogError("Error parsing token in response: {}.", e.what());
+        }
+
+        return std::nullopt;
     }
 
     boost::beast::http::response<boost::beast::http::dynamic_body>

--- a/src/agent/communicator/src/http_request_params.cpp
+++ b/src/agent/communicator/src/http_request_params.cpp
@@ -19,14 +19,15 @@ namespace http_client
         , User_pass(std::move(userPass))
         , Body(std::move(body))
     {
-        auto result = boost::urls::parse_uri(serverUrl);
+        const auto result = boost::urls::parse_uri(serverUrl);
+
         if (!result)
         {
             LogError("Invalid URL: {}", result.error().message());
             return;
         }
 
-        boost::urls::url_view url = *result;
+        const auto& url = *result;
         Use_Https = url.scheme().empty() || url.scheme() == "https";
         Host = url.host();
         Port = url.port();


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/287|

This PR adds try/catch block for exceptions thrown by parsing malformed JSON responses and decoding invalid JWT tokens. It also adds logging for these cases and token validation check on the mock server.