### PR TITLE
Remove `registration_url` Option

### DIFF
--- a/etc/config/wazuh-agent.yml
+++ b/etc/config/wazuh-agent.yml
@@ -1,6 +1,5 @@
 agent:
   server_url: https://localhost:27000
-  registration_url: https://localhost:55000
   retry_interval: 30s
 inventory:
   enabled: true

--- a/src/agent/tests/agent_test.cpp
+++ b/src/agent/tests/agent_test.cpp
@@ -32,7 +32,6 @@ protected:
         configFile << R"(
 agent:
   server_url: https://localhost:27000
-  registration_url: https://localhost:55000
   path.data: /tmp/
   retry_interval: 30s
 inventory:


### PR DESCRIPTION
|Related issue|
|---|
|Closes #317|

This PR cleans up the `registration_url` option from _wazuh-agent.yml_, which was deprecated by
- #322