### PR TITLE
Add registration URL to register parameters

### DIFF
--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -43,7 +43,8 @@ public:
 
     /// @brief Sets the agent's name. The change is not saved to the database until `Save` is called.
     /// @param name The agent's new name.
-    void SetName(const std::string& name);
+    /// @return True if the name was successfully set, false otherwise.
+    bool SetName(const std::string& name);
 
     /// @brief Sets the agent's key. The change is not saved to the database until `Save` is called.
     /// @param key The agent's new key.

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -63,9 +63,22 @@ std::vector<std::string> AgentInfo::GetGroups() const
     return m_groups;
 }
 
-void AgentInfo::SetName(const std::string& name)
+bool AgentInfo::SetName(const std::string& name)
 {
-    m_name = name;
+    if (!name.empty())
+    {
+        m_name = name;
+    }
+    else if (m_getOSInfo != nullptr)
+    {
+        m_name = m_getOSInfo().value("hostname", "Unknown");
+    }
+    else
+    {
+        return false;
+    }
+
+    return true;
 }
 
 bool AgentInfo::SetKey(const std::string& key)

--- a/src/agent/configuration_parser/include/configuration_parser.hpp
+++ b/src/agent/configuration_parser/include/configuration_parser.hpp
@@ -71,7 +71,7 @@ namespace configuration
             }
             catch (const std::exception& e)
             {
-                LogWarn("Requested setting not found, default value used. {}", e.what());
+                LogDebug("Requested setting not found, default value used. {}", e.what());
                 return std::nullopt;
             }
         }

--- a/src/agent/configuration_parser/tests/configuration_parser_test.cpp
+++ b/src/agent/configuration_parser/tests/configuration_parser_test.cpp
@@ -25,7 +25,6 @@ protected:
         outFile << R"(
             agent:
                 server_url: https://myserver:28000
-                registration_url: https://myserver:56000
             inventory:
                 enabled: false
                 interval: 7200
@@ -61,7 +60,6 @@ protected:
         outFile << R"(
             agent:
                 server_url: https://myserver:28000
-                registration_url: https://myserver:56000
             inventory:
                 enabled: false
                 interval: 7200

--- a/src/agent/include/agent_registration.hpp
+++ b/src/agent/include/agent_registration.hpp
@@ -32,11 +32,8 @@ namespace agent_registration
         /// @param password The user's password.
         /// @param key The agent's key.
         /// @param name The agent's name.
-        AgentRegistration(std::string url,
-                          std::string user,
-                          std::string password,
-                          const std::string& key,
-                          const std::string& name);
+        AgentRegistration(
+            std::string url, std::string user, std::string password, const std::string& key, const std::string& name);
 
         /// @brief Registers the agent with the manager.
         ///

--- a/src/agent/include/agent_registration.hpp
+++ b/src/agent/include/agent_registration.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <agent_info.hpp>
-#include <configuration_parser.hpp>
 #include <ihttp_client.hpp>
 
 #include <sysInfo.hpp>
@@ -28,16 +27,16 @@ namespace agent_registration
     public:
         ///@brief Constructor for the AgentRegistration class.
         ///
+        /// @param url The server URL.
         /// @param user The user's username.
         /// @param password The user's password.
         /// @param key The agent's key.
         /// @param name The agent's name.
-        /// @param configFile The path to the configuration file.
-        AgentRegistration(std::string user,
+        AgentRegistration(std::string url,
+                          std::string user,
                           std::string password,
                           const std::string& key,
-                          const std::string& name,
-                          std::optional<std::string> configFile);
+                          const std::string& name);
 
         /// @brief Registers the agent with the manager.
         ///
@@ -51,9 +50,6 @@ namespace agent_registration
 
         /// @brief The agent's information.
         AgentInfo m_agentInfo;
-
-        /// @brief The configuration parser.
-        configuration::ConfigurationParser m_configurationParser;
 
         /// @brief The URL of the manager.
         std::string m_serverUrl;

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -10,11 +10,8 @@ namespace http = boost::beast::http;
 
 namespace agent_registration
 {
-    AgentRegistration::AgentRegistration(std::string url,
-                                         std::string user,
-                                         std::string password,
-                                         const std::string& key,
-                                         const std::string& name)
+    AgentRegistration::AgentRegistration(
+        std::string url, std::string user, std::string password, const std::string& key, const std::string& name)
         : m_agentInfo([this]() { return m_sysInfo.os(); }, [this]() { return m_sysInfo.networks(); })
         , m_serverUrl(std::move(url))
         , m_user(std::move(user))

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -10,17 +10,13 @@ namespace http = boost::beast::http;
 
 namespace agent_registration
 {
-    AgentRegistration::AgentRegistration(std::string user,
+    AgentRegistration::AgentRegistration(std::string url,
+                                         std::string user,
                                          std::string password,
                                          const std::string& key,
-                                         const std::string& name,
-                                         std::optional<std::string> configFile)
+                                         const std::string& name)
         : m_agentInfo([this]() { return m_sysInfo.os(); }, [this]() { return m_sysInfo.networks(); })
-        , m_configurationParser(configFile.has_value() && !configFile->empty()
-                                    ? configuration::ConfigurationParser(std::filesystem::path(configFile.value()))
-                                    : configuration::ConfigurationParser())
-        , m_serverUrl(m_configurationParser.GetConfig<std::string>("agent", "registration_url")
-                          .value_or(config::agent::DEFAULT_REGISTRATION_URL))
+        , m_serverUrl(std::move(url))
         , m_user(std::move(user))
         , m_password(std::move(password))
     {
@@ -29,13 +25,9 @@ namespace agent_registration
             throw std::invalid_argument("--key argument must be alphanumeric and 32 characters in length");
         }
 
-        if (!name.empty())
+        if (!m_agentInfo.SetName(name))
         {
-            m_agentInfo.SetName(name);
-        }
-        else
-        {
-            m_agentInfo.SetName(m_sysInfo.os().value("hostname", "Unknown"));
+            throw std::runtime_error("Couldn't set agent name");
         }
     }
 

--- a/src/agent/src/main.cpp
+++ b/src/agent/src/main.cpp
@@ -20,11 +20,11 @@ int main(int argc, char* argv[])
 
         if (cmdParser.OptionExists(OPT_REGISTER_AGENT))
         {
-            RegisterAgent(cmdParser.GetOptionValue(OPT_USER),
+            RegisterAgent(cmdParser.GetOptionValue(OPT_URL),
+                          cmdParser.GetOptionValue(OPT_USER),
                           cmdParser.GetOptionValue(OPT_PASSWORD),
                           cmdParser.GetOptionValue(OPT_KEY),
-                          cmdParser.GetOptionValue(OPT_NAME),
-                          configFile);
+                          cmdParser.GetOptionValue(OPT_NAME));
         }
         else if (cmdParser.OptionExists(OPT_RESTART))
         {

--- a/src/agent/src/process_options.cpp
+++ b/src/agent/src/process_options.cpp
@@ -7,19 +7,19 @@
 #include <iostream>
 #include <string>
 
-void RegisterAgent(const std::string& user,
+void RegisterAgent(const std::string& url,
+                   const std::string& user,
                    const std::string& password,
                    const std::string& key,
-                   const std::string& name,
-                   const std::string& configFile)
+                   const std::string& name)
 {
-    if (!user.empty() && !password.empty())
+    if (!url.empty() && !user.empty() && !password.empty())
     {
         try
         {
             std::cout << "Starting wazuh-agent registration\n";
 
-            agent_registration::AgentRegistration reg(user, password, key, name, configFile);
+            agent_registration::AgentRegistration reg(url, user, password, key, name);
 
             http_client::HttpClient httpClient;
             if (reg.Register(httpClient))
@@ -38,6 +38,6 @@ void RegisterAgent(const std::string& user,
     }
     else
     {
-        std::cout << OPT_USER << " and " << OPT_PASSWORD << " args are mandatory\n";
+        std::cout << OPT_URL << ", " << OPT_USER << " and " << OPT_PASSWORD << " args are mandatory\n";
     }
 }

--- a/src/agent/src/process_options.hpp
+++ b/src/agent/src/process_options.hpp
@@ -13,6 +13,7 @@ static const auto OPT_REGISTER_AGENT {"--register-agent"};
 static const auto OPT_INSTALL_SERVICE {"--install-service"};
 static const auto OPT_REMOVE_SERVICE {"--remove-service"};
 static const auto OPT_RUN_SERVICE {"--run-service"};
+static const auto OPT_URL {"--url"};
 static const auto OPT_USER {"--user"};
 static const auto OPT_PASSWORD {"--password"};
 static const auto OPT_KEY {"--key"};
@@ -20,16 +21,16 @@ static const auto OPT_NAME {"--name"};
 static const auto OPT_HELP {"--help"};
 
 /// @brief Registers the agent with the given parameters.
+/// @param url The Server Management API URL.
 /// @param user The user to use for authentication with Server Management API.
 /// @param password The password to use for authentication with Server Management API.
 /// @param key The key to use for registration.
 /// @param name The name to use for the agent.
-/// @param configFile The file path to the configuration file.
-void RegisterAgent(const std::string& user,
+void RegisterAgent(const std::string& url,
+                   const std::string& user,
                    const std::string& password,
                    const std::string& key,
-                   const std::string& name,
-                   const std::string& configFile);
+                   const std::string& name);
 
 /// @brief Restarts the agent using the specified configuration file.
 /// @param configFile The file path to the configuration file to use for restarting the agent.

--- a/src/agent/test_tool/mock_server/mock_server.py
+++ b/src/agent/test_tool/mock_server/mock_server.py
@@ -96,7 +96,7 @@ class MockHandler(BaseHTTPRequestHandler):
             self._set_headers(code=200, content_length=len(response))
         elif self.path == "/agents":
             response = self._load_response("agents.json")
-            self._set_headers(code=200, content_length=len(response))
+            self._set_headers(code=201, content_length=len(response))
         elif self.path == "/api/v1/authentication":
             response = generate_authentication_response()
             self._set_headers(code=200, content_length=len(response))

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -181,8 +181,9 @@ TEST_F(RegisterTest, RegisteringWithoutAKeyGeneratesOneAutomatically)
 
 TEST_F(RegisterTest, RegistrationTestFailWithBadKey)
 {
-    ASSERT_THROW(agent_registration::AgentRegistration(
-        "https://localhost:55000", "user", "password", "badKey", "agent_name"), std::invalid_argument);
+    ASSERT_THROW(
+        agent_registration::AgentRegistration("https://localhost:55000", "user", "password", "badKey", "agent_name"),
+        std::invalid_argument);
 }
 
 int main(int argc, char** argv)

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -80,7 +80,7 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
     agent->Save();
 
     registration = std::make_unique<agent_registration::AgentRegistration>(
-        "user", "password", agent->GetKey(), agent->GetName(), std::nullopt);
+        "https://localhost:55000", "user", "password", agent->GetKey(), agent->GetName());
 
     MockHttpClient mockHttpClient;
 
@@ -113,7 +113,7 @@ TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
     agentInfoPersistance.ResetToDefault();
 
     registration = std::make_unique<agent_registration::AgentRegistration>(
-        "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name", std::nullopt);
+        "https://localhost:55000", "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name");
     agent = std::make_unique<AgentInfo>();
 
     MockHttpClient mockHttpClient;
@@ -132,7 +132,7 @@ TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
     agentInfoPersistance.ResetToDefault();
 
     registration = std::make_unique<agent_registration::AgentRegistration>(
-        "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name", std::nullopt);
+        "https://localhost:55000", "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name");
     agent = std::make_unique<AgentInfo>();
 
     MockHttpClient mockHttpClient;
@@ -158,8 +158,8 @@ TEST_F(RegisterTest, RegisteringWithoutAKeyGeneratesOneAutomatically)
     agent = std::make_unique<AgentInfo>();
     EXPECT_TRUE(agent->GetKey().empty());
 
-    registration =
-        std::make_unique<agent_registration::AgentRegistration>("user", "password", "", "agent_name", std::nullopt);
+    registration = std::make_unique<agent_registration::AgentRegistration>(
+        "https://localhost:55000", "user", "password", "", "agent_name");
 
     MockHttpClient mockHttpClient;
 
@@ -181,8 +181,8 @@ TEST_F(RegisterTest, RegisteringWithoutAKeyGeneratesOneAutomatically)
 
 TEST_F(RegisterTest, RegistrationTestFailWithBadKey)
 {
-    ASSERT_THROW(agent_registration::AgentRegistration("user", "password", "badKey", "agent_name", std::nullopt),
-                 std::invalid_argument);
+    ASSERT_THROW(agent_registration::AgentRegistration(
+        "https://localhost:55000", "user", "password", "badKey", "agent_name"), std::invalid_argument);
 }
 
 int main(int argc, char** argv)

--- a/src/cmake/config.cmake
+++ b/src/cmake/config.cmake
@@ -6,8 +6,6 @@ set(VERSION "0.1")
 
 set(DEFAULT_SERVER_URL "https://localhost:27000" CACHE STRING "Default Agent Server Url")
 
-set(DEFAULT_REGISTRATION_URL "https://localhost:55000" CACHE STRING "Default Agent Registration Url")
-
 set(DEFAULT_RETRY_INTERVAL 30 CACHE STRING "Default Agent retry interval")
 
 set(BUFFER_SIZE 4096 CACHE STRING "Default Logcollector reading buffer size")

--- a/src/common/config/include/config.h.in
+++ b/src/common/config/include/config.h.in
@@ -8,7 +8,6 @@ namespace config
     namespace agent
     {
     constexpr auto DEFAULT_SERVER_URL = "@DEFAULT_SERVER_URL@";
-    constexpr auto DEFAULT_REGISTRATION_URL = "@DEFAULT_REGISTRATION_URL@";
     constexpr auto DEFAULT_RETRY_INTERVAL = @DEFAULT_RETRY_INTERVAL@;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/317|

## Description

This PR adds the new option `--url` to the `--register-agent` command. This setting replaces the configuration option `registration_url` since this is a one time operation for an agent and such a setting is not necessary.

## Logs/Alerts example

```

[2024-11-19 23:30:44] POST /security/user/authenticate
Headers:
Host: localhost
User-Agent: WazuhXDR/5.0.0 (Endpoint; aarch64; Linux)
Accept: application/json
Authorization: Basic dGVzdDp0ZXN0


Body:



[2024-11-19 23:30:44] POST /agents
Headers:
Host: localhost
User-Agent: WazuhXDR/5.0.0 (Endpoint; aarch64; Linux)
Accept: application/json
Authorization: Bearer asdasd
Content-Type: application/json
Content-Length: 351


Body:
{"groups":[],"host":{"architecture":"aarch64","hostname":"tomas","ip":["192.168.64.16","fde7:1d32:1c4f:33cc:70ef:32ff:fecc:228b"],"os":{"name":"Ubuntu","platform":"Linux","version":"22.04.5 LTS (Jammy Jellyfish)"}},"id":"c9f47fa0-5f97-44e6-9d9c-210de74e703d","key":"dnio4rvfHVNIXsXeLFRQB6679q2AKIrh","name":"tomas","type":"Endpoint","version":"5.0.0"}

```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X