### PR TITLE
Add messages batch size and interval options

### DIFF
--- a/etc/config/wazuh-agent.yml
+++ b/etc/config/wazuh-agent.yml
@@ -2,6 +2,9 @@ agent:
   thread_count: 4
   server_url: https://localhost:27000
   retry_interval: 30s
+events:
+  batch_interval: 10s
+  batch_size: 1000
 inventory:
   enabled: true
   interval: 1h

--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -73,21 +73,22 @@ namespace communicator
 
         /// @brief Retrieves commands from the manager
         /// @param onSuccess A callback function to execute when a command is received
-        boost::asio::awaitable<void> GetCommandsFromManager(std::function<void(const std::string&)> onSuccess);
+        boost::asio::awaitable<void>
+        GetCommandsFromManager(std::function<void(const int, const std::string&)> onSuccess);
 
         /// @brief Processes messages in a stateful manner
         /// @param getMessages A function to retrieve a message from the queue
         /// @param onSuccess A callback function to execute when a message is processed
         boost::asio::awaitable<void>
         StatefulMessageProcessingTask(std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> getMessages,
-                                      std::function<void(const std::string&)> onSuccess);
+                                      std::function<void(const int, const std::string&)> onSuccess);
 
         /// @brief Processes messages in a stateless manner
         /// @param getMessages A function to retrieve a message from the queue
         /// @param onSuccess A callback function to execute when a message is processed
         boost::asio::awaitable<void> StatelessMessageProcessingTask(
             std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> getMessages,
-            std::function<void(const std::string&)> onSuccess);
+            std::function<void(const int, const std::string&)> onSuccess);
 
         /// @brief Retrieves group configuration from the manager
         /// @param groupName The name of the group to retrieve the configuration for

--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -66,6 +66,15 @@ namespace communicator
                 LogWarn("batch_interval must be greater than zero. Using default value.");
                 m_batchInterval = config::agent::DEFAULT_BATCH_INTERVAL;
             }
+
+            m_batchSize = getConfigValue.template operator()<int>("agent", "batch_size")
+                              .value_or(config::agent::DEFAULT_BATCH_SIZE);
+
+            if (m_batchSize < 1)
+            {
+                LogWarn("batch_size must be greater than zero. Using default value.");
+                m_batchSize = config::agent::DEFAULT_BATCH_SIZE;
+            }
         }
 
         /// @brief Waits for the authentication token to expire and authenticates again
@@ -128,6 +137,9 @@ namespace communicator
 
         /// @brief Time between batch requests
         std::time_t m_batchInterval = config::agent::DEFAULT_BATCH_INTERVAL;
+
+        /// @brief Maximum number of messages to batch
+        int m_batchSize = config::agent::DEFAULT_BATCH_SIZE;
 
         /// @brief The server URL
         std::string m_serverUrl;

--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -79,15 +79,15 @@ namespace communicator
         /// @param getMessages A function to retrieve a message from the queue
         /// @param onSuccess A callback function to execute when a message is processed
         boost::asio::awaitable<void>
-        StatefulMessageProcessingTask(std::function<boost::asio::awaitable<std::string>()> getMessages,
+        StatefulMessageProcessingTask(std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> getMessages,
                                       std::function<void(const std::string&)> onSuccess);
 
         /// @brief Processes messages in a stateless manner
         /// @param getMessages A function to retrieve a message from the queue
         /// @param onSuccess A callback function to execute when a message is processed
-        boost::asio::awaitable<void>
-        StatelessMessageProcessingTask(std::function<boost::asio::awaitable<std::string>()> getMessages,
-                                       std::function<void(const std::string&)> onSuccess);
+        boost::asio::awaitable<void> StatelessMessageProcessingTask(
+            std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> getMessages,
+            std::function<void(const std::string&)> onSuccess);
 
         /// @brief Retrieves group configuration from the manager
         /// @param groupName The name of the group to retrieve the configuration for

--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -61,18 +61,18 @@ namespace communicator
             m_batchInterval = getConfigValue.template operator()<std::time_t>("agent", "batch_interval")
                                   .value_or(config::agent::DEFAULT_BATCH_INTERVAL);
 
-            if (m_batchInterval < 1)
+            if (m_batchInterval < 1'000 || m_batchInterval > (1'000 * 60 * 60))
             {
-                LogWarn("batch_interval must be greater than zero. Using default value.");
+                LogWarn("batch_interval must be between 1s and 1h. Using default value.");
                 m_batchInterval = config::agent::DEFAULT_BATCH_INTERVAL;
             }
 
             m_batchSize = getConfigValue.template operator()<int>("agent", "batch_size")
                               .value_or(config::agent::DEFAULT_BATCH_SIZE);
 
-            if (m_batchSize < 1)
+            if (m_batchSize < 1'000 || m_batchSize > 1'000'000)
             {
-                LogWarn("batch_size must be greater than zero. Using default value.");
+                LogWarn("batch_size must be between 1000 and 1000000. Using default value.");
                 m_batchSize = config::agent::DEFAULT_BATCH_SIZE;
             }
         }

--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -57,6 +57,15 @@ namespace communicator
 
             m_retryInterval = getConfigValue.template operator()<std::time_t>("agent", "retry_interval")
                                   .value_or(config::agent::DEFAULT_RETRY_INTERVAL);
+
+            m_batchInterval = getConfigValue.template operator()<std::time_t>("agent", "batch_interval")
+                                  .value_or(config::agent::DEFAULT_BATCH_INTERVAL);
+
+            if (m_batchInterval < 1)
+            {
+                LogWarn("batch_interval must be greater than zero. Using default value.");
+                m_batchInterval = config::agent::DEFAULT_BATCH_INTERVAL;
+            }
         }
 
         /// @brief Waits for the authentication token to expire and authenticates again
@@ -115,6 +124,9 @@ namespace communicator
 
         /// @brief Time in milliseconds between authentication attemps in case of failure
         std::time_t m_retryInterval = config::agent::DEFAULT_RETRY_INTERVAL;
+
+        /// @brief Time between batch requests
+        std::time_t m_batchInterval = config::agent::DEFAULT_BATCH_INTERVAL;
 
         /// @brief The server URL
         std::string m_serverUrl;

--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -58,7 +58,7 @@ namespace communicator
             m_retryInterval = getConfigValue.template operator()<std::time_t>("agent", "retry_interval")
                                   .value_or(config::agent::DEFAULT_RETRY_INTERVAL);
 
-            m_batchInterval = getConfigValue.template operator()<std::time_t>("agent", "batch_interval")
+            m_batchInterval = getConfigValue.template operator()<std::time_t>("events", "batch_interval")
                                   .value_or(config::agent::DEFAULT_BATCH_INTERVAL);
 
             if (m_batchInterval < 1'000 || m_batchInterval > (1'000 * 60 * 60))
@@ -67,7 +67,7 @@ namespace communicator
                 m_batchInterval = config::agent::DEFAULT_BATCH_INTERVAL;
             }
 
-            m_batchSize = getConfigValue.template operator()<int>("agent", "batch_size")
+            m_batchSize = getConfigValue.template operator()<int>("events", "batch_size")
                               .value_or(config::agent::DEFAULT_BATCH_SIZE);
 
             if (m_batchSize < 1'000 || m_batchSize > 1'000'000)

--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -88,15 +88,15 @@ namespace communicator
         /// @brief Processes messages in a stateful manner
         /// @param getMessages A function to retrieve a message from the queue
         /// @param onSuccess A callback function to execute when a message is processed
-        boost::asio::awaitable<void>
-        StatefulMessageProcessingTask(std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> getMessages,
-                                      std::function<void(const int, const std::string&)> onSuccess);
+        boost::asio::awaitable<void> StatefulMessageProcessingTask(
+            std::function<boost::asio::awaitable<std::tuple<int, std::string>>(const int)> getMessages,
+            std::function<void(const int, const std::string&)> onSuccess);
 
         /// @brief Processes messages in a stateless manner
         /// @param getMessages A function to retrieve a message from the queue
         /// @param onSuccess A callback function to execute when a message is processed
         boost::asio::awaitable<void> StatelessMessageProcessingTask(
-            std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> getMessages,
+            std::function<boost::asio::awaitable<std::tuple<int, std::string>>(const int)> getMessages,
             std::function<void(const int, const std::string&)> onSuccess);
 
         /// @brief Retrieves group configuration from the manager

--- a/src/agent/communicator/include/http_client.hpp
+++ b/src/agent/communicator/include/http_client.hpp
@@ -44,16 +44,16 @@ namespace http_client
         /// @param onSuccess Callback for successful request completion
         /// @param loopRequestCondition Condition to continue looping requests
         /// @return Awaitable task for the HTTP request
-        boost::asio::awaitable<void>
-        Co_PerformHttpRequest(std::shared_ptr<std::string> token,
-                              HttpRequestParams params,
-                              std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> messageGetter,
-                              std::function<void()> onUnauthorized,
-                              std::time_t connectionRetry,
-                              std::time_t batchInterval,
-                              int batchSize,
-                              std::function<void(const int, const std::string&)> onSuccess = {},
-                              std::function<bool()> loopRequestCondition = {}) override;
+        boost::asio::awaitable<void> Co_PerformHttpRequest(
+            std::shared_ptr<std::string> token,
+            HttpRequestParams params,
+            std::function<boost::asio::awaitable<std::tuple<int, std::string>>(const int)> messageGetter,
+            std::function<void()> onUnauthorized,
+            std::time_t connectionRetry,
+            std::time_t batchInterval,
+            int batchSize,
+            std::function<void(const int, const std::string&)> onSuccess = {},
+            std::function<bool()> loopRequestCondition = {}) override;
 
         /// @brief Performs a synchronous HTTP request
         /// @param params Parameters for the request

--- a/src/agent/communicator/include/http_client.hpp
+++ b/src/agent/communicator/include/http_client.hpp
@@ -39,6 +39,7 @@ namespace http_client
         /// @param messageGetter Function to get the message body asynchronously
         /// @param onUnauthorized Callback for unauthorized access
         /// @param connectionRetry Time in milliseconds to wait before retrying the connection
+        /// @param batchInterval Time to wait between requests
         /// @param onSuccess Callback for successful request completion
         /// @param loopRequestCondition Condition to continue looping requests
         /// @return Awaitable task for the HTTP request
@@ -48,6 +49,7 @@ namespace http_client
                               std::function<boost::asio::awaitable<std::string>()> messageGetter,
                               std::function<void()> onUnauthorized,
                               std::time_t connectionRetry,
+                              std::time_t batchInterval,
                               std::function<void(const std::string&)> onSuccess = {},
                               std::function<bool()> loopRequestCondition = {}) override;
 

--- a/src/agent/communicator/include/http_client.hpp
+++ b/src/agent/communicator/include/http_client.hpp
@@ -46,7 +46,7 @@ namespace http_client
         boost::asio::awaitable<void>
         Co_PerformHttpRequest(std::shared_ptr<std::string> token,
                               HttpRequestParams params,
-                              std::function<boost::asio::awaitable<std::string>()> messageGetter,
+                              std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> messageGetter,
                               std::function<void()> onUnauthorized,
                               std::time_t connectionRetry,
                               std::time_t batchInterval,

--- a/src/agent/communicator/include/http_client.hpp
+++ b/src/agent/communicator/include/http_client.hpp
@@ -40,6 +40,7 @@ namespace http_client
         /// @param onUnauthorized Callback for unauthorized access
         /// @param connectionRetry Time in milliseconds to wait before retrying the connection
         /// @param batchInterval Time to wait between requests
+        /// @param batchSize The maximum number of messages to batch
         /// @param onSuccess Callback for successful request completion
         /// @param loopRequestCondition Condition to continue looping requests
         /// @return Awaitable task for the HTTP request
@@ -50,7 +51,8 @@ namespace http_client
                               std::function<void()> onUnauthorized,
                               std::time_t connectionRetry,
                               std::time_t batchInterval,
-                              std::function<void(const std::string&)> onSuccess = {},
+                              int batchSize,
+                              std::function<void(const int, const std::string&)> onSuccess = {},
                               std::function<bool()> loopRequestCondition = {}) override;
 
         /// @brief Performs a synchronous HTTP request

--- a/src/agent/communicator/include/ihttp_client.hpp
+++ b/src/agent/communicator/include/ihttp_client.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 
 namespace http_client
 {
@@ -43,7 +44,7 @@ namespace http_client
         virtual boost::asio::awaitable<void>
         Co_PerformHttpRequest(std::shared_ptr<std::string> token,
                               HttpRequestParams params,
-                              std::function<boost::asio::awaitable<std::string>()> messageGetter,
+                              std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> messageGetter,
                               std::function<void()> onUnauthorized,
                               std::time_t connectionRetry,
                               std::time_t batchInterval,

--- a/src/agent/communicator/include/ihttp_client.hpp
+++ b/src/agent/communicator/include/ihttp_client.hpp
@@ -36,6 +36,7 @@ namespace http_client
         /// @param messageGetter Function to retrieve messages
         /// @param onUnauthorized Action to take on unauthorized access
         /// @param connectionRetry Time to wait before retrying the connection
+        /// @param batchInterval Time to wait between requests
         /// @param onSuccess Action to take on successful request
         /// @param loopRequestCondition Condition to continue the request loop
         /// @return Awaitable task for the HTTP request
@@ -45,6 +46,7 @@ namespace http_client
                               std::function<boost::asio::awaitable<std::string>()> messageGetter,
                               std::function<void()> onUnauthorized,
                               std::time_t connectionRetry,
+                              std::time_t batchInterval,
                               std::function<void(const std::string&)> onSuccess = {},
                               std::function<bool()> loopRequestCondition = {}) = 0;
 

--- a/src/agent/communicator/include/ihttp_client.hpp
+++ b/src/agent/communicator/include/ihttp_client.hpp
@@ -42,16 +42,16 @@ namespace http_client
         /// @param onSuccess Action to take on successful request
         /// @param loopRequestCondition Condition to continue the request loop
         /// @return Awaitable task for the HTTP request
-        virtual boost::asio::awaitable<void>
-        Co_PerformHttpRequest(std::shared_ptr<std::string> token,
-                              HttpRequestParams params,
-                              std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> messageGetter,
-                              std::function<void()> onUnauthorized,
-                              std::time_t connectionRetry,
-                              std::time_t batchInterval,
-                              int batchSize,
-                              std::function<void(const int, const std::string&)> onSuccess = {},
-                              std::function<bool()> loopRequestCondition = {}) = 0;
+        virtual boost::asio::awaitable<void> Co_PerformHttpRequest(
+            std::shared_ptr<std::string> token,
+            HttpRequestParams params,
+            std::function<boost::asio::awaitable<std::tuple<int, std::string>>(const int)> messageGetter,
+            std::function<void()> onUnauthorized,
+            std::time_t connectionRetry,
+            std::time_t batchInterval,
+            int batchSize,
+            std::function<void(const int, const std::string&)> onSuccess = {},
+            std::function<bool()> loopRequestCondition = {}) = 0;
 
         /// @brief Perform an HTTP request and receive the response
         /// @param params The parameters for the request

--- a/src/agent/communicator/include/ihttp_client.hpp
+++ b/src/agent/communicator/include/ihttp_client.hpp
@@ -38,6 +38,7 @@ namespace http_client
         /// @param onUnauthorized Action to take on unauthorized access
         /// @param connectionRetry Time to wait before retrying the connection
         /// @param batchInterval Time to wait between requests
+        /// @param batchSize The maximum number of messages to batch
         /// @param onSuccess Action to take on successful request
         /// @param loopRequestCondition Condition to continue the request loop
         /// @return Awaitable task for the HTTP request
@@ -48,7 +49,8 @@ namespace http_client
                               std::function<void()> onUnauthorized,
                               std::time_t connectionRetry,
                               std::time_t batchInterval,
-                              std::function<void(const std::string&)> onSuccess = {},
+                              int batchSize,
+                              std::function<void(const int, const std::string&)> onSuccess = {},
                               std::function<bool()> loopRequestCondition = {}) = 0;
 
         /// @brief Perform an HTTP request and receive the response

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -80,8 +80,15 @@ namespace communicator
 
         const auto reqParams = http_client::HttpRequestParams(
             boost::beast::http::verb::get, m_serverUrl, "/api/v1/commands", m_getHeaderInfo ? m_getHeaderInfo() : "");
-        co_await m_httpClient->Co_PerformHttpRequest(
-            m_token, reqParams, {}, onAuthenticationFailed, m_retryInterval, m_batchInterval, onSuccess, loopCondition);
+        co_await m_httpClient->Co_PerformHttpRequest(m_token,
+                                                     reqParams,
+                                                     {},
+                                                     onAuthenticationFailed,
+                                                     m_retryInterval,
+                                                     m_batchInterval,
+                                                     m_batchSize,
+                                                     onSuccess,
+                                                     loopCondition);
     }
 
     boost::asio::awaitable<void> Communicator::WaitForTokenExpirationAndAuthenticate()
@@ -149,6 +156,7 @@ namespace communicator
                                                      onAuthenticationFailed,
                                                      m_retryInterval,
                                                      m_batchInterval,
+                                                     m_batchSize,
                                                      onSuccess,
                                                      loopCondition);
     }
@@ -177,6 +185,7 @@ namespace communicator
                                                      onAuthenticationFailed,
                                                      m_retryInterval,
                                                      m_batchInterval,
+                                                     m_batchSize,
                                                      onSuccess,
                                                      loopCondition);
     }

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -124,9 +124,9 @@ namespace communicator
         }
     }
 
-    boost::asio::awaitable<void>
-    Communicator::StatefulMessageProcessingTask(std::function<boost::asio::awaitable<std::string>()> getMessages,
-                                                std::function<void(const std::string&)> onSuccess)
+    boost::asio::awaitable<void> Communicator::StatefulMessageProcessingTask(
+        std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> getMessages,
+        std::function<void(const std::string&)> onSuccess)
     {
         auto onAuthenticationFailed = [this]()
         {
@@ -152,9 +152,9 @@ namespace communicator
                                                      loopCondition);
     }
 
-    boost::asio::awaitable<void>
-    Communicator::StatelessMessageProcessingTask(std::function<boost::asio::awaitable<std::string>()> getMessages,
-                                                 std::function<void(const std::string&)> onSuccess)
+    boost::asio::awaitable<void> Communicator::StatelessMessageProcessingTask(
+        std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> getMessages,
+        std::function<void(const std::string&)> onSuccess)
     {
         auto onAuthenticationFailed = [this]()
         {

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -65,7 +65,8 @@ namespace communicator
         return std::max(0L, static_cast<long>(m_tokenExpTimeInSeconds - now_seconds));
     }
 
-    boost::asio::awaitable<void> Communicator::GetCommandsFromManager(std::function<void(const std::string&)> onSuccess)
+    boost::asio::awaitable<void>
+    Communicator::GetCommandsFromManager(std::function<void(const int, const std::string&)> onSuccess)
     {
         auto onAuthenticationFailed = [this]()
         {
@@ -126,7 +127,7 @@ namespace communicator
 
     boost::asio::awaitable<void> Communicator::StatefulMessageProcessingTask(
         std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> getMessages,
-        std::function<void(const std::string&)> onSuccess)
+        std::function<void(const int, const std::string&)> onSuccess)
     {
         auto onAuthenticationFailed = [this]()
         {
@@ -154,7 +155,7 @@ namespace communicator
 
     boost::asio::awaitable<void> Communicator::StatelessMessageProcessingTask(
         std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> getMessages,
-        std::function<void(const std::string&)> onSuccess)
+        std::function<void(const int, const std::string&)> onSuccess)
     {
         auto onAuthenticationFailed = [this]()
         {

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -80,7 +80,7 @@ namespace communicator
         const auto reqParams = http_client::HttpRequestParams(
             boost::beast::http::verb::get, m_serverUrl, "/api/v1/commands", m_getHeaderInfo ? m_getHeaderInfo() : "");
         co_await m_httpClient->Co_PerformHttpRequest(
-            m_token, reqParams, {}, onAuthenticationFailed, m_retryInterval, onSuccess, loopCondition);
+            m_token, reqParams, {}, onAuthenticationFailed, m_retryInterval, m_batchInterval, onSuccess, loopCondition);
     }
 
     boost::asio::awaitable<void> Communicator::WaitForTokenExpirationAndAuthenticate()
@@ -142,8 +142,14 @@ namespace communicator
                                                               m_serverUrl,
                                                               "/api/v1/events/stateful",
                                                               m_getHeaderInfo ? m_getHeaderInfo() : "");
-        co_await m_httpClient->Co_PerformHttpRequest(
-            m_token, reqParams, getMessages, onAuthenticationFailed, m_retryInterval, onSuccess, loopCondition);
+        co_await m_httpClient->Co_PerformHttpRequest(m_token,
+                                                     reqParams,
+                                                     getMessages,
+                                                     onAuthenticationFailed,
+                                                     m_retryInterval,
+                                                     m_batchInterval,
+                                                     onSuccess,
+                                                     loopCondition);
     }
 
     boost::asio::awaitable<void>
@@ -164,8 +170,14 @@ namespace communicator
                                                               m_serverUrl,
                                                               "/api/v1/events/stateless",
                                                               m_getHeaderInfo ? m_getHeaderInfo() : "");
-        co_await m_httpClient->Co_PerformHttpRequest(
-            m_token, reqParams, getMessages, onAuthenticationFailed, m_retryInterval, onSuccess, loopCondition);
+        co_await m_httpClient->Co_PerformHttpRequest(m_token,
+                                                     reqParams,
+                                                     getMessages,
+                                                     onAuthenticationFailed,
+                                                     m_retryInterval,
+                                                     m_batchInterval,
+                                                     onSuccess,
+                                                     loopCondition);
     }
 
     void Communicator::TryReAuthenticate()

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -133,7 +133,7 @@ namespace communicator
     }
 
     boost::asio::awaitable<void> Communicator::StatefulMessageProcessingTask(
-        std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> getMessages,
+        std::function<boost::asio::awaitable<std::tuple<int, std::string>>(const int)> getMessages,
         std::function<void(const int, const std::string&)> onSuccess)
     {
         auto onAuthenticationFailed = [this]()
@@ -162,7 +162,7 @@ namespace communicator
     }
 
     boost::asio::awaitable<void> Communicator::StatelessMessageProcessingTask(
-        std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> getMessages,
+        std::function<boost::asio::awaitable<std::tuple<int, std::string>>(const int)> getMessages,
         std::function<void(const int, const std::string&)> onSuccess)
     {
         auto onAuthenticationFailed = [this]()

--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -172,7 +172,8 @@ namespace http_client
                         break;
                     }
 
-                    refreshTimer.expires_after(std::chrono::milliseconds(100));
+                    constexpr int refreshInterval = 100;
+                    refreshTimer.expires_after(std::chrono::milliseconds(refreshInterval));
                     co_await refreshTimer.async_wait(boost::asio::use_awaitable);
                 }
             }

--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -101,6 +101,7 @@ namespace http_client
                                       std::function<boost::asio::awaitable<std::string>()> messageGetter,
                                       std::function<void()> onUnauthorized,
                                       std::time_t connectionRetry,
+                                      std::time_t batchInterval,
                                       std::function<void(const std::string&)> onSuccess,
                                       std::function<bool()> loopRequestCondition)
     {
@@ -184,7 +185,7 @@ namespace http_client
                 continue;
             }
 
-            std::time_t timerSleep = A_SECOND_IN_MILLIS;
+            std::time_t timerSleep = batchInterval;
 
             if (res.result() == boost::beast::http::status::ok)
             {

--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -207,7 +207,7 @@ namespace http_client
                 continue;
             }
 
-            std::time_t timerSleep = batchInterval;
+            std::time_t timerSleep = A_SECOND_IN_MILLIS;
 
             if (res.result() == boost::beast::http::status::ok)
             {

--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -98,7 +98,7 @@ namespace http_client
     boost::asio::awaitable<void> HttpClient::Co_PerformHttpRequest(
         std::shared_ptr<std::string> token,
         HttpRequestParams reqParams,
-        std::function<boost::asio::awaitable<std::tuple<int, std::string>>()> messageGetter,
+        std::function<boost::asio::awaitable<std::tuple<int, std::string>>(const int)> messageGetter,
         std::function<void()> onUnauthorized,
         std::time_t connectionRetry,
         std::time_t batchInterval,

--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -157,6 +157,7 @@ namespace http_client
             {
                 const auto messages = co_await messageGetter();
                 messagesCount = std::get<0>(messages);
+                LogTrace("Messages count: {}", messagesCount);
                 reqParams.Body = std::get<1>(messages);
             }
             else

--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -151,9 +151,12 @@ namespace http_client
                 continue;
             }
 
+            auto messagesCount = 0;
+
             if (messageGetter != nullptr)
             {
                 const auto messages = co_await messageGetter();
+                messagesCount = std::get<0>(messages);
                 reqParams.Body = std::get<1>(messages);
             }
             else
@@ -192,7 +195,7 @@ namespace http_client
             {
                 if (onSuccess != nullptr)
                 {
-                    onSuccess(0, boost::beast::buffers_to_string(res.body().data()));
+                    onSuccess(messagesCount, boost::beast::buffers_to_string(res.body().data()));
                 }
             }
             else if (res.result() == boost::beast::http::status::unauthorized ||

--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -192,7 +192,7 @@ namespace http_client
             {
                 if (onSuccess != nullptr)
                 {
-                    onSuccess(boost::beast::buffers_to_string(res.body().data()));
+                    onSuccess(0, boost::beast::buffers_to_string(res.body().data()));
                 }
             }
             else if (res.result() == boost::beast::http::status::unauthorized ||

--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -153,7 +153,8 @@ namespace http_client
 
             if (messageGetter != nullptr)
             {
-                reqParams.Body = co_await messageGetter();
+                const auto messages = co_await messageGetter();
+                reqParams.Body = std::get<1>(messages);
             }
             else
             {

--- a/src/agent/communicator/tests/communicator_test.cpp
+++ b/src/agent/communicator/tests/communicator_test.cpp
@@ -56,7 +56,7 @@ TEST(CommunicatorTest, StatefulMessageProcessingTask_Success)
         co_return std::tuple<int, std::string> {1, std::string("message-content")};
     };
 
-    std::function<void(const std::string&)> onSuccess = [](const std::string& message)
+    std::function<void(const int, const std::string&)> onSuccess = [](const int, const std::string& message)
     {
         EXPECT_EQ(message, "message-content");
     };
@@ -73,7 +73,7 @@ TEST(CommunicatorTest, StatefulMessageProcessingTask_Success)
                [[maybe_unused]] std::function<bool()> loopRequestCondition) -> boost::asio::awaitable<void>
             {
                 const auto message = co_await pGetMessages();
-                pOnSuccess(std::get<1>(message));
+                pOnSuccess(std::get<0>(message), std::get<1>(message));
                 co_return;
             }));
 
@@ -134,7 +134,7 @@ TEST(CommunicatorTest, WaitForTokenExpirationAndAuthenticate_FailedAuthenticatio
             co_await communicatorPtr->StatelessMessageProcessingTask(
                 []() -> boost::asio::awaitable<std::tuple<int, std::string>>
                 { co_return std::tuple<int, std::string>(1, std::string {"message"}); },
-                []([[maybe_unused]] const std::string& msg) {});
+                []([[maybe_unused]] const int, const std::string&) {});
         }(),
         boost::asio::detached);
 
@@ -190,7 +190,7 @@ TEST(CommunicatorTest, StatelessMessageProcessingTask_CallsWithValidToken)
             co_await communicatorPtr->StatelessMessageProcessingTask(
                 []() -> boost::asio::awaitable<std::tuple<int, std::string>>
                 { co_return std::tuple<int, std::string>(1, std::string {"message"}); },
-                []([[maybe_unused]] const std::string& msg) {});
+                []([[maybe_unused]] const int, const std::string&) {});
         }(),
         boost::asio::detached);
 

--- a/src/agent/communicator/tests/communicator_test.cpp
+++ b/src/agent/communicator/tests/communicator_test.cpp
@@ -61,13 +61,14 @@ TEST(CommunicatorTest, StatefulMessageProcessingTask_Success)
         EXPECT_EQ(message, "message-content");
     };
 
-    EXPECT_CALL(*mockHttpClient, Co_PerformHttpRequest(_, _, _, _, _, _, _))
+    EXPECT_CALL(*mockHttpClient, Co_PerformHttpRequest(_, _, _, _, _, _, _, _))
         .WillOnce(Invoke(
             [](std::shared_ptr<std::string>,
                http_client::HttpRequestParams,
                std::function<boost::asio::awaitable<std::string>()> pGetMessages,
                std::function<void()>,
                [[maybe_unused]] std::time_t connectionRetry,
+               [[maybe_unused]] std::time_t batchInterval,
                std::function<void(const std::string&)> pOnSuccess,
                [[maybe_unused]] std::function<bool()> loopRequestCondition) -> boost::asio::awaitable<void>
             {
@@ -108,13 +109,14 @@ TEST(CommunicatorTest, WaitForTokenExpirationAndAuthenticate_FailedAuthenticatio
             }));
 
     // A following call to Co_PerformHttpRequest should not have a token
-    EXPECT_CALL(*mockHttpClientPtr, Co_PerformHttpRequest(_, _, _, _, _, _, _))
+    EXPECT_CALL(*mockHttpClientPtr, Co_PerformHttpRequest(_, _, _, _, _, _, _, _))
         .WillOnce(Invoke(
             [](std::shared_ptr<std::string> token,
                http_client::HttpRequestParams,
                [[maybe_unused]] std::function<boost::asio::awaitable<std::string>()> getMessages,
                [[maybe_unused]] std::function<void()> onUnauthorized,
                [[maybe_unused]] std::time_t connectionRetry,
+               [[maybe_unused]] std::time_t batchInterval,
                [[maybe_unused]] std::function<void(const std::string&)> onSuccess,
                [[maybe_unused]] std::function<bool()> loopCondition) -> boost::asio::awaitable<void>
             {
@@ -162,13 +164,14 @@ TEST(CommunicatorTest, StatelessMessageProcessingTask_CallsWithValidToken)
             }));
 
     std::string capturedToken;
-    EXPECT_CALL(*mockHttpClientPtr, Co_PerformHttpRequest(_, _, _, _, _, _, _))
+    EXPECT_CALL(*mockHttpClientPtr, Co_PerformHttpRequest(_, _, _, _, _, _, _, _))
         .WillOnce(Invoke(
             [&capturedToken](std::shared_ptr<std::string> token,
                              http_client::HttpRequestParams,
                              [[maybe_unused]] std::function<boost::asio::awaitable<std::string>()> getMessages,
                              [[maybe_unused]] std::function<void()> onUnauthorized,
                              [[maybe_unused]] std::time_t connectionRetry,
+                             [[maybe_unused]] std::time_t batchInterval,
                              [[maybe_unused]] std::function<void(const std::string&)> onSuccess,
                              [[maybe_unused]] std::function<bool()> loopCondition) -> boost::asio::awaitable<void>
             {

--- a/src/agent/communicator/tests/http_client_test.cpp
+++ b/src/agent/communicator/tests/http_client_test.cpp
@@ -242,6 +242,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_Success)
                                               getMessages,
                                               onUnauthorized,
                                               5, // NOLINT
+                                              1, // NOLINT
                                               onSuccess,
                                               nullptr);
 
@@ -288,6 +289,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_CallbacksNotCalledIfCannotConnect)
                                               getMessages,
                                               onUnauthorized,
                                               5, // NOLINT
+                                              1, // NOLINT
                                               onSuccess,
                                               nullptr);
 
@@ -335,6 +337,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncWriteFails
                                               getMessages,
                                               onUnauthorized,
                                               5, // NOLINT
+                                              1, // NOLINT
                                               onSuccess,
                                               nullptr);
 
@@ -384,6 +387,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncReadFails)
                                               getMessages,
                                               onUnauthorized,
                                               5, // NOLINT
+                                              1, // NOLINT
                                               onSuccess,
                                               nullptr);
 
@@ -432,6 +436,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_UnauthorizedCalledWhenAuthorization
                                               getMessages,
                                               onUnauthorized,
                                               5, // NOLINT
+                                              1, // NOLINT
                                               onSuccess,
                                               nullptr);
 

--- a/src/agent/communicator/tests/http_client_test.cpp
+++ b/src/agent/communicator/tests/http_client_test.cpp
@@ -215,10 +215,10 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_Success)
     SetupMockSocketReadExpectations(boost::beast::http::status::ok);
 
     auto getMessagesCalled = false;
-    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::string>
+    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::tuple<int, std::string>>
     {
         getMessagesCalled = true;
-        co_return std::string("test message");
+        co_return std::tuple<int, std::string>(1, "test message");
     };
 
     auto onSuccessCalled = false;
@@ -263,10 +263,10 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_CallbacksNotCalledIfCannotConnect)
     SetupMockSocketConnectExpectations(boost::system::errc::make_error_code(boost::system::errc::bad_address));
 
     auto getMessagesCalled = false;
-    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::string>
+    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::tuple<int, std::string>>
     {
         getMessagesCalled = true;
-        co_return std::string("test message");
+        co_return std::tuple<int, std::string>(1, "test message");
     };
 
     auto onSuccessCalled = false;
@@ -311,10 +311,10 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncWriteFails
     SetupMockSocketWriteExpectations(boost::system::errc::make_error_code(boost::system::errc::bad_address));
 
     auto getMessagesCalled = false;
-    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::string>
+    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::tuple<int, std::string>>
     {
         getMessagesCalled = true;
-        co_return std::string("test message");
+        co_return std::tuple<int, std::string>(1, "test message");
     };
 
     auto onSuccessCalled = false;
@@ -361,10 +361,10 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncReadFails)
                                     boost::system::errc::make_error_code(boost::system::errc::bad_address));
 
     auto getMessagesCalled = false;
-    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::string>
+    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::tuple<int, std::string>>
     {
         getMessagesCalled = true;
-        co_return std::string("test message");
+        co_return std::tuple<int, std::string>(1, "test message");
     };
 
     auto onSuccessCalled = false;
@@ -410,10 +410,10 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_UnauthorizedCalledWhenAuthorization
     SetupMockSocketReadExpectations(boost::beast::http::status::unauthorized);
 
     auto getMessagesCalled = false;
-    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::string>
+    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::tuple<int, std::string>>
     {
         getMessagesCalled = true;
-        co_return std::string("test message");
+        co_return std::tuple<int, std::string>(1, "test message");
     };
 
     auto onSuccessCalled = false;

--- a/src/agent/communicator/tests/http_client_test.cpp
+++ b/src/agent/communicator/tests/http_client_test.cpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-capturing-lambda-coroutines,cppcoreguidelines-avoid-reference-coroutine-parameters)
 
@@ -233,6 +234,12 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_Success)
         unauthorizedCalled = true;
     };
 
+    auto loopCondition = true;
+    std::function<bool()> loopRequestCondition = [&loopCondition]()
+    {
+        return std::exchange(loopCondition, false);
+    };
+
     const auto reqParams =
         http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0");
 
@@ -242,8 +249,9 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_Success)
                                               onUnauthorized,
                                               5, // NOLINT
                                               1, // NOLINT
+                                              1, // NOLINT
                                               onSuccess,
-                                              nullptr);
+                                              loopRequestCondition);
 
     boost::asio::io_context ioContext;
     boost::asio::co_spawn(ioContext, std::move(task), boost::asio::detached);
@@ -288,6 +296,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_CallbacksNotCalledIfCannotConnect)
                                               onUnauthorized,
                                               5, // NOLINT
                                               1, // NOLINT
+                                              1, // NOLINT
                                               onSuccess,
                                               nullptr);
 
@@ -327,6 +336,12 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncWriteFails
         unauthorizedCalled = true;
     };
 
+    auto loopCondition = true;
+    std::function<bool()> loopRequestCondition = [&loopCondition]()
+    {
+        return std::exchange(loopCondition, false);
+    };
+
     const auto reqParams =
         http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0");
     auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
@@ -335,8 +350,9 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncWriteFails
                                               onUnauthorized,
                                               5, // NOLINT
                                               1, // NOLINT
+                                              1, // NOLINT
                                               onSuccess,
-                                              nullptr);
+                                              loopRequestCondition);
 
     boost::asio::io_context ioContext;
     boost::asio::co_spawn(ioContext, std::move(task), boost::asio::detached);
@@ -376,6 +392,12 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncReadFails)
         unauthorizedCalled = true;
     };
 
+    auto loopCondition = true;
+    std::function<bool()> loopRequestCondition = [&loopCondition]()
+    {
+        return std::exchange(loopCondition, false);
+    };
+
     const auto reqParams =
         http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0");
     auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
@@ -384,8 +406,9 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncReadFails)
                                               onUnauthorized,
                                               5, // NOLINT
                                               1, // NOLINT
+                                              1, // NOLINT
                                               onSuccess,
-                                              nullptr);
+                                              loopRequestCondition);
 
     boost::asio::io_context ioContext;
     boost::asio::co_spawn(ioContext, std::move(task), boost::asio::detached);
@@ -424,6 +447,12 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_UnauthorizedCalledWhenAuthorization
         unauthorizedCalled = true;
     };
 
+    auto loopCondition = true;
+    std::function<bool()> loopRequestCondition = [&loopCondition]()
+    {
+        return std::exchange(loopCondition, false);
+    };
+
     const auto reqParams =
         http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0");
     auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
@@ -432,8 +461,9 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_UnauthorizedCalledWhenAuthorization
                                               onUnauthorized,
                                               5, // NOLINT
                                               1, // NOLINT
+                                              1, // NOLINT
                                               onSuccess,
-                                              nullptr);
+                                              loopRequestCondition);
 
     boost::asio::io_context ioContext;
     boost::asio::co_spawn(ioContext, std::move(task), boost::asio::detached);

--- a/src/agent/communicator/tests/http_client_test.cpp
+++ b/src/agent/communicator/tests/http_client_test.cpp
@@ -222,8 +222,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_Success)
     };
 
     auto onSuccessCalled = false;
-    std::function<void(const std::string&)> onSuccess =
-        [&onSuccessCalled]([[maybe_unused]] const std::string& responseBody)
+    std::function<void(const int, const std::string&)> onSuccess = [&onSuccessCalled](const int, const std::string&)
     {
         onSuccessCalled = true;
     };
@@ -270,8 +269,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_CallbacksNotCalledIfCannotConnect)
     };
 
     auto onSuccessCalled = false;
-    std::function<void(const std::string&)> onSuccess =
-        [&onSuccessCalled]([[maybe_unused]] const std::string& responseBody)
+    std::function<void(const int, const std::string&)> onSuccess = [&onSuccessCalled](const int, const std::string&)
     {
         onSuccessCalled = true;
     };
@@ -318,8 +316,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncWriteFails
     };
 
     auto onSuccessCalled = false;
-    std::function<void(const std::string&)> onSuccess =
-        [&onSuccessCalled]([[maybe_unused]] const std::string& responseBody)
+    std::function<void(const int, const std::string&)> onSuccess = [&onSuccessCalled](const int, const std::string&)
     {
         onSuccessCalled = true;
     };
@@ -368,8 +365,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncReadFails)
     };
 
     auto onSuccessCalled = false;
-    std::function<void(const std::string&)> onSuccess =
-        [&onSuccessCalled]([[maybe_unused]] const std::string& responseBody)
+    std::function<void(const int, const std::string&)> onSuccess = [&onSuccessCalled](const int, const std::string&)
     {
         onSuccessCalled = true;
     };
@@ -417,8 +413,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_UnauthorizedCalledWhenAuthorization
     };
 
     auto onSuccessCalled = false;
-    std::function<void(const std::string&)> onSuccess =
-        [&onSuccessCalled]([[maybe_unused]] const std::string& responseBody)
+    std::function<void(const int, const std::string&)> onSuccess = [&onSuccessCalled](const int, const std::string&)
     {
         onSuccessCalled = true;
     };

--- a/src/agent/communicator/tests/http_client_test.cpp
+++ b/src/agent/communicator/tests/http_client_test.cpp
@@ -216,7 +216,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_Success)
     SetupMockSocketReadExpectations(boost::beast::http::status::ok);
 
     auto getMessagesCalled = false;
-    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::tuple<int, std::string>>
+    auto getMessages = [&getMessagesCalled](const int) -> boost::asio::awaitable<std::tuple<int, std::string>>
     {
         getMessagesCalled = true;
         co_return std::tuple<int, std::string>(1, "test message");
@@ -270,7 +270,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_CallbacksNotCalledIfCannotConnect)
     SetupMockSocketConnectExpectations(boost::system::errc::make_error_code(boost::system::errc::bad_address));
 
     auto getMessagesCalled = false;
-    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::tuple<int, std::string>>
+    auto getMessages = [&getMessagesCalled](const int) -> boost::asio::awaitable<std::tuple<int, std::string>>
     {
         getMessagesCalled = true;
         co_return std::tuple<int, std::string>(1, "test message");
@@ -318,7 +318,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncWriteFails
     SetupMockSocketWriteExpectations(boost::system::errc::make_error_code(boost::system::errc::bad_address));
 
     auto getMessagesCalled = false;
-    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::tuple<int, std::string>>
+    auto getMessages = [&getMessagesCalled](const int) -> boost::asio::awaitable<std::tuple<int, std::string>>
     {
         getMessagesCalled = true;
         co_return std::tuple<int, std::string>(1, "test message");
@@ -374,7 +374,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncReadFails)
                                     boost::system::errc::make_error_code(boost::system::errc::bad_address));
 
     auto getMessagesCalled = false;
-    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::tuple<int, std::string>>
+    auto getMessages = [&getMessagesCalled](const int) -> boost::asio::awaitable<std::tuple<int, std::string>>
     {
         getMessagesCalled = true;
         co_return std::tuple<int, std::string>(1, "test message");
@@ -429,7 +429,7 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_UnauthorizedCalledWhenAuthorization
     SetupMockSocketReadExpectations(boost::beast::http::status::unauthorized);
 
     auto getMessagesCalled = false;
-    auto getMessages = [&getMessagesCalled]() -> boost::asio::awaitable<std::tuple<int, std::string>>
+    auto getMessages = [&getMessagesCalled](const int) -> boost::asio::awaitable<std::tuple<int, std::string>>
     {
         getMessagesCalled = true;
         co_return std::tuple<int, std::string>(1, "test message");

--- a/src/agent/communicator/tests/mocks/mock_http_client.hpp
+++ b/src/agent/communicator/tests/mocks/mock_http_client.hpp
@@ -17,6 +17,7 @@ public:
                  std::function<boost::asio::awaitable<std::string>()> messageGetter,
                  std::function<void()> onUnauthorized,
                  std::time_t connectionRetry,
+                 std::time_t batchInterval,
                  std::function<void(const std::string&)> onSuccess,
                  std::function<bool()> loopRequestCondition),
                 (override));

--- a/src/agent/communicator/tests/mocks/mock_http_client.hpp
+++ b/src/agent/communicator/tests/mocks/mock_http_client.hpp
@@ -16,7 +16,7 @@ public:
                 Co_PerformHttpRequest,
                 (std::shared_ptr<std::string> token,
                  http_client::HttpRequestParams params,
-                 std::function<boost::asio::awaitable<intStringTuple>()> messageGetter,
+                 std::function<boost::asio::awaitable<intStringTuple>(const int)> messageGetter,
                  std::function<void()> onUnauthorized,
                  std::time_t connectionRetry,
                  std::time_t batchInterval,

--- a/src/agent/communicator/tests/mocks/mock_http_client.hpp
+++ b/src/agent/communicator/tests/mocks/mock_http_client.hpp
@@ -20,7 +20,8 @@ public:
                  std::function<void()> onUnauthorized,
                  std::time_t connectionRetry,
                  std::time_t batchInterval,
-                 std::function<void(const std::string&)> onSuccess,
+                 int batchSize,
+                 std::function<void(const int, const std::string&)> onSuccess,
                  std::function<bool()> loopRequestCondition),
                 (override));
 

--- a/src/agent/communicator/tests/mocks/mock_http_client.hpp
+++ b/src/agent/communicator/tests/mocks/mock_http_client.hpp
@@ -2,6 +2,8 @@
 
 #include <ihttp_client.hpp>
 
+using intStringTuple = std::tuple<int, std::string>;
+
 class MockHttpClient : public http_client::IHttpClient
 {
 public:
@@ -14,7 +16,7 @@ public:
                 Co_PerformHttpRequest,
                 (std::shared_ptr<std::string> token,
                  http_client::HttpRequestParams params,
-                 std::function<boost::asio::awaitable<std::string>()> messageGetter,
+                 std::function<boost::asio::awaitable<intStringTuple>()> messageGetter,
                  std::function<void()> onUnauthorized,
                  std::time_t connectionRetry,
                  std::time_t batchInterval,

--- a/src/agent/include/agent.hpp
+++ b/src/agent/include/agent.hpp
@@ -69,4 +69,7 @@ private:
 
     /// @brief Centralized configuration
     centralized_configuration::CentralizedConfiguration m_centralizedConfiguration;
+
+    /// @brief Maximum messages batch size
+    int m_maxBatchingSize = config::agent::DEFAULT_BATCH_SIZE;
 };

--- a/src/agent/include/agent.hpp
+++ b/src/agent/include/agent.hpp
@@ -69,7 +69,4 @@ private:
 
     /// @brief Centralized configuration
     centralized_configuration::CentralizedConfiguration m_centralizedConfiguration;
-
-    /// @brief Maximum messages batch size
-    int m_maxBatchingSize = config::agent::DEFAULT_BATCH_SIZE;
 };

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -31,6 +31,15 @@ Agent::Agent(const std::string& configFilePath, std::unique_ptr<ISignalHandler> 
                       [this](std::function<void()> task) { m_taskManager.EnqueueTask(std::move(task)); })
     , m_commandHandler(m_dataPath)
 {
+    m_maxBatchingSize =
+        m_configurationParser.GetConfig<int>("agent", "max_batching_size").value_or(config::agent::DEFAULT_BATCH_SIZE);
+
+    if (m_maxBatchingSize < 1)
+    {
+        LogWarn("max_batching_size cannot be lower than 1s. Using default value.");
+        m_maxBatchingSize = config::agent::DEFAULT_BATCH_SIZE;
+    }
+
     m_centralizedConfiguration.SetGroupIdFunction([this](const std::vector<std::string>& groups)
                                                   { return m_agentInfo.SetGroups(groups); });
 

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -63,7 +63,7 @@ void Agent::Run()
     m_taskManager.EnqueueTask(m_communicator.WaitForTokenExpirationAndAuthenticate());
 
     m_taskManager.EnqueueTask(m_communicator.GetCommandsFromManager(
-        [this](const std::string& response) { PushCommandsToQueue(m_messageQueue, response); }));
+        [this](const int, const std::string& response) { PushCommandsToQueue(m_messageQueue, response); }));
 
     m_taskManager.EnqueueTask(m_communicator.StatefulMessageProcessingTask(
         [this]()
@@ -73,8 +73,8 @@ void Agent::Run()
                                         m_maxBatchingSize,
                                         [this]() { return m_agentInfo.GetMetadataInfo(false); });
         },
-        [this]([[maybe_unused]] const std::string& response)
-        { PopMessagesFromQueue(m_messageQueue, MessageType::STATEFUL, m_maxBatchingSize); }));
+        [this]([[maybe_unused]] const int messageCount, const std::string&)
+        { PopMessagesFromQueue(m_messageQueue, MessageType::STATEFUL, messageCount); }));
 
     m_taskManager.EnqueueTask(m_communicator.StatelessMessageProcessingTask(
         [this]()
@@ -84,8 +84,8 @@ void Agent::Run()
                                         m_maxBatchingSize,
                                         [this]() { return m_agentInfo.GetMetadataInfo(false); });
         },
-        [this]([[maybe_unused]] const std::string& response)
-        { PopMessagesFromQueue(m_messageQueue, MessageType::STATELESS, m_maxBatchingSize); }));
+        [this]([[maybe_unused]] const int messageCount, const std::string&)
+        { PopMessagesFromQueue(m_messageQueue, MessageType::STATELESS, messageCount); }));
 
     m_moduleManager.AddModules();
     m_taskManager.EnqueueTask([this]() { m_moduleManager.Start(); });

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -68,20 +68,24 @@ void Agent::Run()
     m_taskManager.EnqueueTask(m_communicator.StatefulMessageProcessingTask(
         [this]()
         {
-            return GetMessagesFromQueue(
-                m_messageQueue, MessageType::STATEFUL, [this]() { return m_agentInfo.GetMetadataInfo(false); });
+            return GetMessagesFromQueue(m_messageQueue,
+                                        MessageType::STATEFUL,
+                                        m_maxBatchingSize,
+                                        [this]() { return m_agentInfo.GetMetadataInfo(false); });
         },
         [this]([[maybe_unused]] const std::string& response)
-        { PopMessagesFromQueue(m_messageQueue, MessageType::STATEFUL); }));
+        { PopMessagesFromQueue(m_messageQueue, MessageType::STATEFUL, m_maxBatchingSize); }));
 
     m_taskManager.EnqueueTask(m_communicator.StatelessMessageProcessingTask(
         [this]()
         {
-            return GetMessagesFromQueue(
-                m_messageQueue, MessageType::STATELESS, [this]() { return m_agentInfo.GetMetadataInfo(false); });
+            return GetMessagesFromQueue(m_messageQueue,
+                                        MessageType::STATELESS,
+                                        m_maxBatchingSize,
+                                        [this]() { return m_agentInfo.GetMetadataInfo(false); });
         },
         [this]([[maybe_unused]] const std::string& response)
-        { PopMessagesFromQueue(m_messageQueue, MessageType::STATELESS); }));
+        { PopMessagesFromQueue(m_messageQueue, MessageType::STATELESS, m_maxBatchingSize); }));
 
     m_moduleManager.AddModules();
     m_taskManager.EnqueueTask([this]() { m_moduleManager.Start(); });

--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -3,10 +3,11 @@
 
 #include <vector>
 
-boost::asio::awaitable<std::string> GetMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue,
-                                                         MessageType messageType,
-                                                         int numMessages,
-                                                         std::function<std::string()> getMetadataInfo)
+boost::asio::awaitable<std::tuple<int, std::string>>
+GetMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue,
+                     MessageType messageType,
+                     int numMessages,
+                     std::function<std::string()> getMetadataInfo)
 {
     const auto messages = co_await multiTypeQueue->getNextNAwaitable(messageType, numMessages, "", "");
 
@@ -22,7 +23,7 @@ boost::asio::awaitable<std::string> GetMessagesFromQueue(std::shared_ptr<IMultiT
         output += "\n" + message.metaData + "\n" + message.data.dump();
     }
 
-    co_return output;
+    co_return std::tuple<int, std::string> {messages.size(), output};
 }
 
 void PopMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, MessageType messageType, int numMessages)

--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -23,7 +23,7 @@ GetMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue,
         output += "\n" + message.metaData + "\n" + message.data.dump();
     }
 
-    co_return std::tuple<int, std::string> {messages.size(), output};
+    co_return std::tuple<int, std::string> {static_cast<int>(messages.size()), output};
 }
 
 void PopMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, MessageType messageType, int numMessages)

--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -3,17 +3,12 @@
 
 #include <vector>
 
-namespace
-{
-    // This should eventually be replaced with a configuration parameter.
-    constexpr int NUM_EVENTS = 1;
-} // namespace
-
 boost::asio::awaitable<std::string> GetMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue,
                                                          MessageType messageType,
+                                                         int numMessages,
                                                          std::function<std::string()> getMetadataInfo)
 {
-    const auto messages = co_await multiTypeQueue->getNextNAwaitable(messageType, NUM_EVENTS, "", "");
+    const auto messages = co_await multiTypeQueue->getNextNAwaitable(messageType, numMessages, "", "");
 
     std::string output;
 
@@ -30,9 +25,9 @@ boost::asio::awaitable<std::string> GetMessagesFromQueue(std::shared_ptr<IMultiT
     co_return output;
 }
 
-void PopMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, MessageType messageType)
+void PopMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, MessageType messageType, int numMessages)
 {
-    multiTypeQueue->popN(messageType, NUM_EVENTS);
+    multiTypeQueue->popN(messageType, numMessages);
 }
 
 void PushCommandsToQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, const std::string& commands)

--- a/src/agent/src/message_queue_utils.hpp
+++ b/src/agent/src/message_queue_utils.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 
 class IMultiTypeQueue;
 
@@ -18,10 +19,11 @@ class IMultiTypeQueue;
 /// @param numMessages The number of messages to get
 /// @param getMetadataInfo Function to get the agent metadata
 /// @return A string containing the messages from the queue
-boost::asio::awaitable<std::string> GetMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue,
-                                                         MessageType messageType,
-                                                         int numMessages,
-                                                         std::function<std::string()> getMetadataInfo);
+boost::asio::awaitable<std::tuple<int, std::string>>
+GetMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue,
+                     MessageType messageType,
+                     int numMessages,
+                     std::function<std::string()> getMetadataInfo);
 
 /// @brief Removes a fixed number of messages from the specified queue
 /// @param multiTypeQueue The queue from which to remove messages

--- a/src/agent/src/message_queue_utils.hpp
+++ b/src/agent/src/message_queue_utils.hpp
@@ -15,16 +15,19 @@ class IMultiTypeQueue;
 /// @brief Gets messages from a queue and returns them as a JSON string
 /// @param multiTypeQueue The queue to get messages from
 /// @param messageType The type of messages to get from the queue
+/// @param numMessages The number of messages to get
 /// @param getMetadataInfo Function to get the agent metadata
 /// @return A string containing the messages from the queue
 boost::asio::awaitable<std::string> GetMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue,
                                                          MessageType messageType,
+                                                         int numMessages,
                                                          std::function<std::string()> getMetadataInfo);
 
 /// @brief Removes a fixed number of messages from the specified queue
 /// @param multiTypeQueue The queue from which to remove messages
 /// @param messageType The type of messages to remove
-void PopMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, MessageType messageType);
+/// @param numMessages The number of messages to remove from the queue
+void PopMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue, MessageType messageType, int numMessages);
 
 /// @brief Pushes a batch of commands to the specified queue
 /// @param multiTypeQueue The queue to push commands to

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -7,6 +7,8 @@
 #include <ihttp_client.hpp>
 #include <ihttp_socket.hpp>
 
+#include "../communicator/tests/mocks/mock_http_client.hpp"
+
 #include <boost/asio.hpp>
 #include <boost/beast.hpp>
 #include <nlohmann/json.hpp>
@@ -14,48 +16,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-
-class MockHttpClient : public http_client::IHttpClient
-{
-public:
-    MOCK_METHOD(boost::beast::http::request<boost::beast::http::string_body>,
-                CreateHttpRequest,
-                (const http_client::HttpRequestParams& params),
-                (override));
-
-    MOCK_METHOD(boost::asio::awaitable<void>,
-                Co_PerformHttpRequest,
-                (std::shared_ptr<std::string> token,
-                 http_client::HttpRequestParams params,
-                 std::function<boost::asio::awaitable<std::string>()> messageGetter,
-                 std::function<void()> onUnauthorized,
-                 std::time_t connectionRetry,
-                 std::function<void(const std::string&)> onSuccess,
-                 std::function<bool()> loopRequestCondition),
-                (override));
-
-    MOCK_METHOD(boost::beast::http::response<boost::beast::http::dynamic_body>,
-                PerformHttpRequest,
-                (const http_client::HttpRequestParams& params),
-                (override));
-
-    MOCK_METHOD(
-        std::optional<std::string>,
-        AuthenticateWithUuidAndKey,
-        (const std::string& host, const std::string& userAgent, const std::string& uuid, const std::string& key),
-        (override));
-
-    MOCK_METHOD(
-        std::optional<std::string>,
-        AuthenticateWithUserPassword,
-        (const std::string& host, const std::string& userAgent, const std::string& user, const std::string& password),
-        (override));
-
-    MOCK_METHOD(boost::beast::http::response<boost::beast::http::dynamic_body>,
-                PerformHttpRequestDownload,
-                (const http_client::HttpRequestParams& params, const std::string& dstFilePath),
-                (override));
-};
 
 class RegisterTest : public ::testing::Test
 {

--- a/src/cmake/config.cmake
+++ b/src/cmake/config.cmake
@@ -14,6 +14,10 @@ set(DEFAULT_SERVER_URL "https://localhost:27000" CACHE STRING "Default Agent Ser
 
 set(DEFAULT_RETRY_INTERVAL 30000 CACHE STRING "Default Agent retry interval (30s)")
 
+set(DEFAULT_BATCH_INTERVAL 10000 CACHE STRING "Default Agent batch interval (10s)")
+
+set(DEFAULT_BATCH_SIZE 1000 CACHE STRING "Default Agent batch size limit (1000)")
+
 set(DEFAULT_LOGCOLLECTOR_ENABLED true CACHE BOOL "Default Logcollector enabled")
 
 set(BUFFER_SIZE 4096 CACHE STRING "Default Logcollector reading buffer size")

--- a/src/common/config/include/config.h.in
+++ b/src/common/config/include/config.h.in
@@ -12,6 +12,8 @@ namespace config
     {
         constexpr auto DEFAULT_SERVER_URL = "@DEFAULT_SERVER_URL@";
         constexpr auto DEFAULT_RETRY_INTERVAL = @DEFAULT_RETRY_INTERVAL@;
+        constexpr auto DEFAULT_BATCH_INTERVAL = @DEFAULT_BATCH_INTERVAL@;
+        constexpr auto DEFAULT_BATCH_SIZE = @DEFAULT_BATCH_SIZE@;
     }
 
     namespace logcollector


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/306|


## Description

This PR implements configurable batching for the Wazuh Agent to improve flexibility in how it sends messages to the server. Previously, the agent sent batches of messages every second without considering the batch size or the time elapsed. With this change, the batching process is governed by two configurable conditions:

A batch is sent if the specified batch_interval has elapsed and the queue contains messages.
A batch is sent if the queue accumulates batch_size messages before batch_interval elapses.
These conditions ensure:

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
