### PR TITLE
Agent delays shutdown while Scanning

### DIFF
--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -74,7 +74,7 @@ class Inventory {
         void ScanPorts();
         void ScanProcesses();
         void Scan();
-        void SyncLoop(std::unique_lock<std::mutex>& lock);
+        void SyncLoop();
         void ShowConfig();
         cJSON * Dump() const;
         static void LogErrorInventory(const std::string& log);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #358 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

While the agent performs the inventory scanning the signal acknowledge gets lock. This was caused by the mutex used for protecting the concurrent access to the DBsync.
In order to avoid this it was perform a more specific use of it.

## Configuration options

For interval scan check:

```yml
agent:
  server_url: https://localhost:27000
  registration_url: https://localhost:55000
  path.data: /tmp/wazuh-agent-data
  retry_interval: 30s
inventory:
  enabled: true
  interval: 10s
  scan_on_start: false
  hardware: true
  system: true
  networks: true
  packages: true
  ports: true
  ports_all: true
  processes: true
  hotfixes: true
logcollector:
  enabled: false
  localfiles:
    - /var/log/auth.log
  reload_interval: 1m
  file_wait: 500ms

```

For scan on start check

```yml

agent:
  server_url: https://localhost:27000
  registration_url: https://localhost:55000
  path.data: /tmp/wazuh-agent-data
  retry_interval: 30s
inventory:
  enabled: true
  interval: 10s
  scan_on_start: true
  hardware: true
  system: true
  networks: true
  packages: true
  ports: true
  ports_all: true
  processes: true
  hotfixes: true
logcollector:
  enabled: false
  localfiles:
    - /var/log/auth.log
  reload_interval: 1m
  file_wait: 500ms

```

## Logs/Alerts example

After `ctrl + C`

``` log
[2024-12-03 15:23:37.322] [wazuh-agent] [trace] [TRACE] [inventoryImp.cpp:894] [ScanProcesses] Ending processes scan
[2024-12-03 15:23:37.322] [wazuh-agent] [trace] [TRACE] [inventoryImp.cpp:779] [ScanHotfixes] Starting hotfixes scan
[2024-12-03 15:23:37.322] [wazuh-agent] [trace] [TRACE] [inventoryImp.cpp:787] [ScanHotfixes] Ending hotfixes scan
[2024-12-03 15:23:37.322] [wazuh-agent] [trace] [TRACE] [inventoryImp.cpp:855] [ScanPorts] Starting ports scan
[2024-12-03 15:23:37.322] [wazuh-agent] [info] [INFO] [logcollector.cpp:51] [Stop] Logcollector stopped
[2024-12-03 15:23:37.325] [wazuh-agent] [trace] [TRACE] [inventoryImp.cpp:858] [ScanPorts] Ending ports scan
[2024-12-03 15:23:37.325] [wazuh-agent] [trace] [TRACE] [inventoryImp.cpp:382] [TryCatchTask] No Scanning during stopping
[2024-12-03 15:23:37.325] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:912] [Scan] Evaluation finished.
[2024-12-03 15:23:37.325] [wazuh-agent] [info] [INFO] [inventory.cpp:36] [Start] Module finished.

```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux

