### PR TITLE
Race condition check for if file was deleted

### DIFF
--- a/src/modules/rootcheck/src/check_rc_sys.c
+++ b/src/modules/rootcheck/src/check_rc_sys.c
@@ -10,6 +10,8 @@
 
 #include "shared.h"
 #include "rootcheck.h"
+#include <errno.h>
+#include <unistd.h>
 
 /* Prototypes */
 static int read_sys_file(const char *file_name, int do_read);
@@ -35,6 +37,14 @@ static int read_sys_file(const char *file_name, int do_read)
     os_check_ads(file_name);
 #endif
     if (lstat(file_name, &statbuf) < 0) {
+	// Check if the specified error is that the file no longer exists
+        if (errno == ENOENT) {
+            // Double-check file existence to handle potential race condition
+            if (access(file_name, F_OK) != 0) {
+                // File definitely does not exist, likely removed between checks
+                return 0;
+            }
+        }
 #ifndef WIN32
         const char op_msg_fmt[] = "Anomaly detected in file '%*s'. Hidden from stats, but showing up on readdir. Possible kernel level rootkit.";
         char op_msg[OS_SIZE_1024 + 1];


### PR DESCRIPTION
It is possible a file is deleted between the initial check and the `lstat` call on the file which will incorrectly flag it as a potential root kit.

One common example that I see is for a file like `/etc/passwd.lock` where I believe the lock file is deleted between the call to `read_sys_file` and the `lstat` call. Checking for the `errorno` after `lstat` can indicate if the file doesn't exist and then double checking that the file really doesn't exist with `access` can remediate this race condition.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Checks if a file was deleted during a race condition between a file being scanned and `lstat` being checked on the file.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer