### PR TITLE
Preserve var/lib/wazuh-agent during the removal process

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/postrm
+++ b/packages/debs/SPECS/wazuh-agent/debian/postrm
@@ -11,7 +11,6 @@ case "$1" in
         if [ "$1" = "remove" ]; then
             rm -rf ${WAZUH_SHARE_DIR}
             rm -f /usr/lib/systemd/system/wazuh-agent.service
-            rm -rf /var/lib/wazuh-agent
 
             # Remove the shared library configuration file if it exists
             if [ -f /etc/ld.so.conf.d/wazuh-agentlibs.conf ]; then
@@ -33,7 +32,7 @@ case "$1" in
         if getent group wazuh >/dev/null 2>&1; then
             delgroup wazuh > /dev/null 2>&1
         fi
-        rm -rf /etc/wazuh-agent
+        rm -rf /var/lib/wazuh-agent
     ;;
 
     upgrade)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/374|

## Description

The current behavior of the Wazuh Agent Debian package when executing the remove command is inconsistent with Debian packaging guidelines. Specifically, data files in `/var/lib/wazuh-agent` are deleted upon removal. This behavior can lead to unexpected data loss for users who intend to retain their data files while removing the package.

This PR modifies the package's behavior to ensure that both configuration files in `/etc/wazuh-agent` and data files in `/var/lib/wazuh-agent` are preserved when using the remove command. The purge command will continue to delete all associated files, including both configuration and data.

**Note:** This PR also removes an [extra line ](https://github.com/wazuh/wazuh-agent/pull/379/files#diff-0ab66c2d5220b7e1c89031f3bfd2d2e77e50fbaa06d26c1cec0207c6270798faL36) that was intended to remove `/etc/wazuh-agent`, but it is not needed because it is automatically removed by the package manager.

## Tests

The following package was generated to test the changes:

- Current PR: [wazuh-agent_5.0.0-0_amd64_d69891c.deb](https://github.com/wazuh/wazuh-agent-packages/actions/runs/12124110266/artifacts/2262748474)

<details>
<summary>Setup</summary>

```bash
cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

</details>

<details>
<summary>Install the Package</summary>

```bash
sudo apt install $(pwd)/wazuh-agent_5.0.0-0_amd64_d69891c.deb -y
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent' instead of '/home/vagrant/wazuh-agent_5.0.0-0_amd64_d69891c.deb'
The following NEW packages will be installed:
  wazuh-agent
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/4,692 kB of archives.
After this operation, 16.9 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-agent_5.0.0-0_amd64_d69891c.deb wazuh-agent amd64 5.0.0-0 [4,692 kB]
Preconfiguring packages ...       
Selecting previously unselected package wazuh-agent.
(Reading database ... 25141 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_5.0.0-0_amd64_d69891c.deb ...
Unpacking wazuh-agent (5.0.0-0) ...
Setting up wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.31-13+deb11u11) ...
```
</details>

<details>
<summary>Start wazuh-agent and Check Files in <code>/var/lib/wazuh-agent/</code></summary>

```bash
vagrant@debian11:~$ sudo  systemctl start wazuh-agent

vagrant@debian11:~$ sudo  systemctl status wazuh-agent
● wazuh-agent.service - Wazuh agent
     Loaded: loaded (/lib/systemd/system/wazuh-agent.service; disabled; vendor preset: enabled)
     Active: active (running) since Mon 2024-12-02 19:55:40 UTC; 20s ago
   Main PID: 1808 (wazuh-agent)
      Tasks: 5 (limit: 2322)
     Memory: 5.1M
        CPU: 65ms
     CGroup: /system.slice/wazuh-agent.service
             └─1808 /usr/share/wazuh-agent/bin/wazuh-agent

Dec 02 19:55:40 debian11 env[1808]: [2024-12-02 19:55:40.128] [wazuh-agent] [info] [INFO] [process_options_unix.cpp:24] [StartAgent] Starting wazuh-agent
Dec 02 19:55:40 debian11 env[1808]: [2024-12-02 19:55:40.138] [wazuh-agent] [info] [INFO] [inventory.cpp:17] [Start] Starting inventory.
Dec 02 19:55:40 debian11 env[1808]: [2024-12-02 19:55:40.139] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:907] [SyncLoop] Module started.
Dec 02 19:55:40 debian11 env[1808]: [2024-12-02 19:55:40.139] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:890] [Scan] Starting evaluation.
Dec 02 19:55:40 debian11 env[1808]: [2024-12-02 19:55:40.139] [wazuh-agent] [info] [INFO] [logcollector.cpp:23] [Start] Logcollector started
Dec 02 19:55:40 debian11 env[1808]: [2024-12-02 19:55:40.140] [wazuh-agent] [info] [INFO] [file_reader.cpp:57] [AddLocalfiles] Reading log file: /var/log/auth.log
Dec 02 19:55:40 debian11 env[1808]: [2024-12-02 19:55:40.141] [wazuh-agent] [error] [ERROR] [http_client.cpp:356] [PerformHttpRequestInternal] Error: Error connecting to host: Connection refused.
Dec 02 19:55:40 debian11 env[1808]: [2024-12-02 19:55:40.142] [wazuh-agent] [warning] [WARN] [http_client.cpp:244] [AuthenticateWithUuidAndKey] Error: 500.
Dec 02 19:55:40 debian11 env[1808]: [2024-12-02 19:55:40.142] [wazuh-agent] [warning] [WARN] [communicator.cpp:31] [SendAuthenticationRequest] Failed to authenticate with the manager. Retrying in 30 seconds.
Dec 02 19:55:40 debian11 env[1808]: [2024-12-02 19:55:40.278] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:902] [Scan] Evaluation finished.


vagrant@debian11:~$ ls /var/lib/wazuh-agent/
agent_info.db  command_store.db  command_store.db-shm  command_store.db-wal  local.db  local.db-journal  queue.db  queue.db-shm  queue.db-wal

```
</details>




<details>
<summary>Remove and Validate Data Persistence in <code>/var/lib/wazuh-agent/</code></summary>

```bash
vagrant@debian11:~$ sudo apt remove wazuh-agent
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages will be REMOVED:
  wazuh-agent
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 16.9 MB disk space will be freed.
Do you want to continue? [Y/n] 
(Reading database ... 25153 files and directories currently installed.)
Removing wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.31-13+deb11u11) ...

vagrant@debian11:~$ ls /var/lib/wazuh-agent/
agent_info.db  command_store.db  local.db  local.db-journal  queue.db

vagrant@debian11:~$ ls /etc/wazuh-agent/
wazuh-agent.yml

```
</details>

<details>
<summary>Purge wazuh-agent</summary>

```bash
vagrant@debian11:~$ sudo apt purge wazuh-agent
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages will be REMOVED:
  wazuh-agent*
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 0 B of additional disk space will be used.
Do you want to continue? [Y/n] Y
(Reading database ... 25144 files and directories currently installed.)
Purging configuration files for wazuh-agent (5.0.0-0) ...
dpkg: warning: while removing wazuh-agent, directory '/usr/lib/systemd/system' not empty so not removed

vagrant@debian11:~$ sudo find / -name "*wazuh-agent*"
/home/vagrant/wazuh-agent_5.0.0-0_amd64_d69891c.deb

```
</details>


<details>
<summary>Clean install wazuh-agent and remove it</summary>

```bash
vagrant@debian11:~$ sudo apt install $(pwd)/wazuh-agent_5.0.0-0_amd64_d69891c.deb -y
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent' instead of '/home/vagrant/wazuh-agent_5.0.0-0_amd64_d69891c.deb'
The following NEW packages will be installed:
  wazuh-agent
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/4,692 kB of archives.
After this operation, 16.9 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-agent_5.0.0-0_amd64_d69891c.deb wazuh-agent amd64 5.0.0-0 [4,692 kB]
Preconfiguring packages ...       
Selecting previously unselected package wazuh-agent.
(Reading database ... 25141 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_5.0.0-0_amd64_d69891c.deb ...
Unpacking wazuh-agent (5.0.0-0) ...
Setting up wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.31-13+deb11u11) ...

vagrant@debian11:~$ ls /var/lib/wazuh-agent/

vagrant@debian11:~$ sudo apt remove wazuh-agent
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages will be REMOVED:
  wazuh-agent
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 16.9 MB disk space will be freed.
Do you want to continue? [Y/n] Y
(Reading database ... 25153 files and directories currently installed.)
Removing wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.31-13+deb11u11) ...
vagrant@debian11:~$ ls /var/lib/wazuh-agent/
ls: cannot access '/var/lib/wazuh-agent/': No such file or directory

vagrant@debian11:~$ sudo apt purge wazuh-agent
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages will be REMOVED:
  wazuh-agent*
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 0 B of additional disk space will be used.
Do you want to continue? [Y/n] 
(Reading database ... 25143 files and directories currently installed.)
Purging configuration files for wazuh-agent (5.0.0-0) ...
dpkg: warning: while removing wazuh-agent, directory '/usr/lib/systemd/system' not empty so not removed
vagrant@debian11:~$ sudo find / -name "*wazuh-agent*"
/home/vagrant/wazuh-agent_5.0.0-0_amd64_d69891c.deb
```
**Note**: If the /var/lib/wazuh-agent/ folder is empty, it will be removed by the package manager during the removal process.

</details>
