### PR TITLE
Fix Agent Registration Behavior

### DIFF
--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -41,20 +41,20 @@ public:
     /// @return A vector of the agent's groups.
     std::vector<std::string> GetGroups() const;
 
-    /// @brief Sets the agent's name.
+    /// @brief Sets the agent's name. The change is not saved to the database until `Save` is called.
     /// @param name The agent's new name.
     void SetName(const std::string& name);
 
-    /// @brief Sets the agent's key.
+    /// @brief Sets the agent's key. The change is not saved to the database until `Save` is called.
     /// @param key The agent's new key.
     /// @return True if the key was successfully set, false otherwise.
     bool SetKey(const std::string& key);
 
-    /// @brief Sets the agent's UUID.
+    /// @brief Sets the agent's UUID. The change is not saved to the database until `Save` is called.
     /// @param uuid The agent's new UUID.
     void SetUUID(const std::string& uuid);
 
-    /// @brief Sets the agent's groups.
+    /// @brief Sets the agent's groups. The change is not saved to the database until `Save` is called.
     /// @param groupList A vector of the agent's new groups.
     void SetGroups(const std::vector<std::string>& groupList);
 

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -75,6 +75,9 @@ public:
     /// @return A string with all information about the agent.
     std::string GetMetadataInfo(const bool agentIsRegistering) const;
 
+    /// @brief Saves the agent's information to the database.
+    void Save() const;
+
 private:
     /// @brief Creates a random key for the agent.
     ///

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -86,7 +86,6 @@ bool AgentInfo::SetKey(const std::string& key)
     return true;
 }
 
-
 void AgentInfo::SetUUID(const std::string& uuid)
 {
     m_uuid = uuid;
@@ -158,7 +157,8 @@ std::string AgentInfo::GetMetadataInfo(const bool agentIsRegistering) const
     return agentMetadataInfo.dump();
 }
 
-void AgentInfo::Save() const {
+void AgentInfo::Save() const
+{
     AgentInfoPersistance agentInfoPersistance;
     agentInfoPersistance.SetName(m_name);
     agentInfoPersistance.SetKey(m_key);

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -27,7 +27,6 @@ AgentInfo::AgentInfo(std::function<nlohmann::json()> getOSInfo, std::function<nl
     if (m_uuid.empty())
     {
         m_uuid = boost::uuids::to_string(boost::uuids::random_generator()());
-        agentInfoPersistance.SetUUID(m_uuid);
     }
 
     if (getOSInfo != nullptr)
@@ -66,15 +65,11 @@ std::vector<std::string> AgentInfo::GetGroups() const
 
 void AgentInfo::SetName(const std::string& name)
 {
-    AgentInfoPersistance agentInfoPersistance;
-    agentInfoPersistance.SetName(name);
     m_name = name;
 }
 
 bool AgentInfo::SetKey(const std::string& key)
 {
-    AgentInfoPersistance agentInfoPersistance;
-
     if (!key.empty())
     {
         if (!ValidateKey(key))
@@ -88,22 +83,17 @@ bool AgentInfo::SetKey(const std::string& key)
         m_key = CreateKey();
     }
 
-    agentInfoPersistance.SetKey(m_key);
-
     return true;
 }
 
+
 void AgentInfo::SetUUID(const std::string& uuid)
 {
-    AgentInfoPersistance agentInfoPersistance;
-    agentInfoPersistance.SetUUID(uuid);
     m_uuid = uuid;
 }
 
 void AgentInfo::SetGroups(const std::vector<std::string>& groupList)
 {
-    AgentInfoPersistance agentInfoPersistance;
-    agentInfoPersistance.SetGroups(groupList);
     m_groups = groupList;
 }
 

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -158,6 +158,14 @@ std::string AgentInfo::GetMetadataInfo(const bool agentIsRegistering) const
     return agentMetadataInfo.dump();
 }
 
+void AgentInfo::Save() const {
+    AgentInfoPersistance agentInfoPersistance;
+    agentInfoPersistance.SetName(m_name);
+    agentInfoPersistance.SetKey(m_key);
+    agentInfoPersistance.SetUUID(m_uuid);
+    agentInfoPersistance.SetGroups(m_groups);
+}
+
 std::vector<std::string> AgentInfo::GetActiveIPAddresses(const nlohmann::json& networksJson) const
 {
     std::vector<std::string> ipAddresses;

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -36,6 +36,7 @@ TEST_F(AgentInfoTest, TestPersistedValues)
     agentInfo.SetName("test_name");
     agentInfo.SetKey("4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj");
     agentInfo.SetUUID("test_uuid");
+    agentInfo.Save();
     const AgentInfo agentInfoReloaded;
     EXPECT_EQ(agentInfoReloaded.GetName(), "test_name");
     EXPECT_EQ(agentInfoReloaded.GetKey(), "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj");
@@ -45,25 +46,27 @@ TEST_F(AgentInfoTest, TestPersistedValues)
 TEST_F(AgentInfoTest, TestSetName)
 {
     AgentInfo agentInfo;
+    const std::string oldName = agentInfo.GetName();
     const std::string newName = "new_name";
 
     agentInfo.SetName(newName);
     EXPECT_EQ(agentInfo.GetName(), newName);
 
     const AgentInfo agentInfoReloaded;
-    EXPECT_EQ(agentInfoReloaded.GetName(), newName);
+    EXPECT_EQ(agentInfoReloaded.GetName(), oldName);
 }
 
 TEST_F(AgentInfoTest, TestSetKey)
 {
     AgentInfo agentInfo;
+    const std::string oldKey = agentInfo.GetKey();
     const std::string newKey = "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj";
 
     agentInfo.SetKey(newKey);
     EXPECT_EQ(agentInfo.GetKey(), newKey);
 
     const AgentInfo agentInfoReloaded;
-    EXPECT_EQ(agentInfoReloaded.GetKey(), newKey);
+    EXPECT_EQ(agentInfoReloaded.GetKey(), oldKey);
 }
 
 TEST_F(AgentInfoTest, TestSetBadKey)
@@ -80,12 +83,13 @@ TEST_F(AgentInfoTest, TestSetEmptyKey)
 {
     AgentInfo agentInfo;
     const std::string newKey;
+    const std::string oldKey = agentInfo.GetKey();
 
     agentInfo.SetKey(newKey);
     EXPECT_NE(agentInfo.GetKey(), newKey);
 
     const AgentInfo agentInfoReloaded;
-    EXPECT_NE(agentInfoReloaded.GetKey(), newKey);
+    EXPECT_EQ(agentInfoReloaded.GetKey(), oldKey);
 }
 
 TEST_F(AgentInfoTest, TestSetUUID)
@@ -97,19 +101,20 @@ TEST_F(AgentInfoTest, TestSetUUID)
     EXPECT_EQ(agentInfo.GetUUID(), newUUID);
 
     const AgentInfo agentInfoReloaded;
-    EXPECT_EQ(agentInfoReloaded.GetUUID(), newUUID);
+    EXPECT_NE(agentInfoReloaded.GetUUID(), newUUID);
 }
 
 TEST_F(AgentInfoTest, TestSetGroups)
 {
     AgentInfo agentInfo;
+    const std::vector<std::string> oldGroups = agentInfo.GetGroups();
     const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
 
     agentInfo.SetGroups(newGroups);
     EXPECT_EQ(agentInfo.GetGroups(), newGroups);
 
     const AgentInfo agentInfoReloaded;
-    EXPECT_EQ(agentInfoReloaded.GetGroups(), newGroups);
+    EXPECT_EQ(agentInfoReloaded.GetGroups(), oldGroups);
 }
 
 TEST_F(AgentInfoTest, TestLoadMetadataInfoNoSysInfo)

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -66,6 +66,7 @@ namespace agent_registration
             return false;
         }
 
+        m_agentInfo.Save();
         return true;
     }
 

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -60,7 +60,7 @@ namespace agent_registration
 
         const auto res = httpClient.PerformHttpRequest(reqParams);
 
-        if (res.result() != http::status::ok)
+        if (res.result() != http::status::created)
         {
             std::cout << "Registration error: " << res.result_int() << ".\n";
             return false;

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -80,7 +80,7 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
     agent->Save();
 
     registration = std::make_unique<agent_registration::AgentRegistration>(
-        "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name", std::nullopt);
+        "user", "password", agent->GetKey(), agent->GetName(), std::nullopt);
 
     MockHttpClient mockHttpClient;
 
@@ -150,10 +150,13 @@ TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
     ASSERT_FALSE(res);
 }
 
-TEST_F(RegisterTest, RegistrationTestSuccessWithEmptyKey)
+TEST_F(RegisterTest, RegisteringWithoutAKeyGeneratesOneAutomatically)
 {
     AgentInfoPersistance agentInfoPersistance;
     agentInfoPersistance.ResetToDefault();
+
+    agent = std::make_unique<AgentInfo>();
+    EXPECT_TRUE(agent->GetKey().empty());
 
     registration =
         std::make_unique<agent_registration::AgentRegistration>("user", "password", "", "agent_name", std::nullopt);
@@ -171,6 +174,9 @@ TEST_F(RegisterTest, RegistrationTestSuccessWithEmptyKey)
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     const bool res = registration->Register(mockHttpClient);
     ASSERT_TRUE(res);
+
+    agent = std::make_unique<AgentInfo>();
+    EXPECT_FALSE(agent->GetKey().empty());
 }
 
 TEST_F(RegisterTest, RegistrationTestFailWithBadKey)

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -98,7 +98,7 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
                                              bodyJson);
 
     boost::beast::http::response<boost::beast::http::dynamic_body> expectedResponse;
-    expectedResponse.result(boost::beast::http::status::ok);
+    expectedResponse.result(boost::beast::http::status::created);
 
     EXPECT_CALL(mockHttpClient, PerformHttpRequest(testing::Eq(reqParams))).WillOnce(testing::Return(expectedResponse));
 
@@ -164,7 +164,7 @@ TEST_F(RegisterTest, RegistrationTestSuccessWithEmptyKey)
         .WillOnce(testing::Return("token"));
 
     boost::beast::http::response<boost::beast::http::dynamic_body> expectedResponse;
-    expectedResponse.result(boost::beast::http::status::ok);
+    expectedResponse.result(boost::beast::http::status::created);
 
     EXPECT_CALL(mockHttpClient, PerformHttpRequest(testing::_)).WillOnce(testing::Return(expectedResponse));
 


### PR DESCRIPTION
## Summary  

This pull request addresses two issues:  
- #314
- #318

## Changes  

- **Database Handling:**
   - Refactored the `AgentInfo` component to delay database writes until registration is confirmed.
    - Introduced a `Save()` method to persist data only after successful registration.
- **Registration Status Code:**
   Modified the expected status code for registration responses from `200` to `201`.

## Tests

- [X] **AgentInfo Tests:**
   - Updated existing tests to validate the new behavior of `Set()` and `Save()`.
   - Verified that database writes only occur after `Save()` is called.
- [X] **AgentRegistration Tests:**
   - Adapted tests to account for the `201` status code as a success indicator.
   - Ensured the agent correctly interprets `201` and does not fail the registration process.
- [X] **Manual Testing:**
   - Tested with a mock server using Imposter: #281
     - Verified that `201` responses result in successful registration.
     - Confirmed that the database remains unmodified in cases of registration failure.

> [!IMPORTANT] 
> In this change, we simplify the `RegistrationTestSuccessWithEmptyKey` test, since this test makes the agent produce a random key. Since persistence is removed, the mock does not have access to the new key. However, the persistence behavior of `AgentRegistration` is checked in `RegistrationSuccess`.

### Manual testing

#### Registration failure

```shell
./wazuh-agent --config-file wazuh-agent.yml --register-agent --user wazuh --password topsecret --name other
```

> Failed to authenticate with the manager
> wazuh-agent registration failed


```shell
sqlite3 agent_info.db 'select * from agent_info'
```

> ||

#### Registration success

```shell
./wazuh-agent --config-file wazuh-agent.yml --register-agent --user wazuh --password topsecret --name dummy
```

> wazuh-agent registered


```shell
sqlite3 agent_info.db 'select * from agent_info'
```

> dummy|vEcz2euGDR2mTAxn4Fu6KrCIOhmsfq7U|114563d6-a9ae-4aec-aa58-7f0ee0500bab