### PR TITLE
Wazuh Agent DEB package cleanup issues after uninstallation

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/postrm
+++ b/packages/debs/SPECS/wazuh-agent/debian/postrm
@@ -5,8 +5,7 @@
 set -e
 export INSTALLATION_WAZUH_DIR="/opt/wazuh-agent"
 WAZUH_TMP_DIR="${INSTALLATION_WAZUH_DIR}/tmp"
-BINARY_DIR="/usr/share/wazuh-agent/bin/"
-BINARY_LIB_DIR="/usr/share/wazuh-agent/lib/"
+WAZUH_SHARE_DIR="/usr/share/wazuh-agent"
 
 case "$1" in
     remove|failed-upgrade|abort-install|abort-upgrade|disappear)
@@ -16,13 +15,18 @@ case "$1" in
         fi
 
         if [ "$1" = "remove" ]; then
-            rm -rf ${BINARY_DIR}
+            rm -rf ${WAZUH_SHARE_DIR}
             rm -f /usr/lib/systemd/system/wazuh-agent.service
-            rm -f ${BINARY_LIB_DIR}libstdc++.so.6
-            rm -rf /etc/wazuh-agent
             rm -rf /var/lib/wazuh-agent
-            # Rename the files (avoid errors if command fail)
-            find /etc/wazuh-agent -type f -exec mv {} ${INSTALLATION_WAZUH_DIR}/tmp/{}.save \; 2>/dev/null || true
+            rm -rf ${INSTALLATION_WAZUH_DIR}
+            # Save config files
+            find /etc/wazuh-agent -type f -exec mv {} {}.save \; 2>/dev/null || true
+
+            # Remove the shared library configuration file if it exists
+            if [ -f /etc/ld.so.conf.d/wazuh-agentlibs.conf ]; then
+              rm -f /etc/ld.so.conf.d/wazuh-agentlibs.conf
+              ldconfig  # Update the linker cache
+            fi
         fi
 
         if getent passwd wazuh >/dev/null 2>&1; then
@@ -38,7 +42,7 @@ case "$1" in
         if getent group wazuh >/dev/null 2>&1; then
             delgroup wazuh > /dev/null 2>&1
         fi
-        rm -rf ${INSTALLATION_WAZUH_DIR}
+        rm -rf /etc/wazuh-agent
     ;;
 
     upgrade)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/346|

## Description

This PR addresses an [issue](https://github.com/wazuh/wazuh-agent/issues/346) where the Wazuh Agent DEB package leaves files and directories behind after uninstallation, depending on whether **apt remove** or **apt purge** is used.

**Note:** The configuration files will be renamed by adding `.save` to the end of the filename and retained in the same folder, `/etc/wazuh-agent`.



## Problem Identified:

When using apt remove, the following files and directories are not removed:

- `/usr/share/wazuh-agent`
- `/var/lib/dpkg/info/wazuh-agent.list`
- `/var/lib/dpkg/info/wazuh-agent.postrm`
- `/etc/ld.so.conf.d/wazuh-agentlibs.conf`
- `/opt/wazuh-agent`

So, those files:
- `/var/lib/dpkg/info/wazuh-agent.list`
- `/var/lib/dpkg/info/wazuh-agent.postrm`

**Note**: These files are considered part of the package configuration and should be removed during **apt purge**.


**apt purge:** should fully remove all files, including configuration files and package manager files.

## Tests

Package generated: 
- https://github.com/wazuh/wazuh-agent-packages/actions/runs/12042177486/job/33575376708

<details>
<summary>Setup</summary>

```bash
cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```
</details>


### This PR
<details>
<summary>apt remove wazuh-agent</summary>

```bash
apt remove wazuh-agent                          
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following package was automatically installed and is no longer required:
  lsb-release
Use 'apt autoremove' to remove it.
The following packages will be REMOVED:
  wazuh-agent
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 16.6 MB disk space will be freed.
Do you want to continue? [Y/n] Y
(Reading database ... 6124 files and directories currently installed.)
Removing wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.36-9+deb12u9) ...
```
</details>

<details>
<summary>Result</summary>

```bash
root@83648212e5bb:~# find / -name "*wazuh*" 
/var/lib/dpkg/info/wazuh-agent.postrm
/var/lib/dpkg/info/wazuh-agent.list
/etc/wazuh-agent
/etc/wazuh-agent/wazuh-agent.yml.save
```
</details>


<details>
<summary>apt purge wazuh-agent</summary>

```bash
apt purge wazuh-agent                          
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following package was automatically installed and is no longer required:
  lsb-release
Use 'apt autoremove' to remove it.
The following packages will be REMOVED:
  wazuh-agent*
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 16.6 MB disk space will be freed.
Do you want to continue? [Y/n] Y
(Reading database ... 6124 files and directories currently installed.)
Removing wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.36-9+deb12u9) ...
(Reading database ... 6116 files and directories currently installed.)
Purging configuration files for wazuh-agent (5.0.0-0) ...
```
</details>

<details>
<summary>Result</summary>

```bash
root@83648212e5bb:~# find /  -name "*wazuh*" 
root@83648212e5bb:~#
```
</details>
