### PR TITLE
Add nuget installation inside docker images

### DIFF
--- a/.github/actions/ghcr_pull_and_push/build_and_push_image_to_ghcr.sh
+++ b/.github/actions/ghcr_pull_and_push/build_and_push_image_to_ghcr.sh
@@ -10,13 +10,19 @@ else
 fi
 GITHUB_REPOSITORY="wazuh/wazuh"
 GITHUB_OWNER="wazuh"
+IMAGE_ID_CACHE=ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:latest-5.0
+IMAGE_ID_CACHE=$(echo ${IMAGE_ID_CACHE} | tr '[A-Z]' '[a-z]')
 IMAGE_ID=ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 IMAGE_ID=$(echo ${IMAGE_ID} | tr '[A-Z]' '[a-z]')
 
 # Login to GHCR
 echo ${GITHUB_PUSH_SECRET} | docker login https://ghcr.io -u $GITHUB_USER --password-stdin
 
+# Pull latest image id from cache
+echo pull ${IMAGE_ID_CACHE}
+docker pull ${IMAGE_ID_CACHE}
+
 # Build image
-echo build -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
-docker build -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
+echo build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ${IMAGE_ID_CACHE} -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
+docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ${IMAGE_ID_CACHE} -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
 docker push ${IMAGE_ID}

--- a/packages/debs/amd64/agent/Dockerfile
+++ b/packages/debs/amd64/agent/Dockerfile
@@ -58,3 +58,5 @@ RUN apt update && apt install dirmngr gnupg apt-transport-https ca-certificates 
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     sh -c 'echo "deb https://download.mono-project.com/repo/debian stable-buster main" > /etc/apt/sources.list.d/mono-official-stable.list' && \
     apt update && apt install mono-devel -y
+
+RUN curl -o /usr/local/bin/nuget https://dist.nuget.org/win-x86-commandline/v6.10.2/nuget.exe

--- a/packages/rpms/amd64/agent/Dockerfile
+++ b/packages/rpms/amd64/agent/Dockerfile
@@ -91,3 +91,5 @@ RUN mkdir -p /usr/local/var/lib/rpm && \
 RUN rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF" && \
     su -c 'curl https://download.mono-project.com/repo/centos7-stable.repo | tee /etc/yum.repos.d/mono-centos7-stable.repo' && \
     yum install mono-devel -y
+
+RUN curl -o /usr/local/bin/nuget https://dist.nuget.org/win-x86-commandline/v6.10.2/nuget.exe


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent-packages/issues/143|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team, 

This PR adds the installation of nuget inside the Dockerfiles for AMD64 packages to avoid downloading it in every package-building process.

## Tests

The following workflow run have been performed, building the packages successfully.
* :green_circle: DEB package: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11837172757/job/32983603483
* :green_circle: RPM package: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11837175686/job/32983611864

