### PR TITLE
Remap Inventory Package Fields

### DIFF
--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -52,6 +52,7 @@ class Inventory {
         nlohmann::json EcsSystemData(const nlohmann::json& originalData);
         nlohmann::json GetOSData();
         nlohmann::json EcsHardwareData(const nlohmann::json& originalData);
+        nlohmann::json EcsPackageData(const nlohmann::json& originalData);
         nlohmann::json GetHardwareData();
         nlohmann::json GetNetworkData();
         nlohmann::json GetPortsData();

--- a/src/modules/inventory/src/inventoryImp.cpp
+++ b/src/modules/inventory/src/inventoryImp.cpp
@@ -283,7 +283,7 @@ std::string Inventory::GetPrimaryKeys([[maybe_unused]] const nlohmann::json& dat
     }
     else if (table == PACKAGES_TABLE)
     {
-        ret = data["package"]["name"].dump() + ":" + data["package"]["version"].dump() + ":" + data["package"]["architecture"].dump() + ":" + data["package"]["type"].dump() + ":" + data["package"]["path"].dump();
+        ret = data["package"]["name"].get<std::string>() + ":" + data["package"]["version"].get<std::string>() + ":" + data["package"]["architecture"].get<std::string>() + ":" + data["package"]["type"].get<std::string>() + ":" + data["package"]["path"].get<std::string>();
     }
     return ret;
 }


### PR DESCRIPTION
|Related issue|
|---|
| Closes #297  |


<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Get the original package inventory fields and renamed them in order to comply with the ECS mapping.


## Logs/Alerts example

```json
Body:
{
    "agent": {
        "groups": [],
        "host": {
            "architecture": "x86_64",
            "hostname": "pm-ubuntu24-server",
            "ip": [
                "192.168.0.141",
                "fe80::be24:11ff:fe54:83fb"
            ],
            "os": {
                "name": "Ubuntu",
                "platform": "Linux"
            }
        },
        "id": "03a098ee-ec5d-4658-8daa-721a53ea5cd5",
        "name": "",
        "type": "Endpoint",
        "version": "5.0.0"
    }
}
{
    "id": "aW52ZW50b3J5OnBhY2thZ2VzOiJsaWJjdGYwIjoiMi40Mi00dWJ1bnR1Mi4zIjoiYW1kNjQiOiJkZWIiOiIgIg==",
    "module": "inventory",
    "operation": "create",
    "type": "packages"
}
{
    "package": {
        "architecture": "amd64",
        "description": "Compact C Type Format library (runtime, BFD dependency)",
        "installed": " ",
        "name": "libctf0",
        "path": " ",
        "size": 232,
        "type": "deb",
        "version": "2.42-4ubuntu2.3"
    },
    "scan_time": "2024/11/14 17:58:47"
}

```

64 base decoding:
![image (6)](https://github.com/user-attachments/assets/08d7a643-7ff1-4616-8a83-4227ed97db8d)


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

Running agent against mock server, received propper events with only the packages inventory item enabled.


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

