### PR TITLE
Fixed access to Message.data in GetCommandFromQueue function

### DIFF
--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -63,7 +63,7 @@ std::optional<module_command::CommandEntry> GetCommandFromQueue(std::shared_ptr<
     }
 
     Message m = multiTypeQueue->getNext(MessageType::COMMAND);
-    nlohmann::json jsonData = m.data.at(0).at("data");
+    nlohmann::json jsonData = m.data;
 
     std::string id;
     std::string module;

--- a/src/agent/tests/message_queue_utils_test.cpp
+++ b/src/agent/tests/message_queue_utils_test.cpp
@@ -8,8 +8,8 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
-const nlohmann::json BASE_DATA_CONTENT = R"([{"data": {"id":"112233", "args": ["origin_test",
-                                        "command_test", "parameters_test"]}}])"_json;
+const nlohmann::json BASE_DATA_CONTENT = R"({"id":"112233", "args": ["origin_test",
+                                        "command_test", "parameters_test"]})"_json;
 
 class MockMultiTypeQueue : public MultiTypeQueue
 {


### PR DESCRIPTION
|Related issue|
|---|
||

## Description

This PR fixes the access to `“data”` inside the `GetCommandFromQueue `function.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
