### PR TITLE
Add OS version to messages metadata

### DIFF
--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -202,6 +202,7 @@ void AgentInfo::LoadEndpointInfo()
         m_endpointInfo["os"] = nlohmann::json::object();
         m_endpointInfo["os"]["name"] = osInfo.value("os_name", "Unknown");
         m_endpointInfo["os"]["platform"] = osInfo.value("sysname", "Unknown");
+        m_endpointInfo["os"]["version"] = osInfo.value("os_version", "Unknown");
     }
 
     if (m_getNetworksInfo != nullptr)

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -143,6 +143,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
     os["hostname"] = "test_name";
     os["os_name"] = "test_os";
     os["sysname"] = "test_platform";
+    os["os_version"] = "1.0.0";
     os["architecture"] = "test_arch";
 
     networks["iface"] = nlohmann::json::array();
@@ -178,6 +179,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
     EXPECT_TRUE(metadataInfo["host"]["os"] != nullptr);
     EXPECT_EQ(metadataInfo["host"]["os"]["name"], "test_os");
     EXPECT_EQ(metadataInfo["host"]["os"]["platform"], "test_platform");
+    EXPECT_EQ(metadataInfo["host"]["os"]["version"], "1.0.0");
     EXPECT_TRUE(metadataInfo["host"]["ip"] != nullptr);
     EXPECT_EQ(metadataInfo["host"]["ip"][0], "127.0.0.1");
     EXPECT_EQ(metadataInfo["host"]["ip"][1], "fe80::0000");
@@ -196,6 +198,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoConnected)
     os["hostname"] = "test_name";
     os["os_name"] = "test_os";
     os["sysname"] = "test_platform";
+    os["os_version"] = "1.0.0";
     os["architecture"] = "test_arch";
 
     networks["iface"] = nlohmann::json::array();
@@ -227,6 +230,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoConnected)
     EXPECT_TRUE(metadataInfo["agent"]["host"]["os"] != nullptr);
     EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["name"], "test_os");
     EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["platform"], "test_platform");
+    EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["version"], "1.0.0");
     EXPECT_TRUE(metadataInfo["agent"]["host"]["ip"] != nullptr);
     EXPECT_EQ(metadataInfo["agent"]["host"]["ip"][0], "127.0.0.1");
     EXPECT_EQ(metadataInfo["agent"]["host"]["architecture"], "test_arch");


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/316|

## Description

This PR includes the OS version in the agent metadata. This includes:

- Registration requests.
- Stateless requests.
- Stateful requests.

## Logs/Alerts example

Register:
```
{
    "groups": [],
    "host": {
        "architecture": "aarch64",
        "hostname": "tomas",
        "ip": [
            "192.168.64.16",
            "fde7:1d32:1c4f:33cc:70ef:32ff:fecc:228b"
        ],
        "os": {
            "name": "Ubuntu",
            "platform": "Linux",
            "version": "22.04.5 LTS (Jammy Jellyfish)"
        }
    },
    "id": "784832cf-f189-4da8-8abd-b5b99a23e9a2",
    "key": "KPhX7AZXe3FK32wj1hKFaZG8RnfdDRnE",
    "name": "tomas",
    "type": "Endpoint",
    "version": "5.0.0"
}
```

Stateful/stateless:
```
{
    "agent": {
        "groups": [],
        "host": {
            "architecture": "aarch64",
            "hostname": "tomas",
            "ip": [
                "192.168.64.16",
                "fde7:1d32:1c4f:33cc:70ef:32ff:fecc:228b"
            ],
            "os": {
                "name": "Ubuntu",
                "platform": "Linux",
                "version": "22.04.5 LTS (Jammy Jellyfish)"
            }
        },
        "id": "784832cf-f189-4da8-8abd-b5b99a23e9a2",
        "name": "tomas",
        "type": "Endpoint",
        "version": "5.0.0"
    }
}
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X