### PR TITLE
Stop agent execution when it is not registered

### DIFF
--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -77,6 +77,10 @@ namespace communicator
             }
         }
 
+        /// @brief Sends an authentication request to the manager
+        /// @return The HTTP status of the authentication request
+        boost::beast::http::status SendAuthenticationRequest();
+
         /// @brief Waits for the authentication token to expire and authenticates again
         boost::asio::awaitable<void> WaitForTokenExpirationAndAuthenticate();
 
@@ -112,10 +116,6 @@ namespace communicator
         /// @brief Calculates the remaining time (in seconds) until the authentication token expires
         /// @return The remaining time in seconds until the authentication token expires
         long GetTokenRemainingSecs() const;
-
-        /// @brief Sends an authentication request to the manager
-        /// @return The HTTP status of the authentication request
-        boost::beast::http::status SendAuthenticationRequest();
 
         /// @brief Checks if the authentication token has expired and authenticates again if necessary
         void TryReAuthenticate();

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -57,6 +57,9 @@ Agent::~Agent()
 
 void Agent::Run()
 {
+    // Check if the server recognizes the agent
+    m_communicator.SendAuthenticationRequest();
+
     m_taskManager.EnqueueTask(m_communicator.WaitForTokenExpirationAndAuthenticate());
 
     m_taskManager.EnqueueTask(m_communicator.GetCommandsFromManager(

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -31,6 +31,12 @@ Agent::Agent(const std::string& configFilePath, std::unique_ptr<ISignalHandler> 
                       [this](std::function<void()> task) { m_taskManager.EnqueueTask(std::move(task)); })
     , m_commandHandler(m_dataPath)
 {
+    // Check if agent is registered
+    if (m_agentInfo.GetName().empty() || m_agentInfo.GetKey().empty() || m_agentInfo.GetUUID().empty())
+    {
+        throw std::runtime_error("The agent is not registered");
+    }
+
     m_centralizedConfiguration.SetGroupIdFunction([this](const std::vector<std::string>& groups)
                                                   { return m_agentInfo.SetGroups(groups); });
 

--- a/src/agent/src/main.cpp
+++ b/src/agent/src/main.cpp
@@ -10,6 +10,7 @@ namespace program_options = boost::program_options;
 
 /// Command-line options
 static const auto OPT_HELP {"help"};
+static const auto OPT_RUN {"run"};
 static const auto OPT_STATUS {"status"};
 static const auto OPT_CONFIG_FILE {"config-file"};
 static const auto OPT_REGISTER_AGENT {"register-agent"};
@@ -32,6 +33,7 @@ int main(int argc, char* argv[])
     {
         program_options::options_description cmdParser("Allowed options");
         cmdParser.add_options()(OPT_HELP, "Display this help menu")(
+            OPT_RUN, "Run agent in foreground (this is the default behavior)")(
             OPT_STATUS, "Check if the agent is running (running or stopped)")(
             OPT_CONFIG_FILE, program_options::value<std::string>(), "Path to the Wazuh configuration file (optional)")(
             OPT_REGISTER_AGENT, "Use this option to register as a new agent")(

--- a/src/agent/tests/agent_test.cpp
+++ b/src/agent/tests/agent_test.cpp
@@ -19,11 +19,20 @@ protected:
     void SetUp() override
     {
         CreateTempConfigFile();
+
+        SysInfo sysInfo;
+        std::unique_ptr<AgentInfo> agent = std::make_unique<AgentInfo>(
+            "/tmp", [&sysInfo]() mutable { return sysInfo.os(); }, [&sysInfo]() mutable { return sysInfo.networks(); });
+
+        agent->SetKey("4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj");
+        agent->SetName("agent_name");
+        agent->Save();
     }
 
     void TearDown() override
     {
         std::remove(AGENT_CONFIG_PATH);
+        std::remove("/tmp/agent_info.db");
     }
 
     void CreateTempConfigFile()


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/359|

## Description

This PR prevents an agent from continuing to run indefinitely in the following scenarios:
- The agent has not been previously registered.
- The server does not recognize the agent during authentication.
- The agent key used to authenticate is invalid.

## Logs/Alerts example

###Agent not registered:

```
# ./wazuh-agent --run --config-file wazuh-agent.yml 
[2024-12-02 19:33:11.138] [wazuh-agent] [info] [INFO] [process_options_unix.cpp:24] [StartAgent] Starting wazuh-agent
[2024-12-02 19:33:11.168] [wazuh-agent] [info] [INFO] [communicator.hpp:55] [Communicator] Using insecure connection.
[2024-12-02 19:33:11.169] [wazuh-agent] [critical] [CRITICAL] [main.cpp:98] [main] An error occurred: The agent is not registered.
```

### Agent not exists error (API):

```
# ./wazuh-agent --run --config-file wazuh-agent.yml 
[2024-12-02 19:34:46.700] [wazuh-agent] [info] [INFO] [process_options_unix.cpp:24] [StartAgent] Starting wazuh-agent
[2024-12-02 19:34:46.706] [wazuh-agent] [info] [INFO] [communicator.hpp:55] [Communicator] Using insecure connection.
[2024-12-02 19:34:46.712] [wazuh-agent] [critical] [CRITICAL] [main.cpp:98] [main] An error occurred: Agent does not exist.
```

### Agent key invalid error (API):

```
# ./wazuh-agent --run --config-file wazuh-agent.yml 
[2024-12-02 19:35:31.394] [wazuh-agent] [info] [INFO] [process_options_unix.cpp:24] [StartAgent] Starting wazuh-agent
[2024-12-02 19:35:31.397] [wazuh-agent] [info] [INFO] [communicator.hpp:55] [Communicator] Using insecure connection.
[2024-12-02 19:35:31.402] [wazuh-agent] [critical] [CRITICAL] [main.cpp:98] [main] An error occurred: Invalid key.
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X