### PR TITLE
Standardize logging for modules

### DIFF
--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -10,11 +10,11 @@
 void Inventory::Start() {
 
     if (!m_enabled) {
-        LogInfo("Module disabled. Exiting...");
+        LogInfo("Inventory module is disabled.");
         return;
     }
 
-    LogInfo("Starting inventory.");
+    LogInfo("Inventory module started.");
 
     ShowConfig();
 
@@ -33,7 +33,7 @@ void Inventory::Start() {
         LogErrorInventory(ex.what());
     }
 
-    LogInfo("Module finished.");
+    LogInfo("Inventory module finished.");
 
 }
 
@@ -54,7 +54,7 @@ void Inventory::Setup(const configuration::ConfigurationParser& configurationPar
 }
 
 void Inventory::Stop() {
-    LogInfo("Module stopped.");
+    LogInfo("Inventory module stopped.");
     Inventory::Instance().Destroy();
 }
 

--- a/src/modules/inventory/src/inventoryImp.cpp
+++ b/src/modules/inventory/src/inventoryImp.cpp
@@ -904,8 +904,6 @@ void Inventory::Scan()
 
 void Inventory::SyncLoop(std::unique_lock<std::mutex>& lock)
 {
-    LogInfo("Module started.");
-
     if (m_scanOnStart)
     {
         Scan();

--- a/src/modules/logcollector/src/logcollector.cpp
+++ b/src/modules/logcollector/src/logcollector.cpp
@@ -16,11 +16,11 @@ using namespace logcollector;
 
 void Logcollector::Start() {
     if (!m_enabled) {
-        LogInfo("Logcollector is disabled");
+        LogInfo("Logcollector module is disabled.");
         return;
     }
 
-    LogInfo("Logcollector started");
+    LogInfo("Logcollector module started.");
     m_ioContext.run();
 }
 
@@ -48,7 +48,7 @@ void Logcollector::SetupFileReader(const configuration::ConfigurationParser& con
 
 void Logcollector::Stop() {
     m_ioContext.stop();
-    LogInfo("Logcollector stopped");
+    LogInfo("Logcollector module stopped.");
 }
 
 // NOLINTBEGIN(performance-unnecessary-value-param)


### PR DESCRIPTION
|Related issue|
|---|
|Close #367|

This PR Adapt the Inventory log and the Logcollector log, to align them.


## Configuration options
default wazuh-agent.yml 
``` yml
agent:
  server_url: https://localhost:27000
  registration_url: https://localhost:55000
  path.data: /tmp/wazuh-agent-data
  retry_interval: 30s
inventory:
  enabled: false
  interval: 1h
  scan_on_start: true
  hardware: true
  system: true
  networks: true
  packages: true
  ports: true
  ports_all: true
  processes: true
  hotfixes: true
logcollector:
  enabled: true
  localfiles:
    - /var/log/auth.log
  reload_interval: 1m
  file_wait: 500ms
```

## Logs/Alerts example

```log
"Inventory module started."
"Inventory module finished."
"Inventory module stopped."

"Logcollector module started."
"Logcollector module finished."
"Logcollector module stopped."

```
