### PR TITLE
Add active IPv6 addresses to agent metadata

### DIFF
--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -181,6 +181,10 @@ std::vector<std::string> AgentInfo::GetActiveIPAddresses(const nlohmann::json& n
                 {
                     ipAddresses.emplace_back(iface["IPv4"][0].value("address", ""));
                 }
+                if (iface.contains("IPv6") && !iface["IPv6"].empty())
+                {
+                    ipAddresses.emplace_back(iface["IPv6"][0].value("address", ""));
+                }
             }
         }
     }

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -137,7 +137,8 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
     nlohmann::json os;
     nlohmann::json networks;
     nlohmann::json ip;
-    nlohmann::json address;
+    nlohmann::json address4;
+    nlohmann::json address6;
 
     os["hostname"] = "test_name";
     os["os_name"] = "test_os";
@@ -147,10 +148,14 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
     networks["iface"] = nlohmann::json::array();
 
     ip["state"] = "up";
-    ip["IPv4"] = nlohmann::json::array();
 
-    address["address"] = "127.0.0.1";
-    ip["IPv4"].push_back(address);
+    ip["IPv4"] = nlohmann::json::array();
+    address4["address"] = "127.0.0.1";
+    ip["IPv4"].push_back(address4);
+
+    ip["IPv6"] = nlohmann::json::array();
+    address6["address"] = "fe80::0000";
+    ip["IPv6"].push_back(address6);
 
     networks["iface"].push_back(ip);
 
@@ -175,6 +180,8 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
     EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["platform"], "test_platform");
     EXPECT_TRUE(metadataInfo["agent"]["host"]["ip"] != nullptr);
     EXPECT_EQ(metadataInfo["agent"]["host"]["ip"][0], "127.0.0.1");
+    EXPECT_EQ(metadataInfo["agent"]["host"]["ip"][1], "fe80::0000");
+    EXPECT_TRUE(metadataInfo["agent"]["host"]["ip"][2] == nullptr);
     EXPECT_EQ(metadataInfo["agent"]["host"]["architecture"], "test_arch");
     EXPECT_EQ(metadataInfo["agent"]["host"]["hostname"], "test_name");
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/300|

## Description

This PR includes the IPv6 addresses of the active interfaces in the agent metadata.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X

## Example

```json
{
    "agent": {
        "groups": [],
        "host": {
            "architecture": "aarch64",
            "hostname": "tomas",
            "ip": [
                "192.168.64.15",
                "fde7:1d32:1c4f:33cc:4012:38ff:fece:4be8"
            ],
            "os": {
                "name": "Ubuntu",
                "platform": "Linux"
            }
        },
        "id": "8d22443f-861a-40cd-9624-f360616a2fec",
        "key": "LYhJJxRhI9jLBfBCnZnq0o4JInPbV7cy",
        "name": "test_name",
        "type": "Endpoint",
        "version": "5.0.0"
    }
}
```