### PR TITLE
Adapt agent metadata to latest changes requested

### DIFF
--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -72,8 +72,8 @@ public:
 
     /// @brief Gets all the information about the agent.
     /// @param agentIsRegistering Indicates if the agent is about to register.
-    /// @return A json object with all information about the agent.
-    nlohmann::json GetMetadataInfo(const bool agentIsRegistering) const;
+    /// @return A string with all information about the agent.
+    std::string GetMetadataInfo(const bool agentIsRegistering) const;
 
 private:
     /// @brief Creates a random key for the agent.

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -100,8 +100,8 @@ private:
 
     /// @brief Extracts the active IP address from the network JSON data.
     /// @param networksJson JSON object containing network interface information.
-    /// @return Optional string with the active IP address if found; otherwise, `std::nullopt`.
-    std::optional<std::string> GetActiveIPAddress(const nlohmann::json& networksJson) const;
+    /// @return Vector of strings with the active IP addresses.
+    std::vector<std::string> GetActiveIPAddresses(const nlohmann::json& networksJson) const;
 
     /// @brief The agent's name.
     std::string m_name;

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -8,7 +8,7 @@
 
 /// @brief Stores and manages information about an agent.
 ///
-/// This class provides methods for getting and setting the agent's key,
+/// This class provides methods for getting and setting the agent's name, key,
 /// UUID, and groups. It also includes private methods for creating and
 /// validating the key.
 class AgentInfo
@@ -25,6 +25,10 @@ public:
     AgentInfo(std::function<nlohmann::json()> getOSInfo = nullptr,
               std::function<nlohmann::json()> getNetworksInfo = nullptr);
 
+    /// @brief Gets the agent's name.
+    /// @return The agent's name.
+    std::string GetName() const;
+
     /// @brief Gets the agent's key.
     /// @return The agent's key.
     std::string GetKey() const;
@@ -36,6 +40,10 @@ public:
     /// @brief Gets the agent's groups.
     /// @return A vector of the agent's groups.
     std::vector<std::string> GetGroups() const;
+
+    /// @brief Sets the agent's name.
+    /// @param name The agent's new name.
+    void SetName(const std::string& name);
 
     /// @brief Sets the agent's key.
     /// @param key The agent's new key.
@@ -94,6 +102,9 @@ private:
     /// @param networksJson JSON object containing network interface information.
     /// @return Optional string with the active IP address if found; otherwise, `std::nullopt`.
     std::optional<std::string> GetActiveIPAddress(const nlohmann::json& networksJson) const;
+
+    /// @brief The agent's name.
+    std::string m_name;
 
     /// @brief The agent's key.
     std::string m_key;

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -92,9 +92,6 @@ private:
     /// @brief Loads the endpoint information into `m_endpointInfo`.
     void LoadEndpointInfo();
 
-    /// @brief Loads the metadata information into `m_metadataInfo`.
-    void LoadMetadataInfo();
-
     /// @brief Loads the header information into `m_headerInfo`.
     void LoadHeaderInfo();
 
@@ -117,9 +114,6 @@ private:
 
     /// @brief The agent's endpoint information.
     nlohmann::json m_endpointInfo;
-
-    /// @brief The agent's metadata information.
-    nlohmann::json m_metadataInfo;
 
     /// @brief The agent's header information.
     std::string m_headerInfo;

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -145,7 +145,7 @@ std::string AgentInfo::GetHeaderInfo() const
     return m_headerInfo;
 }
 
-nlohmann::json AgentInfo::GetMetadataInfo(const bool agentIsRegistering) const
+std::string AgentInfo::GetMetadataInfo(const bool agentIsRegistering) const
 {
     nlohmann::json metadataInfo;
 
@@ -156,7 +156,7 @@ nlohmann::json AgentInfo::GetMetadataInfo(const bool agentIsRegistering) const
         metadataInfo["agent"]["key"] = GetKey();
     }
 
-    return metadataInfo;
+    return metadataInfo.dump();
 }
 
 std::optional<std::string> AgentInfo::GetActiveIPAddress(const nlohmann::json& networksJson) const

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -19,6 +19,7 @@ namespace
 AgentInfo::AgentInfo(std::function<nlohmann::json()> getOSInfo, std::function<nlohmann::json()> getNetworksInfo)
 {
     AgentInfoPersistance agentInfoPersistance;
+    m_name = agentInfoPersistance.GetName();
     m_key = agentInfoPersistance.GetKey();
     m_uuid = agentInfoPersistance.GetUUID();
     m_groups = agentInfoPersistance.GetGroups();
@@ -44,6 +45,11 @@ AgentInfo::AgentInfo(std::function<nlohmann::json()> getOSInfo, std::function<nl
     LoadHeaderInfo();
 }
 
+std::string AgentInfo::GetName() const
+{
+    return m_name;
+}
+
 std::string AgentInfo::GetKey() const
 {
     return m_key;
@@ -57,6 +63,13 @@ std::string AgentInfo::GetUUID() const
 std::vector<std::string> AgentInfo::GetGroups() const
 {
     return m_groups;
+}
+
+void AgentInfo::SetName(const std::string& name)
+{
+    AgentInfoPersistance agentInfoPersistance;
+    agentInfoPersistance.SetName(name);
+    m_name = name;
 }
 
 bool AgentInfo::SetKey(const std::string& key)
@@ -186,6 +199,7 @@ void AgentInfo::LoadEndpointInfo()
 void AgentInfo::LoadMetadataInfo()
 {
     m_metadataInfo["id"] = GetUUID();
+    m_metadataInfo["name"] = GetName();
     m_metadataInfo["type"] = GetType();
     m_metadataInfo["version"] = GetVersion();
     m_metadataInfo["groups"] = GetGroups();

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -58,7 +58,8 @@ void AgentInfoPersistance::CreateAgentInfoTable()
 {
     try
     {
-        const std::vector<Column> columns = {Column("key", ColumnType::TEXT, true, false),
+        const std::vector<Column> columns = {Column("name", ColumnType::TEXT, true, false),
+                                             Column("key", ColumnType::TEXT, true, false),
                                              Column("uuid", ColumnType::TEXT, true, false, true)};
 
         m_db->CreateTable(AGENT_INFO_TABLE_NAME, columns);
@@ -92,7 +93,8 @@ void AgentInfoPersistance::InsertDefaultAgentInfo()
 
         if (count == 0)
         {
-            const std::vector<Column> columns = {Column("key", ColumnType::TEXT, ""),
+            const std::vector<Column> columns = {Column("name", ColumnType::TEXT, ""),
+                                                 Column("key", ColumnType::TEXT, ""),
                                                  Column("uuid", ColumnType::TEXT, "")};
 
             m_db->Insert(AGENT_INFO_TABLE_NAME, columns);
@@ -139,6 +141,11 @@ std::string AgentInfoPersistance::GetAgentInfoValue(const std::string& column) c
     return value;
 }
 
+std::string AgentInfoPersistance::GetName() const
+{
+    return GetAgentInfoValue("name");
+}
+
 std::string AgentInfoPersistance::GetKey() const
 {
     return GetAgentInfoValue("key");
@@ -172,6 +179,11 @@ std::vector<std::string> AgentInfoPersistance::GetGroups() const
     }
 
     return groupList;
+}
+
+void AgentInfoPersistance::SetName(const std::string& name)
+{
+    SetAgentInfoValue("name", name);
 }
 
 void AgentInfoPersistance::SetKey(const std::string& key)

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -223,8 +223,10 @@ void AgentInfoPersistance::ResetToDefault()
 {
     try
     {
-        m_db->Remove(AGENT_INFO_TABLE_NAME);
-        m_db->Remove(AGENT_GROUP_TABLE_NAME);
+        m_db->DropTable(AGENT_INFO_TABLE_NAME);
+        m_db->DropTable(AGENT_GROUP_TABLE_NAME);
+        CreateAgentInfoTable();
+        CreateAgentGroupTable();
         InsertDefaultAgentInfo();
     }
     catch (const std::exception& e)

--- a/src/agent/agent_info/src/agent_info_persistance.hpp
+++ b/src/agent/agent_info/src/agent_info_persistance.hpp
@@ -31,6 +31,10 @@ public:
     /// @brief Deleted move assignment operator.
     AgentInfoPersistance& operator=(AgentInfoPersistance&&) = delete;
 
+    /// @brief Retrieves the agent's name from the database.
+    /// @return The name of the agent as a string.
+    std::string GetName() const;
+
     /// @brief Retrieves the agent's key from the database.
     /// @return The key of the agent as a string.
     std::string GetKey() const;
@@ -42,6 +46,10 @@ public:
     /// @brief Retrieves the list of agent groups from the database.
     /// @return A vector of strings, each representing a group name.
     std::vector<std::string> GetGroups() const;
+
+    /// @brief Sets the agent's name in the database.
+    /// @param name The name to set.
+    void SetName(const std::string& name);
 
     /// @brief Sets the agent's key in the database.
     /// @param key The key to set.

--- a/src/agent/agent_info/tests/agent_info_persistance_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_persistance_test.cpp
@@ -25,8 +25,16 @@ TEST_F(AgentInfoPersistanceTest, TestConstruction)
 
 TEST_F(AgentInfoPersistanceTest, TestDefaultValues)
 {
+    EXPECT_EQ(persistance->GetName(), "");
     EXPECT_EQ(persistance->GetKey(), "");
     EXPECT_EQ(persistance->GetUUID(), "");
+}
+
+TEST_F(AgentInfoPersistanceTest, TestSetName)
+{
+    const std::string newName = "new_name";
+    persistance->SetName(newName);
+    EXPECT_EQ(persistance->GetName(), newName);
 }
 
 TEST_F(AgentInfoPersistanceTest, TestSetKey)
@@ -58,6 +66,18 @@ TEST_F(AgentInfoPersistanceTest, TestSetGroupsDelete)
     EXPECT_EQ(persistance->GetGroups(), oldGroups);
     persistance->SetGroups(newGroups);
     EXPECT_EQ(persistance->GetGroups(), newGroups);
+}
+
+TEST_F(AgentInfoPersistanceTest, TestResetToDefault)
+{
+    const std::string newName = "new_name";
+    persistance->SetName(newName);
+    EXPECT_EQ(persistance->GetName(), newName);
+
+    persistance->ResetToDefault();
+    EXPECT_EQ(persistance->GetName(), "");
+    EXPECT_EQ(persistance->GetKey(), "");
+    EXPECT_EQ(persistance->GetUUID(), "");
 }
 
 int main(int argc, char** argv)

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -116,7 +116,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoNoSysInfo)
 {
     const AgentInfo agentInfo;
 
-    auto metadataInfo = agentInfo.GetMetadataInfo(true);
+    auto metadataInfo = nlohmann::json::parse(agentInfo.GetMetadataInfo(true));
 
     EXPECT_TRUE(metadataInfo["agent"] != nullptr);
 
@@ -124,6 +124,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoNoSysInfo)
     EXPECT_EQ(metadataInfo["agent"]["type"], agentInfo.GetType());
     EXPECT_EQ(metadataInfo["agent"]["version"], agentInfo.GetVersion());
     EXPECT_EQ(metadataInfo["agent"]["id"], agentInfo.GetUUID());
+    EXPECT_EQ(metadataInfo["agent"]["name"], agentInfo.GetName());
     EXPECT_EQ(metadataInfo["agent"]["key"], agentInfo.GetKey());
     EXPECT_TRUE(metadataInfo["agent"]["groups"] != nullptr);
 
@@ -155,7 +156,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
 
     const AgentInfo agentInfo([os]() { return os; }, [networks]() { return networks; });
 
-    auto metadataInfo = agentInfo.GetMetadataInfo(true);
+    auto metadataInfo = nlohmann::json::parse(agentInfo.GetMetadataInfo(true));
 
     EXPECT_TRUE(metadataInfo["agent"] != nullptr);
 
@@ -163,6 +164,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
     EXPECT_EQ(metadataInfo["agent"]["type"], agentInfo.GetType());
     EXPECT_EQ(metadataInfo["agent"]["version"], agentInfo.GetVersion());
     EXPECT_EQ(metadataInfo["agent"]["id"], agentInfo.GetUUID());
+    EXPECT_EQ(metadataInfo["agent"]["name"], agentInfo.GetName());
     EXPECT_EQ(metadataInfo["agent"]["key"], agentInfo.GetKey());
     EXPECT_TRUE(metadataInfo["agent"]["groups"] != nullptr);
 
@@ -200,7 +202,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoConnected)
 
     const AgentInfo agentInfo([os]() { return os; }, [networks]() { return networks; });
 
-    auto metadataInfo = agentInfo.GetMetadataInfo(false);
+    auto metadataInfo = nlohmann::json::parse(agentInfo.GetMetadataInfo(false));
 
     EXPECT_TRUE(metadataInfo["agent"] != nullptr);
 
@@ -208,6 +210,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoConnected)
     EXPECT_EQ(metadataInfo["agent"]["type"], agentInfo.GetType());
     EXPECT_EQ(metadataInfo["agent"]["version"], agentInfo.GetVersion());
     EXPECT_EQ(metadataInfo["agent"]["id"], agentInfo.GetUUID());
+    EXPECT_EQ(metadataInfo["agent"]["name"], agentInfo.GetName());
     EXPECT_TRUE(metadataInfo["agent"]["key"] == nullptr);
     EXPECT_TRUE(metadataInfo["agent"]["groups"] != nullptr);
 

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -25,6 +25,7 @@ TEST_F(AgentInfoTest, TestDefaultConstructor)
 TEST_F(AgentInfoTest, TestDefaultConstructorDefaultValues)
 {
     const AgentInfo agentInfo;
+    EXPECT_EQ(agentInfo.GetName(), "");
     EXPECT_EQ(agentInfo.GetKey(), "");
     EXPECT_NE(agentInfo.GetUUID(), "");
 }
@@ -32,11 +33,25 @@ TEST_F(AgentInfoTest, TestDefaultConstructorDefaultValues)
 TEST_F(AgentInfoTest, TestPersistedValues)
 {
     AgentInfo agentInfo;
+    agentInfo.SetName("test_name");
     agentInfo.SetKey("4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj");
     agentInfo.SetUUID("test_uuid");
     const AgentInfo agentInfoReloaded;
+    EXPECT_EQ(agentInfoReloaded.GetName(), "test_name");
     EXPECT_EQ(agentInfoReloaded.GetKey(), "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj");
     EXPECT_EQ(agentInfoReloaded.GetUUID(), "test_uuid");
+}
+
+TEST_F(AgentInfoTest, TestSetName)
+{
+    AgentInfo agentInfo;
+    const std::string newName = "new_name";
+
+    agentInfo.SetName(newName);
+    EXPECT_EQ(agentInfo.GetName(), newName);
+
+    const AgentInfo agentInfoReloaded;
+    EXPECT_EQ(agentInfoReloaded.GetName(), newName);
 }
 
 TEST_F(AgentInfoTest, TestSetKey)

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -173,7 +173,8 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
     EXPECT_TRUE(metadataInfo["agent"]["host"]["os"] != nullptr);
     EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["name"], "test_os");
     EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["platform"], "test_platform");
-    EXPECT_EQ(metadataInfo["agent"]["host"]["ip"], "127.0.0.1");
+    EXPECT_TRUE(metadataInfo["agent"]["host"]["ip"] != nullptr);
+    EXPECT_EQ(metadataInfo["agent"]["host"]["ip"][0], "127.0.0.1");
     EXPECT_EQ(metadataInfo["agent"]["host"]["architecture"], "test_arch");
     EXPECT_EQ(metadataInfo["agent"]["host"]["hostname"], "test_name");
 }
@@ -219,7 +220,8 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoConnected)
     EXPECT_TRUE(metadataInfo["agent"]["host"]["os"] != nullptr);
     EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["name"], "test_os");
     EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["platform"], "test_platform");
-    EXPECT_EQ(metadataInfo["agent"]["host"]["ip"], "127.0.0.1");
+    EXPECT_TRUE(metadataInfo["agent"]["host"]["ip"] != nullptr);
+    EXPECT_EQ(metadataInfo["agent"]["host"]["ip"][0], "127.0.0.1");
     EXPECT_EQ(metadataInfo["agent"]["host"]["architecture"], "test_arch");
     EXPECT_EQ(metadataInfo["agent"]["host"]["hostname"], "test_name");
 }

--- a/src/agent/include/agent_registration.hpp
+++ b/src/agent/include/agent_registration.hpp
@@ -31,10 +31,12 @@ namespace agent_registration
         /// @param user The user's username.
         /// @param password The user's password.
         /// @param key The agent's key.
+        /// @param name The agent's name.
         /// @param configFile The path to the configuration file.
         AgentRegistration(std::string user,
                           std::string password,
                           const std::string& key,
+                          const std::string& name,
                           std::optional<std::string> configFile);
 
         /// @brief Registers the agent with the manager.

--- a/src/agent/multitype_queue/include/imultitype_queue.hpp
+++ b/src/agent/multitype_queue/include/imultitype_queue.hpp
@@ -64,12 +64,12 @@ public:
      * @param messageQuantity The quantity of messages to return.
      * @param moduleName The name of the module requesting the message.
      * @param moduleType The type of the module requesting the messages.
-     * @return boost::asio::awaitable<Message> Awaitable object representing the next message.
+     * @return boost::asio::awaitable<std::vector<Message>> Awaitable object representing the next N messages.
      */
-    virtual boost::asio::awaitable<Message> getNextNAwaitable(MessageType type,
-                                                              int messageQuantity,
-                                                              const std::string moduleName = "",
-                                                              const std::string moduleType = "") = 0;
+    virtual boost::asio::awaitable<std::vector<Message>> getNextNAwaitable(MessageType type,
+                                                                           int messageQuantity,
+                                                                           const std::string moduleName = "",
+                                                                           const std::string moduleType = "") = 0;
 
     /**
      * @brief Retrieves the next N messages from the queue.

--- a/src/agent/multitype_queue/include/multitype_queue.hpp
+++ b/src/agent/multitype_queue/include/multitype_queue.hpp
@@ -90,20 +90,20 @@ public:
     int push(std::vector<Message> messages) override;
 
     /**
-     * @copydoc IMultiTypeQueue::getNext(MessageType, const std::string)
+     * @copydoc IMultiTypeQueue::getNext(MessageType, const std::string, const std::string)
      */
     Message getNext(MessageType type, const std::string moduleName = "", const std::string moduleType = "") override;
 
     /**
-     * @copydoc IMultiTypeQueue::getNextNAwaitable(MessageType, int, const std::string)
+     * @copydoc IMultiTypeQueue::getNextNAwaitable(MessageType, int, const std::string, const std::string)
      */
-    boost::asio::awaitable<Message> getNextNAwaitable(MessageType type,
-                                                      int messageQuantity,
-                                                      const std::string moduleName = "",
-                                                      const std::string moduleType = "") override;
+    boost::asio::awaitable<std::vector<Message>> getNextNAwaitable(MessageType type,
+                                                                   int messageQuantity,
+                                                                   const std::string moduleName = "",
+                                                                   const std::string moduleType = "") override;
 
     /**
-     * @copydoc IMultiTypeQueue::getNextN(MessageType, int, const std::string)
+     * @copydoc IMultiTypeQueue::getNextN(MessageType, int, const std::string, const std::string)
      */
     std::vector<Message> getNextN(MessageType type,
                                   int messageQuantity,

--- a/src/agent/multitype_queue/tests/multitype_queue_test.cpp
+++ b/src/agent/multitype_queue/tests/multitype_queue_test.cpp
@@ -491,8 +491,8 @@ TEST_F(MultiTypeQueueTest, GetNextAwaitableBase)
         [&multiTypeQueue]() -> boost::asio::awaitable<void>
         {
             auto messageReceived = co_await multiTypeQueue.getNextNAwaitable(MessageType::STATELESS, 2);
-            EXPECT_EQ(messageReceived.data.at(0).at("data"), "content-1");
-            EXPECT_EQ(messageReceived.data.at(1).at("data"), "content-2");
+            EXPECT_EQ(messageReceived[0].data.at("data"), "content-1");
+            EXPECT_EQ(messageReceived[1].data.at("data"), "content-2");
         },
         boost::asio::detached);
 

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -11,6 +11,7 @@ namespace agent_registration
     AgentRegistration::AgentRegistration(std::string user,
                                          std::string password,
                                          const std::string& key,
+                                         const std::string& name,
                                          std::optional<std::string> configFile)
         : m_agentInfo([this]() { return m_sysInfo.os(); }, [this]() { return m_sysInfo.networks(); })
         , m_configurationParser(configFile.has_value() && !configFile->empty()
@@ -23,6 +24,15 @@ namespace agent_registration
         if (!m_agentInfo.SetKey(key))
         {
             throw std::invalid_argument("--key argument must be alphanumeric and 32 characters in length");
+        }
+
+        if (!name.empty())
+        {
+            m_agentInfo.SetName(name);
+        }
+        else
+        {
+            m_agentInfo.SetName(boost::asio::ip::host_name());
         }
     }
 

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -32,7 +32,7 @@ namespace agent_registration
         }
         else
         {
-            m_agentInfo.SetName(boost::asio::ip::host_name());
+            m_agentInfo.SetName(m_sysInfo.os().value("hostname", "Unknown"));
         }
     }
 

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -53,7 +53,7 @@ namespace agent_registration
                                                               m_agentInfo.GetHeaderInfo(),
                                                               token.value(),
                                                               "",
-                                                              m_agentInfo.GetMetadataInfo(true).dump());
+                                                              m_agentInfo.GetMetadataInfo(true));
 
         const auto res = httpClient.PerformHttpRequest(reqParams);
 

--- a/src/agent/src/main.cpp
+++ b/src/agent/src/main.cpp
@@ -23,6 +23,7 @@ int main(int argc, char* argv[])
             RegisterAgent(cmdParser.GetOptionValue(OPT_USER),
                           cmdParser.GetOptionValue(OPT_PASSWORD),
                           cmdParser.GetOptionValue(OPT_KEY),
+                          cmdParser.GetOptionValue(OPT_NAME),
                           configFile);
         }
         else if (cmdParser.OptionExists(OPT_RESTART))

--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -19,12 +19,12 @@ boost::asio::awaitable<std::string> GetMessagesFromQueue(std::shared_ptr<IMultiT
 
     if (getMetadataInfo != nullptr)
     {
-        output = getMetadataInfo() + "\n";
+        output = getMetadataInfo();
     }
 
     for (const auto& message : messages)
     {
-        output += message.metaData + "\n" + message.data.dump() + "\n";
+        output += "\n" + message.metaData + "\n" + message.data.dump();
     }
 
     co_return output;

--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -11,20 +11,23 @@ namespace
 
 boost::asio::awaitable<std::string> GetMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue,
                                                          MessageType messageType,
-                                                         std::function<nlohmann::json()> getMetadataInfo)
+                                                         std::function<std::string()> getMetadataInfo)
 {
-    const auto message = co_await multiTypeQueue->getNextNAwaitable(messageType, NUM_EVENTS, "", "");
+    const auto messages = co_await multiTypeQueue->getNextNAwaitable(messageType, NUM_EVENTS, "", "");
 
-    nlohmann::json jsonObj;
     std::string output;
 
     if (getMetadataInfo != nullptr)
     {
-        jsonObj = getMetadataInfo();
-        output = jsonObj.dump() + "\n";
+        output = getMetadataInfo() + "\n";
     }
 
-    co_return output + message.metaData + "\n" + message.data.dump();
+    for (const auto& message : messages)
+    {
+        output += message.metaData + "\n" + message.data.dump() + "\n";
+    }
+
+    co_return output;
 }
 
 void PopMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, MessageType messageType)

--- a/src/agent/src/message_queue_utils.hpp
+++ b/src/agent/src/message_queue_utils.hpp
@@ -16,10 +16,10 @@ class IMultiTypeQueue;
 /// @param multiTypeQueue The queue to get messages from
 /// @param messageType The type of messages to get from the queue
 /// @param getMetadataInfo Function to get the agent metadata
-/// @return A JSON string containing the messages from the queue
+/// @return A string containing the messages from the queue
 boost::asio::awaitable<std::string> GetMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue,
                                                          MessageType messageType,
-                                                         std::function<nlohmann::json()> getMetadataInfo);
+                                                         std::function<std::string()> getMetadataInfo);
 
 /// @brief Removes a fixed number of messages from the specified queue
 /// @param multiTypeQueue The queue from which to remove messages

--- a/src/agent/src/process_options.cpp
+++ b/src/agent/src/process_options.cpp
@@ -10,6 +10,7 @@
 void RegisterAgent(const std::string& user,
                    const std::string& password,
                    const std::string& key,
+                   const std::string& name,
                    const std::string& configFile)
 {
     if (!user.empty() && !password.empty())
@@ -18,7 +19,7 @@ void RegisterAgent(const std::string& user,
         {
             std::cout << "Starting wazuh-agent registration\n";
 
-            agent_registration::AgentRegistration reg(user, password, key, configFile);
+            agent_registration::AgentRegistration reg(user, password, key, name, configFile);
 
             http_client::HttpClient httpClient;
             if (reg.Register(httpClient))

--- a/src/agent/src/process_options.hpp
+++ b/src/agent/src/process_options.hpp
@@ -16,6 +16,7 @@ static const auto OPT_RUN_SERVICE {"--run-service"};
 static const auto OPT_USER {"--user"};
 static const auto OPT_PASSWORD {"--password"};
 static const auto OPT_KEY {"--key"};
+static const auto OPT_NAME {"--name"};
 static const auto OPT_HELP {"--help"};
 
 /// @brief Registers the agent with the given parameters.
@@ -27,6 +28,7 @@ static const auto OPT_HELP {"--help"};
 void RegisterAgent(const std::string& user,
                    const std::string& password,
                    const std::string& key,
+                   const std::string& name,
                    const std::string& configFile);
 
 /// @brief Restarts the agent using the specified configuration file.

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -68,7 +68,7 @@ protected:
 TEST_F(RegisterTest, RegistrationTestSuccess)
 {
     registration = std::make_unique<agent_registration::AgentRegistration>(
-        "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", std::nullopt);
+        "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name", std::nullopt);
     SysInfo sysInfo;
     agent = std::make_unique<AgentInfo>([&sysInfo]() mutable { return sysInfo.os(); },
                                         [&sysInfo]() mutable { return sysInfo.networks(); });
@@ -101,7 +101,7 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
 TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
 {
     registration = std::make_unique<agent_registration::AgentRegistration>(
-        "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", std::nullopt);
+        "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name", std::nullopt);
     agent = std::make_unique<AgentInfo>();
 
     MockHttpClient mockHttpClient;
@@ -117,7 +117,7 @@ TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
 TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
 {
     registration = std::make_unique<agent_registration::AgentRegistration>(
-        "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", std::nullopt);
+        "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name", std::nullopt);
     agent = std::make_unique<AgentInfo>();
 
     MockHttpClient mockHttpClient;
@@ -137,7 +137,8 @@ TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
 
 TEST_F(RegisterTest, RegistrationTestSuccessWithEmptyKey)
 {
-    registration = std::make_unique<agent_registration::AgentRegistration>("user", "password", "", std::nullopt);
+    registration =
+        std::make_unique<agent_registration::AgentRegistration>("user", "password", "", "agent_name", std::nullopt);
     SysInfo sysInfo;
     agent = std::make_unique<AgentInfo>([&sysInfo]() mutable { return sysInfo.os(); },
                                         [&sysInfo]() mutable { return sysInfo.networks(); });
@@ -169,7 +170,7 @@ TEST_F(RegisterTest, RegistrationTestSuccessWithEmptyKey)
 
 TEST_F(RegisterTest, RegistrationTestFailWithBadKey)
 {
-    ASSERT_THROW(agent_registration::AgentRegistration("user", "password", "badKey", std::nullopt),
+    ASSERT_THROW(agent_registration::AgentRegistration("user", "password", "badKey", "agent_name", std::nullopt),
                  std::invalid_argument);
 }
 

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <agent_info.hpp>
+#include <agent_info_persistance.hpp>
 #include <agent_registration.hpp>
 #include <ihttp_client.hpp>
 #include <ihttp_socket.hpp>
@@ -67,6 +68,9 @@ protected:
 
 TEST_F(RegisterTest, RegistrationTestSuccess)
 {
+    AgentInfoPersistance agentInfoPersistance;
+    agentInfoPersistance.ResetToDefault();
+
     registration = std::make_unique<agent_registration::AgentRegistration>(
         "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name", std::nullopt);
     SysInfo sysInfo;
@@ -78,7 +82,7 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
     EXPECT_CALL(mockHttpClient, AuthenticateWithUserPassword(testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Return("token"));
 
-    nlohmann::json bodyJson = agent->GetMetadataInfo(true);
+    const auto bodyJson = agent->GetMetadataInfo(true);
 
     http_client::HttpRequestParams reqParams(boost::beast::http::verb::post,
                                              "https://localhost:55000",
@@ -100,6 +104,9 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
 
 TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
 {
+    AgentInfoPersistance agentInfoPersistance;
+    agentInfoPersistance.ResetToDefault();
+
     registration = std::make_unique<agent_registration::AgentRegistration>(
         "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name", std::nullopt);
     agent = std::make_unique<AgentInfo>();
@@ -116,6 +123,9 @@ TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
 
 TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
 {
+    AgentInfoPersistance agentInfoPersistance;
+    agentInfoPersistance.ResetToDefault();
+
     registration = std::make_unique<agent_registration::AgentRegistration>(
         "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name", std::nullopt);
     agent = std::make_unique<AgentInfo>();
@@ -137,6 +147,9 @@ TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
 
 TEST_F(RegisterTest, RegistrationTestSuccessWithEmptyKey)
 {
+    AgentInfoPersistance agentInfoPersistance;
+    agentInfoPersistance.ResetToDefault();
+
     registration =
         std::make_unique<agent_registration::AgentRegistration>("user", "password", "", "agent_name", std::nullopt);
     SysInfo sysInfo;
@@ -148,7 +161,7 @@ TEST_F(RegisterTest, RegistrationTestSuccessWithEmptyKey)
     EXPECT_CALL(mockHttpClient, AuthenticateWithUserPassword(testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Return("token"));
 
-    nlohmann::json bodyJson = agent->GetMetadataInfo(true);
+    const auto bodyJson = agent->GetMetadataInfo(true);
 
     http_client::HttpRequestParams reqParams(boost::beast::http::verb::post,
                                              "https://localhost:55000",

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -86,7 +86,7 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
                                              agent->GetHeaderInfo(),
                                              "token",
                                              "",
-                                             bodyJson.dump());
+                                             bodyJson);
 
     boost::beast::http::response<boost::beast::http::dynamic_body> expectedResponse;
     expectedResponse.result(boost::beast::http::status::ok);
@@ -156,7 +156,7 @@ TEST_F(RegisterTest, RegistrationTestSuccessWithEmptyKey)
                                              agent->GetHeaderInfo(),
                                              "token",
                                              "",
-                                             bodyJson.dump());
+                                             bodyJson);
 
     boost::beast::http::response<boost::beast::http::dynamic_body> expectedResponse;
     expectedResponse.result(boost::beast::http::status::ok);

--- a/src/agent/tests/message_queue_utils_test.cpp
+++ b/src/agent/tests/message_queue_utils_test.cpp
@@ -59,8 +59,8 @@ TEST_F(MessageQueueUtilsTest, GetMessagesFromQueueTest)
 
     const auto jsonResult = result.get();
 
-    std::string expectedString = R"({"module":"logcollector","type":"file"})" + std::string("\n") +
-                                 R"(["{\"event\":{\"original\":\"Testing message!\"}}"])" + std::string("\n");
+    std::string expectedString = std::string("\n") + R"({"module":"logcollector","type":"file"})" + std::string("\n") +
+                                 R"(["{\"event\":{\"original\":\"Testing message!\"}}"])";
 
     ASSERT_EQ(jsonResult, expectedString);
 }
@@ -96,7 +96,7 @@ TEST_F(MessageQueueUtilsTest, GetMessagesFromQueueMetadataTest)
 
     std::string expectedString = R"({"agent":"test"})" + std::string("\n") +
                                  R"({"module":"logcollector","type":"file"})" + std::string("\n") +
-                                 R"(["{\"event\":{\"original\":\"Testing message!\"}}"])" + std::string("\n");
+                                 R"(["{\"event\":{\"original\":\"Testing message!\"}}"])";
 
     ASSERT_EQ(jsonResult, expectedString);
 }

--- a/src/modules/logcollector/tests/unit/queue_mock.hpp
+++ b/src/modules/logcollector/tests/unit/queue_mock.hpp
@@ -13,7 +13,7 @@ public:
               (MessageType type, const std::string module,
                const std::string moduleType),
               (override));
-  MOCK_METHOD(boost::asio::awaitable<Message>, getNextNAwaitable,
+  MOCK_METHOD(boost::asio::awaitable<std::vector<Message>>, getNextNAwaitable,
               (MessageType type, int messageQuantity,
                const std::string moduleName, const std::string moduleType),
               (override));


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/256|

## Description

This PR includes the following changes/improvements:
- Add the `name` to the agent metadata.
- Report the `ip` as an array in the agent metadata.
- Return agent metadata as a string to avoid conversions.
- Fix the function `getNextNAwaitable` to return multiple messages.
- Fix metadata cache.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X

## Examples

- Registration:

```log
[2024-11-13 14:56:40] POST /security/user/authenticate
Headers:
Host: localhost
User-Agent: WazuhXDR/5.0.0 (Endpoint; aarch64; Linux)
Accept: application/json
Authorization: Basic d2F6dWg6d2F6dWg=


Body:



[2024-11-13 14:56:40] POST /agents
Headers:
Host: localhost
User-Agent: WazuhXDR/5.0.0 (Endpoint; aarch64; Linux)
Accept: application/json
Authorization: Bearer 1234567890
Content-Type: application/json
Content-Length: 277


Body:
{"agent":{"groups":[],"host":{"architecture":"aarch64","hostname":"tomas","ip":["192.168.64.15"],"os":{"name":"Ubuntu","platform":"Linux"}},"id":"632c61c2-5df5-45f2-bf45-b5d968f4cea3","key":"LeAuQ3QsnaefDrULb0SXB2Q8OHHP9rv8","name":"tomas","type":"Endpoint","version":"5.0.0"}}
```

- Stateless:

```log
[2024-11-13 14:57:42] POST /api/v1/authentication
Headers:
Host: localhost
User-Agent: WazuhXDR/5.0.0 (Endpoint; aarch64; Linux)
Accept: application/json
Content-Type: application/json
Content-Length: 89


Body:
{"uuid":"632c61c2-5df5-45f2-bf45-b5d968f4cea3", "key":"LeAuQ3QsnaefDrULb0SXB2Q8OHHP9rv8"}


[2024-11-13 14:58:04] POST /api/v1/events/stateless
Headers:
Host: localhost
User-Agent: WazuhXDR/5.0.0 (Endpoint; aarch64; Linux)
Accept: application/json
Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIENvbW11bmljYXRpb25zIEFQSSIsImlhdCI6MTczMTUwOTg2MiwiZXhwIjoxNzMxNTA5OTIyLCJ1dWlkIjoiZWRhYjllZjYtZjAyZC00YTRiLWJhYTQtZjJhZDEyNzg5ODkwIn0.Zm21lvSUIcaTzZmbTZv7VVKDCtkm3m6Mp7HBuL7A1ek
Content-Type: application/json
Content-Length: 451


Body:
{"agent":{"groups":[],"host":{"architecture":"aarch64","hostname":"tomas","ip":["192.168.64.15"],"os":{"name":"Ubuntu","platform":"Linux"}},"id":"632c61c2-5df5-45f2-bf45-b5d968f4cea3","name":"tomas","type":"Endpoint","version":"5.0.0"}}
{"module":"logcollector","type":"file"}
{"event":{"ingested":"2024-11-13T14:58:04.446Z","module":"logcollector","original":"alksjdaslkd","provider":"syslog"},"log":{"file":{"path":"/test/test.log"}},"tags":["mvp"]}
```