### PR TITLE
Remove ldconfig from wazuh-agent package

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/postinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/postinst
@@ -40,10 +40,6 @@ case "$1" in
         ${BINARY_DIR}wazuh-agent --restart > /dev/null 2>&1
     fi
 
-    touch /etc/ld.so.conf.d/wazuh-agentlibs.conf
-    echo "/usr/share/wazuh-agent/lib" >> /etc/ld.so.conf.d/wazuh-agentlibs.conf
-    ldconfig
-
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/347|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

After a thorough analysis of the problem, we have decided to remove the use of ldconfig from the package, and remove the file created in /etc/ld.so.conf.d/wazuh-agentlibs.conf as well.

This way we ensure that no process needs to be restarted during the installation of Wazuh, eliminating all the possible problems that this would bring.


## Tests

After generate a package:
[wazuh-agent_5.0.0-0_amd64_d6f63f36a.zip](https://github.com/user-attachments/files/17950862/wazuh-agent_5.0.0-0_amd64_d6f63f36a.zip)

<details><summary> Ubuntu 22 🟢</summary>

```
vagrant@ubuntu22:~$ sudo apt install /vagrant/packages/wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent' instead of '/vagrant/packages/wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb'
The following NEW packages will be installed:
  wazuh-agent
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/4,606 kB of archives.
After this operation, 16.6 MB of additional disk space will be used.
Get:1 /vagrant/packages/wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb wazuh-agent amd64 5.0.0-0 [4,606 kB]
Preconfiguring packages ...
Selecting previously unselected package wazuh-agent.
(Reading database ... 44902 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb ...
Unpacking wazuh-agent (5.0.0-0) ...
Setting up wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
Scanning processes...
Scanning linux images...

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.

vagrant@ubuntu22:~$ sudo apt purge wazuh-agent
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages will be REMOVED:
  wazuh-agent*
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 16.6 MB disk space will be freed.
Do you want to continue? [Y/n]
(Reading database ... 44915 files and directories currently installed.)
Removing wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
(Reading database ... 44905 files and directories currently installed.)
Purging configuration files for wazuh-agent (5.0.0-0) ...
dpkg: warning: while removing wazuh-agent, directory '/usr/lib/systemd/system' not empty so not removed

vagrant@ubuntu22:~$ sudo apt install /vagrant/packages/wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent' instead of '/vagrant/packages/wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb'
The following NEW packages will be installed:
  wazuh-agent
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/4,606 kB of archives.
After this operation, 16.6 MB of additional disk space will be used.
Get:1 /vagrant/packages/wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb wazuh-agent amd64 5.0.0-0 [4,606 kB]
Preconfiguring packages ...
Selecting previously unselected package wazuh-agent.
(Reading database ... 44902 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb ...
Unpacking wazuh-agent (5.0.0-0) ...
Setting up wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
Scanning processes...
Scanning linux images...

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
```
</details>


<details><summary> Ubuntu 24 🟢</summary>

```
vagrant@ubuntu24:~$ sudo apt install /vagrant/packages/wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent' instead of '/vagrant/packages/wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb'
The following packages were automatically installed and are no longer required:
  cmake-data libjsoncpp25 librhash0
Use 'sudo apt autoremove' to remove them.
The following NEW packages will be installed:
  wazuh-agent
0 upgraded, 1 newly installed, 0 to remove and 132 not upgraded.
Need to get 0 B/4,606 kB of archives.
After this operation, 16.6 MB of additional disk space will be used.
Get:1 /vagrant/packages/wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb wazuh-agent amd64 5.0.0-0 [4,606 kB]
Preconfiguring packages ...
Selecting previously unselected package wazuh-agent.
(Reading database ... 94518 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb ...
Unpacking wazuh-agent (5.0.0-0) ...
Setting up wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.39-0ubuntu8.3) ...
Scanning processes...
Scanning linux images...

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.

vagrant@ubuntu24:~$ sudo apt purge wazuh-agent
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  cmake-data libjsoncpp25 librhash0
Use 'sudo apt autoremove' to remove them.
The following packages will be REMOVED:
  wazuh-agent*
0 upgraded, 0 newly installed, 1 to remove and 132 not upgraded.
After this operation, 16.6 MB disk space will be freed.
Do you want to continue? [Y/n]
(Reading database ... 94530 files and directories currently installed.)
Removing wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.39-0ubuntu8.3) ...
(Reading database ... 94522 files and directories currently installed.)
Purging configuration files for wazuh-agent (5.0.0-0) ...

vagrant@ubuntu24:~$ sudo apt install /vagrant/packages/wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent' instead of '/vagrant/packages/wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb'
The following packages were automatically installed and are no longer required:
  cmake-data libjsoncpp25 librhash0
Use 'sudo apt autoremove' to remove them.
The following NEW packages will be installed:
  wazuh-agent
0 upgraded, 1 newly installed, 0 to remove and 132 not upgraded.
Need to get 0 B/4,606 kB of archives.
After this operation, 16.6 MB of additional disk space will be used.
Get:1 /vagrant/packages/wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb wazuh-agent amd64 5.0.0-0 [4,606 kB]
Preconfiguring packages ...
Selecting previously unselected package wazuh-agent.
(Reading database ... 94518 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_5.0.0-0_amd64_d6f63f36a.deb ...
Unpacking wazuh-agent (5.0.0-0) ...
Setting up wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.39-0ubuntu8.3) ...
Scanning processes...
Scanning linux images...

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
```
</details>
