### PR TITLE
Fix/311 agent registration object

### DIFF
--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -147,21 +147,22 @@ std::string AgentInfo::GetHeaderInfo() const
 std::string AgentInfo::GetMetadataInfo(const bool agentIsRegistering) const
 {
     nlohmann::json agentMetadataInfo;
-    agentMetadataInfo["agent"] = nlohmann::json::object();
-    agentMetadataInfo["agent"]["id"] = GetUUID();
-    agentMetadataInfo["agent"]["name"] = GetName();
-    agentMetadataInfo["agent"]["type"] = GetType();
-    agentMetadataInfo["agent"]["version"] = GetVersion();
-    agentMetadataInfo["agent"]["groups"] = GetGroups();
+    auto& target = agentIsRegistering ? agentMetadataInfo : agentMetadataInfo["agent"];
+
+    target["id"] = GetUUID();
+    target["name"] = GetName();
+    target["type"] = GetType();
+    target["version"] = GetVersion();
+    target["groups"] = GetGroups();
 
     if (!m_endpointInfo.empty())
     {
-        agentMetadataInfo["agent"]["host"] = m_endpointInfo;
+        target["host"] = m_endpointInfo;
     }
 
     if (agentIsRegistering)
     {
-        agentMetadataInfo["agent"]["key"] = GetKey();
+        target["key"] = GetKey();
     }
 
     return agentMetadataInfo.dump();

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -118,18 +118,18 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoNoSysInfo)
 
     auto metadataInfo = nlohmann::json::parse(agentInfo.GetMetadataInfo(true));
 
-    EXPECT_TRUE(metadataInfo["agent"] != nullptr);
+    EXPECT_TRUE(metadataInfo != nullptr);
 
     // Agent information
-    EXPECT_EQ(metadataInfo["agent"]["type"], agentInfo.GetType());
-    EXPECT_EQ(metadataInfo["agent"]["version"], agentInfo.GetVersion());
-    EXPECT_EQ(metadataInfo["agent"]["id"], agentInfo.GetUUID());
-    EXPECT_EQ(metadataInfo["agent"]["name"], agentInfo.GetName());
-    EXPECT_EQ(metadataInfo["agent"]["key"], agentInfo.GetKey());
-    EXPECT_TRUE(metadataInfo["agent"]["groups"] != nullptr);
+    EXPECT_EQ(metadataInfo["type"], agentInfo.GetType());
+    EXPECT_EQ(metadataInfo["version"], agentInfo.GetVersion());
+    EXPECT_EQ(metadataInfo["id"], agentInfo.GetUUID());
+    EXPECT_EQ(metadataInfo["name"], agentInfo.GetName());
+    EXPECT_EQ(metadataInfo["key"], agentInfo.GetKey());
+    EXPECT_TRUE(metadataInfo["groups"] != nullptr);
 
     // Endpoint information
-    EXPECT_TRUE(metadataInfo["agent"]["host"] == nullptr);
+    EXPECT_TRUE(metadataInfo["host"] == nullptr);
 }
 
 TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
@@ -163,27 +163,27 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
 
     auto metadataInfo = nlohmann::json::parse(agentInfo.GetMetadataInfo(true));
 
-    EXPECT_TRUE(metadataInfo["agent"] != nullptr);
+    EXPECT_TRUE(metadataInfo != nullptr);
 
     // Agent information
-    EXPECT_EQ(metadataInfo["agent"]["type"], agentInfo.GetType());
-    EXPECT_EQ(metadataInfo["agent"]["version"], agentInfo.GetVersion());
-    EXPECT_EQ(metadataInfo["agent"]["id"], agentInfo.GetUUID());
-    EXPECT_EQ(metadataInfo["agent"]["name"], agentInfo.GetName());
-    EXPECT_EQ(metadataInfo["agent"]["key"], agentInfo.GetKey());
-    EXPECT_TRUE(metadataInfo["agent"]["groups"] != nullptr);
+    EXPECT_EQ(metadataInfo["type"], agentInfo.GetType());
+    EXPECT_EQ(metadataInfo["version"], agentInfo.GetVersion());
+    EXPECT_EQ(metadataInfo["id"], agentInfo.GetUUID());
+    EXPECT_EQ(metadataInfo["name"], agentInfo.GetName());
+    EXPECT_EQ(metadataInfo["key"], agentInfo.GetKey());
+    EXPECT_TRUE(metadataInfo["groups"] != nullptr);
 
     // Endpoint information
-    EXPECT_TRUE(metadataInfo["agent"]["host"] != nullptr);
-    EXPECT_TRUE(metadataInfo["agent"]["host"]["os"] != nullptr);
-    EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["name"], "test_os");
-    EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["platform"], "test_platform");
-    EXPECT_TRUE(metadataInfo["agent"]["host"]["ip"] != nullptr);
-    EXPECT_EQ(metadataInfo["agent"]["host"]["ip"][0], "127.0.0.1");
-    EXPECT_EQ(metadataInfo["agent"]["host"]["ip"][1], "fe80::0000");
-    EXPECT_TRUE(metadataInfo["agent"]["host"]["ip"][2] == nullptr);
-    EXPECT_EQ(metadataInfo["agent"]["host"]["architecture"], "test_arch");
-    EXPECT_EQ(metadataInfo["agent"]["host"]["hostname"], "test_name");
+    EXPECT_TRUE(metadataInfo["host"] != nullptr);
+    EXPECT_TRUE(metadataInfo["host"]["os"] != nullptr);
+    EXPECT_EQ(metadataInfo["host"]["os"]["name"], "test_os");
+    EXPECT_EQ(metadataInfo["host"]["os"]["platform"], "test_platform");
+    EXPECT_TRUE(metadataInfo["host"]["ip"] != nullptr);
+    EXPECT_EQ(metadataInfo["host"]["ip"][0], "127.0.0.1");
+    EXPECT_EQ(metadataInfo["host"]["ip"][1], "fe80::0000");
+    EXPECT_TRUE(metadataInfo["host"]["ip"][2] == nullptr);
+    EXPECT_EQ(metadataInfo["host"]["architecture"], "test_arch");
+    EXPECT_EQ(metadataInfo["host"]["hostname"], "test_name");
 }
 
 TEST_F(AgentInfoTest, TestLoadMetadataInfoConnected)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #311|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors