### PR TITLE
Change platform field in header for type

### DIFF
--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -215,7 +215,7 @@ void AgentInfo::LoadEndpointInfo()
         m_endpointInfo["architecture"] = osInfo.value("architecture", "Unknown");
         m_endpointInfo["os"] = nlohmann::json::object();
         m_endpointInfo["os"]["name"] = osInfo.value("os_name", "Unknown");
-        m_endpointInfo["os"]["platform"] = osInfo.value("sysname", "Unknown");
+        m_endpointInfo["os"]["type"] = osInfo.value("sysname", "Unknown");
         m_endpointInfo["os"]["version"] = osInfo.value("os_version", "Unknown");
     }
 

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -144,7 +144,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
 
     os["hostname"] = "test_name";
     os["os_name"] = "test_os";
-    os["sysname"] = "test_platform";
+    os["sysname"] = "test_type";
     os["os_version"] = "1.0.0";
     os["architecture"] = "test_arch";
 
@@ -180,7 +180,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
     EXPECT_TRUE(metadataInfo["host"] != nullptr);
     EXPECT_TRUE(metadataInfo["host"]["os"] != nullptr);
     EXPECT_EQ(metadataInfo["host"]["os"]["name"], "test_os");
-    EXPECT_EQ(metadataInfo["host"]["os"]["platform"], "test_platform");
+    EXPECT_EQ(metadataInfo["host"]["os"]["type"], "test_type");
     EXPECT_EQ(metadataInfo["host"]["os"]["version"], "1.0.0");
     EXPECT_TRUE(metadataInfo["host"]["ip"] != nullptr);
     EXPECT_EQ(metadataInfo["host"]["ip"][0], "127.0.0.1");
@@ -199,7 +199,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoConnected)
 
     os["hostname"] = "test_name";
     os["os_name"] = "test_os";
-    os["sysname"] = "test_platform";
+    os["sysname"] = "test_type";
     os["os_version"] = "1.0.0";
     os["architecture"] = "test_arch";
 
@@ -231,7 +231,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoConnected)
     EXPECT_TRUE(metadataInfo["agent"]["host"] != nullptr);
     EXPECT_TRUE(metadataInfo["agent"]["host"]["os"] != nullptr);
     EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["name"], "test_os");
-    EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["platform"], "test_platform");
+    EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["type"], "test_type");
     EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["version"], "1.0.0");
     EXPECT_TRUE(metadataInfo["agent"]["host"]["ip"] != nullptr);
     EXPECT_EQ(metadataInfo["agent"]["host"]["ip"][0], "127.0.0.1");


### PR DESCRIPTION
|Related issue|
|---|
|Close #369|

This PR suggests changing the type field in the header to the platform field, that way we maintain compatibility with the documentation and the system table, the update would be in the header.

## Configuration options
default wazuh-agent.yml 
``` yml
agent:
  server_url: https://localhost:27000
  registration_url: https://localhost:55000
  path.data: /tmp/wazuh-agent-data
  retry_interval: 30s
inventory:
  enabled: false
  interval: 1h
  scan_on_start: true
  hardware: true
  system: true
  networks: true
  packages: true
  ports: true
  ports_all: true
  processes: true
  hotfixes: true
logcollector:
  enabled: false
  localfiles:
    - /var/log/auth.log
  reload_interval: 1m
  file_wait: 500ms
```

## Proposed Solution

```json
{
    "agent":
    {
        "groups":
        [],
        "host":
        {
            "architecture": "x86_64",
            "hostname": "VBox",
            "ip":
            [
                "10.0.2.5",
                "fe80::15c0:9312:3e94:ccc4",
                "192.168.78.102",
                "fe80::f827:ee12:cf2f:e5d4"
            ],
            "os":
            {
                "name": "Ubuntu",
                "type": "Linux",
                "version": "24.04.1 LTS (Noble Numbat)"
            }
        },
        "id": "10c69d6d-a80c-49ac-92ad-ae320fba8b93",
        "name": "",
        "type": "Endpoint",
        "version": "5.0.0"
    }
}
```

## Tests

``` test
19: Test timeout computed to be: 10000000
19: [==========] Running 12 tests from 1 test suite.
19: [----------] Global test environment set-up.
19: [----------] 12 tests from AgentInfoTest
19: [ RUN      ] AgentInfoTest.TestDefaultConstructorDefaultValues
19: [       OK ] AgentInfoTest.TestDefaultConstructorDefaultValues (40 ms)
19: [ RUN      ] AgentInfoTest.TestPersistedValues
19: [       OK ] AgentInfoTest.TestPersistedValues (36 ms)
19: [ RUN      ] AgentInfoTest.TestSetName
19: [       OK ] AgentInfoTest.TestSetName (26 ms)
19: [ RUN      ] AgentInfoTest.TestSetKey
19: [       OK ] AgentInfoTest.TestSetKey (26 ms)
19: [ RUN      ] AgentInfoTest.TestSetBadKey
19: [       OK ] AgentInfoTest.TestSetBadKey (34 ms)
19: [ RUN      ] AgentInfoTest.TestSetEmptyKey
19: [       OK ] AgentInfoTest.TestSetEmptyKey (19 ms)
19: [ RUN      ] AgentInfoTest.TestSetUUID
19: [       OK ] AgentInfoTest.TestSetUUID (25 ms)
19: [ RUN      ] AgentInfoTest.TestSetGroups
19: [       OK ] AgentInfoTest.TestSetGroups (22 ms)
19: [ RUN      ] AgentInfoTest.TestLoadMetadataInfoNoSysInfo
19: [       OK ] AgentInfoTest.TestLoadMetadataInfoNoSysInfo (29 ms)
19: [ RUN      ] AgentInfoTest.TestLoadMetadataInfoRegistration
19: [       OK ] AgentInfoTest.TestLoadMetadataInfoRegistration (16 ms)
19: [ RUN      ] AgentInfoTest.TestLoadMetadataInfoConnected
19: [       OK ] AgentInfoTest.TestLoadMetadataInfoConnected (22 ms)
19: [ RUN      ] AgentInfoTest.TestLoadHeaderInfo
19: [       OK ] AgentInfoTest.TestLoadHeaderInfo (27 ms)
19: [----------] 12 tests from AgentInfoTest (329 ms total)
19: 
19: [----------] Global test environment tear-down
19: [==========] 12 tests from 1 test suite ran. (329 ms total)
19: [  PASSED  ] 12 tests.
1/1 Test #19: AgentInfoTest ....................   Passed    0.33 sec

100% tests passed, 0 tests failed out of 1

```
