### PR TITLE
Print request content as trace logs

### DIFF
--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -226,7 +226,8 @@ namespace http_client
                 timerSleep = connectionRetry;
             }
 
-            LogDebug("{}", ResponseToString(reqParams.Endpoint, res));
+            LogDebug("Request {}: Status {}", reqParams.Endpoint, res.result_int());
+            LogTrace("{}", ResponseToString(reqParams.Endpoint, res));
 
             co_await WaitForTimer(timer, timerSleep);
         } while (loopRequestCondition != nullptr && loopRequestCondition());
@@ -393,7 +394,8 @@ namespace http_client
                 throw std::runtime_error("Error handling response: " + ec.message());
             }
 
-            LogDebug("{}", ResponseToString(params.Endpoint, res));
+            LogDebug("Request {}: Status {}", params.Endpoint, res.result_int());
+            LogTrace("{}", ResponseToString(params.Endpoint, res));
         }
         catch (std::exception const& e)
         {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #368|

This PR aims to replace the HTTP(s) request response debug logs with two different logs:
1. **Debug log**: indicating the endpoint and the status code.
2. **Trace log**: containing the endpoint, the status code and the response body.

The reason to "duplicate" this information is traceability: different components may print interleaved logs.

## Demo Logs

### Authorization Token Request
```
[2024-12-03 11:48:32.105] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:397] [PerformHttpRequestInternal] Request /api/v1/authentication: Status 200

[2024-12-03 11:48:32.106] [wazuh-agent] [trace] [TRACE] [http_client.cpp:398] [PerformHttpRequestInternal] Request endpoint: /api/v1/authentication
Response: HTTP/1.1 200 OK
X-Imposter-Request: 974e8dcd-9b5f-413e-baf3-21ba502128b9
Server: imposter
content-length: 315

{"token":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJXYXp1aCIsImF1ZCI6IldhenVoIENvbW11bmljYXRpb25zIEFQSSIsImlhdCI6MTczMzIyMjkxMiwiZXhwIjoxNzMzMjIzODEyLCJ1dWlkIjoiMDE2ZDE3NzAtOTlmNi00OTM0LWFmMDMtYmJiOWFiZmM2YmZiIn0.MEQCIBW5kM8lcNgOLxkvXnA42jjmw69Qx-R_lbydLiNQ2JTlAiBWA5LyJjSjxkea2p3Dkkj0STDGu2v_EMzfnOvFqPrsug"}

```

### Stateful Push Request

```
[2024-12-03 11:47:23.940] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:229] [Co_PerformHttpRequest] Request /api/v1/events/stateful: Status 200

[2024-12-03 11:47:23.941] [wazuh-agent] [trace] [TRACE] [http_client.cpp:230] [Co_PerformHttpRequest] Request endpoint: /api/v1/events/stateful
Response: HTTP/1.1 200 OK
X-Imposter-Request: 10e92eba-3cc9-40d8-9a3f-7882e40e7637
Server: imposter
content-length: 0
```