### PR TITLE
Add support for agent self-restarting on Linux

### DIFF
--- a/docs/ref/commands.md
+++ b/docs/ref/commands.md
@@ -63,3 +63,32 @@ Executing this command triggers a reload of the configuration and modules to ens
     }
 }
 ```
+
+## Restart Handler
+
+The restart handler is responsible for restarting the agent. This command does not require any arguments.
+
+Executing this command triggers a restart, which can be processed in two ways:
+
+- If the service was started by systemd, it will use the same command to restart the agent.
+- If it was called manually, it will use the same command with the same arguments that were used to call it.
+
+```json
+{
+    "action":
+    {
+        "args":
+        {},
+        "name": "restart",
+        "version": "5.0.0"
+    },
+    "source": "Users/Services",
+    "document_id": "A8-62pMBBmC6Jrvqj9kW",
+    "user": "Management API",
+    "target":
+    {
+        "id": "d5b250c4-dfa1-4d94-827f-9f99210dbe6c",
+        "type": "agent"
+    }
+}
+```

--- a/packages/debs/SPECS/wazuh-agent/debian/postrm
+++ b/packages/debs/SPECS/wazuh-agent/debian/postrm
@@ -26,13 +26,16 @@ case "$1" in
 
     purge)
 
+        rm -rf /var/lib/wazuh-agent
+        if [ -d "/etc/wazuh-agent/shared" ]; then
+            rm -rf "/etc/wazuh-agent/shared"
+        fi
         if getent passwd wazuh >/dev/null 2>&1; then
             deluser wazuh > /dev/null 2>&1
         fi
         if getent group wazuh >/dev/null 2>&1; then
             delgroup wazuh > /dev/null 2>&1
         fi
-        rm -rf /var/lib/wazuh-agent
     ;;
 
     upgrade)

--- a/packages/debs/SPECS/wazuh-agent/debian/prerm
+++ b/packages/debs/SPECS/wazuh-agent/debian/prerm
@@ -15,18 +15,9 @@ case "$1" in
       elif ${BINARY_DIR}wazuh-agent --status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
           pid=$(ps -ef | grep "${BINARY_DIR}wazuh-agent" | grep -v grep | awk '{print $2}')
           if [ -n "$pid" ]; then
-              kill -SIGTERM "$pid" 2>/dev/null
+              kill -15 "$pid" 2>/dev/null
           fi
       fi
-
-      # # Process: wazuh-agent
-      # if pgrep -f "wazuh-agent" > /dev/null 2>&1; then
-      #   kill -15 $(pgrep -f "wazuh-agent") > /dev/null 2>&1
-      # fi
-
-      # if pgrep -f "wazuh-agent" > /dev/null 2>&1; then
-      #   kill -9 $(pgrep -f "wazuh-agent") > /dev/null 2>&1
-      # fi
     ;;
 
     remove)
@@ -38,10 +29,9 @@ case "$1" in
       elif ${BINARY_DIR}wazuh-agent --status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
           pid=$(ps -ef | grep "${BINARY_DIR}wazuh-agent" | grep -v grep | awk '{print $2}')
           if [ -n "$pid" ]; then
-              kill -SIGTERM "$pid" 2>/dev/null
+              kill -15 "$pid" 2>/dev/null
           fi
       fi
-
     ;;
 
     failed-upgrade)
@@ -52,20 +42,9 @@ case "$1" in
       elif ${BINARY_DIR}wazuh-agent --status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
           pid=$(ps -ef | grep "${BINARY_DIR}wazuh-agent" | grep -v grep | awk '{print $2}')
           if [ -n "$pid" ]; then
-              kill -SIGTERM "$pid" 2>/dev/null
+              kill -15 "$pid" 2>/dev/null
           fi
       fi
-
-      # if [ -f ${INSTALLATION_WAZUH_DIR}/bin/wazuh-agent ]; then
-      #   # pkill wazuh-agent
-      #   if pgrep -f "wazuh-agent" > /dev/null 2>&1; then
-      #     kill -15 $(pgrep -f "wazuh-agent") > /dev/null 2>&1
-      #   fi
-
-      #   if pgrep -f "wazuh-agent" > /dev/null 2>&1; then
-      #     kill -9 $(pgrep -f "wazuh-agent") > /dev/null 2>&1
-      #   fi
-      # fi
     ;;
 
     *)

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -16,6 +16,7 @@ add_subdirectory(configuration_parser)
 add_subdirectory(multitype_queue)
 add_subdirectory(persistence)
 add_subdirectory(task_manager)
+add_subdirectory(restart_handler)
 
 find_package(OpenSSL REQUIRED)
 find_package(Boost REQUIRED COMPONENTS asio beast system program_options)
@@ -65,6 +66,7 @@ target_link_libraries(Agent
     MultiTypeQueue
     ModuleManager
     Boost::asio
+    RestartHandler
     sysinfo
     PRIVATE
     OpenSSL::SSL

--- a/src/agent/command_handler/include/command_entry/command_entry.hpp
+++ b/src/agent/command_handler/include/command_entry/command_entry.hpp
@@ -10,12 +10,14 @@ namespace module_command
     /// @brief Commands
     const std::string SET_GROUP_COMMAND = "set-group";
     const std::string FETCH_CONFIG_COMMAND = "fetch-config";
+    const std::string RESTART_COMMAND = "restart";
 
     /// @brief Commands arguments
     const std::string GROUPS_ARG = "groups";
 
     /// @brief Modules
     const std::string CENTRALIZED_CONFIGURATION_MODULE = "CentralizedConfiguration";
+    const std::string RESTART_HANDLER_MODULE = "RestartHandler";
 
     /// @enum Status of a command execution
     enum class Status

--- a/src/agent/command_handler/src/command_handler.cpp
+++ b/src/agent/command_handler/src/command_handler.cpp
@@ -17,7 +17,9 @@ namespace
                          {{module_command::GROUPS_ARG, nlohmann::json::value_t::array}}}},
         {module_command::FETCH_CONFIG_COMMAND,
          CommandDetails {
-             module_command::CENTRALIZED_CONFIGURATION_MODULE, module_command::CommandExecutionMode::SYNC, {}}}};
+             module_command::CENTRALIZED_CONFIGURATION_MODULE, module_command::CommandExecutionMode::SYNC, {}}},
+        {module_command::RESTART_COMMAND,
+         CommandDetails {module_command::RESTART_HANDLER_MODULE, module_command::CommandExecutionMode::SYNC, {}}}};
 } // namespace
 
 namespace command_handler
@@ -133,8 +135,17 @@ namespace command_handler
         {
             for (auto& cmd : cmds.value())
             {
-                cmd.ExecutionResult.ErrorCode = module_command::Status::FAILURE;
-                cmd.ExecutionResult.Message = "Agent stopped during execution";
+                if (cmd.Command == module_command::RESTART_COMMAND)
+                {
+                    LogInfo("Agent restarted successfully");
+                    cmd.ExecutionResult.ErrorCode = module_command::Status::SUCCESS;
+                    cmd.ExecutionResult.Message = "Agent restarted successfully";
+                }
+                else
+                {
+                    cmd.ExecutionResult.ErrorCode = module_command::Status::FAILURE;
+                    cmd.ExecutionResult.Message = "Agent stopped during execution";
+                }
                 reportCommandResult(cmd);
                 m_commandStore->UpdateCommand(cmd);
             }

--- a/src/agent/restart_handler/CMakeLists.txt
+++ b/src/agent/restart_handler/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(RestartHandler)
+
+include(../../cmake/CommonSettings.cmake)
+set_common_settings()
+
+find_package(Boost REQUIRED COMPONENTS asio)
+
+if(WIN32)
+    set(SOURCES src/restart_handler_win.cpp)
+else()
+    set(SOURCES src/restart_handler_unix.cpp)
+endif()
+
+add_library(RestartHandler ${SOURCES})
+target_include_directories(RestartHandler PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(RestartHandler PUBLIC Boost::asio CommandEntry PRIVATE Logger)
+
+include(../../cmake/ConfigureTarget.cmake)
+configure_target(RestartHandler)

--- a/src/agent/restart_handler/include/restart_handler.hpp
+++ b/src/agent/restart_handler/include/restart_handler.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <command_entry.hpp>
+
+#include <boost/asio/awaitable.hpp>
+
+#include <vector>
+
+namespace restart_handler
+{
+    /// @brief Class for handling service restarts.
+    class RestartHandler
+    {
+    public:
+        /// @brief A list of command line arguments used to restart the agent process.
+        static std::vector<char*> startupCmdLineArgs;
+
+        /// @brief RestartHandler class.
+        explicit RestartHandler();
+
+        /// @brief Stores the command-line arguments passed to the agent.
+        /// @param argc Number of arguments.
+        /// @param argv Array of arguments.
+        static void SetCommandLineArguments(int argc, char* argv[])
+        {
+            for (int i = 0; i < argc; ++i)
+            {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                RestartHandler::startupCmdLineArgs.emplace_back(argv[i]);
+            }
+            // Add a nullptr to terminate the argument list, as required by execve.
+            RestartHandler::startupCmdLineArgs.emplace_back(nullptr);
+        }
+
+        /// @brief Executes the restart command.
+        /// @return Result of the restart command execution.
+        static boost::asio::awaitable<module_command::CommandExecutionResult> RestartCommand();
+    };
+} // namespace restart_handler

--- a/src/agent/restart_handler/src/restart_handler_unix.cpp
+++ b/src/agent/restart_handler/src/restart_handler_unix.cpp
@@ -1,0 +1,100 @@
+#include "restart_handler_unix.hpp"
+#include <fstream>
+#include <logger.hpp>
+
+#include <chrono>
+#include <thread>
+
+namespace restart_handler
+{
+
+    std::vector<char*> RestartHandler::startupCmdLineArgs;
+
+    bool UsingSystemctl()
+    {
+        return (0 == std::system("which systemctl > /dev/null 2>&1") && nullptr != std::getenv("INVOCATION_ID"));
+    }
+
+    boost::asio::awaitable<module_command::CommandExecutionResult> RestartWithSystemd()
+    {
+        LogInfo("Systemctl restarting wazuh agent service.");
+        if (std::system("systemctl restart wazuh-agent") != 0)
+        {
+            co_return module_command::CommandExecutionResult {module_command::Status::IN_PROGRESS,
+                                                              "Systemctl restart execution"};
+        }
+        else
+        {
+            LogError("Failed using systemctl.");
+            co_return module_command::CommandExecutionResult {module_command::Status::FAILURE,
+                                                              "Systemctl restart failed"};
+        }
+    }
+
+    void StopAgent()
+    {
+        const int timeoutInSecs = 30;
+        const time_t startTime = time(nullptr);
+
+        pid_t pid = getppid();
+
+        // Shutdown Gracefully
+        kill(pid, SIGTERM);
+
+        while (true)
+        {
+            if (kill(pid, 0) != 0)
+            {
+                LogInfo("Agent gracefully stopped.");
+                break;
+            }
+
+            if (difftime(time(nullptr), startTime) > timeoutInSecs)
+            {
+                LogError("Timeout reached! Forcing agent process termination.");
+                kill(pid, SIGKILL);
+            }
+
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    }
+
+    boost::asio::awaitable<module_command::CommandExecutionResult> RestartWithFork()
+    {
+        pid_t pid = fork();
+
+        if (pid < 0)
+        {
+            LogError("Fork failed.");
+        }
+        else if (pid == 0)
+        {
+            // Child process
+            StopAgent();
+
+            LogInfo("Starting wazuh agent in a new process.");
+
+            if (execve(RestartHandler::startupCmdLineArgs[0], RestartHandler::startupCmdLineArgs.data(), nullptr) == -1)
+            {
+                LogError("Failed to spawn new Wazuh agent process.");
+            }
+        }
+
+        co_return module_command::CommandExecutionResult {module_command::Status::IN_PROGRESS,
+                                                          "Pending restart execution"};
+    }
+
+    boost::asio::awaitable<module_command::CommandExecutionResult> RestartHandler::RestartCommand()
+    {
+
+        if (UsingSystemctl())
+        {
+            return RestartWithSystemd();
+        }
+        else
+        {
+            return RestartWithFork();
+        }
+    }
+
+} // namespace restart_handler

--- a/src/agent/restart_handler/src/restart_handler_unix.hpp
+++ b/src/agent/restart_handler/src/restart_handler_unix.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include <boost/asio/awaitable.hpp>
+#include <command_entry.hpp>
+#include <restart_handler.hpp>
+#include <vector>
+
+namespace restart_handler
+{
+
+    /// @brief Checks if systemctl is available and running as a systemd service.
+    ///
+    /// Determines if systemctl can be used in the current environment.
+    /// @return true if systemctl is available and running as a systemd service, otherwise returns false.
+    bool UsingSystemctl();
+
+    /// @brief Stops the agent by terminating the child process.
+    ///
+    /// This function sends a SIGTERM signal to the agent process to stop it. If the agent process
+    /// does not stop within a specified timeout period (30 seconds), it forces termination with a SIGKILL signal.
+    void StopAgent();
+
+    /// @brief Restarts the module by forking a new process.
+    ///
+    /// This function restarts the module by creating a new child process.
+    ///
+    /// @return A boost::asio::awaitable containing the result of the command execution.
+    boost::asio::awaitable<module_command::CommandExecutionResult> RestartWithFork();
+
+    /// @brief Restarts the module using systemd service management.
+    ///
+    /// This function restarts the module via systemd, ensuring the module is properly restarted using
+    /// system service management mechanisms.
+    ///
+    /// @return A boost::asio::awaitable containing the result of the command execution.
+    boost::asio::awaitable<module_command::CommandExecutionResult> RestartWithSystemd();
+
+} // namespace restart_handler

--- a/src/agent/restart_handler/src/restart_handler_win.cpp
+++ b/src/agent/restart_handler/src/restart_handler_win.cpp
@@ -1,0 +1,17 @@
+#include <boost/asio/awaitable.hpp>
+#include <logger.hpp>
+#include <restart_handler.hpp>
+
+namespace restart_handler
+{
+
+    std::vector<char*> RestartHandler::startupCmdLineArgs;
+
+    boost::asio::awaitable<module_command::CommandExecutionResult> RestartHandler::RestartCommand()
+    {
+        // TODO
+        co_return module_command::CommandExecutionResult {module_command::Status::FAILURE,
+                                                          "RestartHandler is not implemented yet"};
+    }
+
+} // namespace restart_handler

--- a/src/agent/service/wazuh-agent.service
+++ b/src/agent/service/wazuh-agent.service
@@ -7,12 +7,9 @@ After=network.target network-online.target
 Type=simple
 
 ExecStart=/usr/bin/env WAZUH_HOME/wazuh-agent
+TimeoutStopSec=30s
 
 KillSignal=SIGTERM
-
-KillMode=process
-
-SendSIGKILL=no
 
 RemainAfterExit=yes
 

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -7,6 +7,7 @@
 #include <message.hpp>
 #include <message_queue_utils.hpp>
 #include <multitype_queue.hpp>
+#include <restart_handler.hpp>
 
 #include <filesystem>
 #include <memory>
@@ -151,6 +152,11 @@ void Agent::Run()
                             return m_centralizedConfiguration.ExecuteCommand(std::move(command), std::move(parameters));
                         },
                         m_messageQueue);
+                }
+                else if (cmd.Module == module_command::RESTART_HANDLER_MODULE)
+                {
+                    LogInfo("Restart: Initiating restart");
+                    return restart_handler::RestartHandler::RestartCommand();
                 }
                 return DispatchCommand(cmd, m_moduleManager.GetModule(cmd.Module), m_messageQueue);
             }),

--- a/src/agent/src/main.cpp
+++ b/src/agent/src/main.cpp
@@ -4,6 +4,7 @@
 
 #include <boost/program_options.hpp>
 #include <iostream>
+#include <restart_handler.hpp>
 #include <string>
 
 namespace program_options = boost::program_options;
@@ -94,6 +95,7 @@ int main(int argc, char* argv[])
         }
         else
         {
+            restart_handler::RestartHandler::SetCommandLineArguments(argc, argv);
             StartAgent(validOptions.count(OPT_CONFIG_FILE) ? validOptions[OPT_CONFIG_FILE].as<std::string>() : "");
         }
 

--- a/src/agent/src/unix/instance_handler_unix.cpp
+++ b/src/agent/src/unix/instance_handler_unix.cpp
@@ -80,7 +80,7 @@ namespace instance_handler
         const std::string filename = fmt::format("{}/wazuh-agent.lock", m_lockFilePath);
 
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-magic-numbers)
-        int fd = open(filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        int fd = open(filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
         if (fd == -1)
         {
             m_errno = errno;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/77|

# Description
Base on the design phase, this PR implement how to handles the Wazuh agent restart process. Upon receiving a **restart command**, the program identifies the restart method (systemd or manual). It ensures the agent is stopped with a 30-second timeout, then restarts it. If the agent doesn’t stop gracefully, it is forcefully terminated. The process includes confirmation of the agent's successful restart.

<p align="center">
<img src="https://github.com/user-attachments/assets/37a905c5-ab58-48e2-b44d-2ae0d12a1337">
</p>


## Implementation Details:
- Once the command is received, the system will notify that the restart process is initializing before proceeding.
- Depending on how the agent was initially started, this module will use the same method for the restart, which could either be systemd or a manual method.
- If systemd was used, it will be responsible for stopping and restarting the agent, ensuring the process is killed if it hasn't restarted within 30 seconds. Any unexpected errors will be reported.
- For manual restarts, a fork is used to create a child process, which is responsible for stopping the current agent process, checking if it was closed before the timeout (also 30 seconds). If not, the agent will be killed and a new process will be started. Any unexpected errors will be reported.
- Once the agent has restarted, a success notification will be sent.


# Extra changes:

- The SIGTERM signal name was not recognized, so I replaced it with the corresponding value to avoid the following error:

```bash
# apt remove wazuh-agent
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following package was automatically installed and is no longer required:
  lsb-release
Use 'apt autoremove' to remove it.
The following packages will be REMOVED:
  wazuh-agent
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 15.5 MB disk space will be freed.
Do you want to continue? [Y/n] 
(Reading database ... 9917 files and directories currently installed.)
Removing wazuh-agent (5.0.0-0) ...
Call pid 4119 with sigterm to stop the service
/var/lib/dpkg/info/wazuh-agent.prerm: 43: kill: Illegal option -S
dpkg: error processing package wazuh-agent (--remove):
 installed wazuh-agent package pre-removal script subprocess returned error exit status 2
dpkg: too many errors, stopping
Errors were encountered while processing:
 wazuh-agent
Processing was halted because there were too many errors.
E: Sub-process /usr/bin/dpkg returned an error code (1)	
```

- Fixed the following warning:

```bash
root@52347fca4dff:~/output# apt purge wazuh-agent
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following package was automatically installed and is no longer required:
  lsb-release
Use 'apt autoremove' to remove it.
The following packages will be REMOVED:
  wazuh-agent*
0 upgraded, 0 newly installed, 1 to remove and 11 not upgraded.
After this operation, 16.5 MB disk space will be freed.
Do you want to continue? [Y/n] 
(Reading database ... 7766 files and directories currently installed.)
Removing wazuh-agent (5.0.0-0) ...
(Reading database ... 7759 files and directories currently installed.)
Purging configuration files for wazuh-agent (5.0.0-0) ...
dpkg: warning: while removing wazuh-agent, directory '/etc/wazuh-agent' not empty so not removed
root@52347fca4dff:~/output# ls /etc/wazuh-agent
shared
root@52347fca4dff:~/output#  ls /etc/wazuh-agent/shared/
validYaml.yml
```

# Test

### Server

```bash
wazuh-agent/src/tests/mock-server#   ./mock-server --http
```
Add the restart command action to `src/tests/mock-server/config/commands.groovy`

```bash
def actions = [
    ...
    ["name": "restart", "version": "v5.0.0"],
    ...
]
```

### Agent

Configure the agent to use the server address:

```bash
sed -i 's|server_url:.*|server_url: http://192.168.100.250:27000 |' /etc/wazuh-agent/wazuh-agent.yml
```

# Register the agent

```bash
# sudo SPDLOG_LEVEL=TRACE /usr/share/wazuh-agent/bin/wazuh-agent --user wazuh --password topsecret --url http://192.168.100.250:27000 --name dummy --register

vagrant@ubuntu2204:~$ sudo SPDLOG_LEVEL=TRACE /usr/share/wazuh-agent/bin/wazuh-agent --user wazuh --password topsecret --url http://192.168.100.250:27000 --name dummy --register
[2025-01-22 00:20:25.075] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:54] [LoadLocalConfig] Loading local config file: /etc/wazuh-agent/wazuh-agent.yml.
[2025-01-22 00:20:25.076] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:147] [GetConfig] Requested setting not found, default value used. Key not found: path.data
Starting wazuh-agent registration
[2025-01-22 00:20:25.217] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:296] [PerformHttpRequest] Request /security/user/authenticate: Status 200
[2025-01-22 00:20:25.217] [wazuh-agent] [trace] [TRACE] [http_client.cpp:297] [PerformHttpRequest] Request endpoint: /security/user/authenticate
Response: HTTP/1.1 200 OK
X-Imposter-Request: 6a273dcf-c7d0-4a47-86b6-0f049cb614d7
Server: imposter
content-length: 47

{ "data": { "token": "a1b2c3d4e5f6g7h8i9j0" } }
[2025-01-22 00:20:25.320] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:296] [PerformHttpRequest] Request /agents: Status 201
[2025-01-22 00:20:25.320] [wazuh-agent] [trace] [TRACE] [http_client.cpp:297] [PerformHttpRequest] Request endpoint: /agents
Response: HTTP/1.1 201 Created
X-Imposter-Request: 9cdc2d69-3018-438b-b05a-bc89b36db9ff
Server: imposter
content-length: 0


wazuh-agent registered
```

# Manually run the agent
```
root@ubuntu2204:~$ sudo /usr/share/wazuh-agent/bin/wazuh-agent
...
[2025-01-22 03:27:33.168] [wazuh-agent] [info] [INFO] [agent.cpp:170] [operator()] Restart: Initiating self-restart
[2025-01-22 03:27:33.174] [wazuh-agent] [info] [INFO] [inventory.cpp:62] [Stop] Inventory module stopping...
[2025-01-22 03:27:33.182] [wazuh-agent] [info] [INFO] [command_handler.hpp:105] [CommandsProcessingTask] Done processing command: restart(restart)
[2025-01-22 03:27:33.519] [wazuh-agent] [info] [INFO] [logcollector.cpp:96] [Stop] Logcollector module stopped.
[2025-01-22 03:27:33.540] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:1165] [Scan] Evaluation finished.
[2025-01-22 03:27:33.587] [wazuh-agent] [info] [INFO] [inventory.cpp:37] [Start] Inventory module stopped.
root@ubuntu2204:/home/vagrant# [2025-01-22 03:27:34.175] [wazuh-agent] [info] [INFO] [restart_unix.cpp:66] [StopAgent] Agent gracefully stopped.
[2025-01-22 03:27:34.175] [wazuh-agent] [info] [INFO] [restart_unix.cpp:94] [RestartWithFork] Starting wazuh agent in a new process.
[2025-01-22 03:27:34.180] [wazuh-agent] [info] [INFO] [process_options_unix.cpp:24] [StartAgent] Starting wazuh-agent
[2025-01-22 03:27:34.181] [wazuh-agent] [info] [INFO] [communicator.hpp:55] [Communicator] Using insecure connection.
[2025-01-22 03:27:34.188] [wazuh-agent] [info] [INFO] [communicator.cpp:28] [SendAuthenticationRequest] Successfully authenticated with the manager.
[2025-01-22 03:27:34.189] [wazuh-agent] [info] [INFO] [inventory.cpp:18] [Start] Inventory module started.
[2025-01-22 03:27:34.189] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:1170] [SyncLoop] Module started.
[2025-01-22 03:27:34.189] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:1153] [Scan] Starting evaluation.
[2025-01-22 03:27:34.190] [wazuh-agent] [info] [INFO] [logcollector.cpp:32] [Start] Logcollector module started.
[2025-01-22 03:27:34.191] [wazuh-agent] [info] [INFO] [file_reader.cpp:61] [AddLocalfiles] Reading log file: /var/log/auth.log
[2025-01-22 03:27:34.199] [wazuh-agent] [info] [INFO] [command_handler.hpp:146] [CleanUpInProgressCommands] Agent restarted successfully
```

# Using Systemd to run the agent

```bash
root@ubuntu2204:/home/vagrant# journalctl -xu wazuh-agent -f
...
Jan 22 16:31:18 ubuntu2204.localdomain env[10942]: [2025-01-22 16:31:18.237] [wazuh-agent] [info] [INFO] [agent.cpp:170] [operator()] Restart: Initiating self-restart
Jan 22 16:31:18 ubuntu2204.localdomain env[10942]: [2025-01-22 16:31:18.239] [wazuh-agent] [info] [INFO] [restart_unix.cpp:36] [RestartWithSystemd] Systemctl restarting wazuh agent service.
Jan 22 16:31:18 ubuntu2204.localdomain env[10942]: [2025-01-22 16:31:18.243] [wazuh-agent] [info] [INFO] [inventory.cpp:62] [Stop] Inventory module stopping...
Jan 22 16:31:18 ubuntu2204.localdomain systemd[1]: Stopping Wazuh agent...
░░ Subject: A stop job for unit wazuh-agent.service has begun execution
░░ Defined-By: systemd
░░ Support: http://www.ubuntu.com/support
░░ 
░░ A stop job for unit wazuh-agent.service has begun execution.
░░ 
░░ The job identifier is 32220.
Jan 22 16:31:18 ubuntu2204.localdomain env[10942]: [2025-01-22 16:31:18.247] [wazuh-agent] [info] [INFO] [command_handler.hpp:105] [CommandsProcessingTask] Done processing command: restart(restart)
Jan 22 16:31:18 ubuntu2204.localdomain env[10942]: [2025-01-22 16:31:18.352] [wazuh-agent] [info] [INFO] [logcollector.cpp:96] [Stop] Logcollector module stopped.
Jan 22 16:31:18 ubuntu2204.localdomain env[10942]: [2025-01-22 16:31:18.353] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:1165] [Scan] Evaluation finished.
Jan 22 16:31:18 ubuntu2204.localdomain env[10942]: [2025-01-22 16:31:18.361] [wazuh-agent] [info] [INFO] [inventory.cpp:37] [Start] Inventory module stopped.
Jan 22 16:31:18 ubuntu2204.localdomain systemd[1]: wazuh-agent.service: Deactivated successfully.
░░ Subject: Unit succeeded
░░ Defined-By: systemd
░░ Support: http://www.ubuntu.com/support
░░ 
░░ The unit wazuh-agent.service has successfully entered the 'dead' state.
Jan 22 16:31:18 ubuntu2204.localdomain systemd[1]: Stopped Wazuh agent.
░░ Subject: A stop job for unit wazuh-agent.service has finished
░░ Defined-By: systemd
░░ Support: http://www.ubuntu.com/support
░░ 
░░ A stop job for unit wazuh-agent.service has finished.
░░ 
░░ The job identifier is 32220 and the job result is done.
Jan 22 16:31:18 ubuntu2204.localdomain systemd[1]: Started Wazuh agent.
░░ Subject: A start job for unit wazuh-agent.service has finished successfully
░░ Defined-By: systemd
░░ Support: http://www.ubuntu.com/support
░░ 
░░ A start job for unit wazuh-agent.service has finished successfully.
░░ 
░░ The job identifier is 32220.
Jan 22 16:31:18 ubuntu2204.localdomain env[10964]: [2025-01-22 16:31:18.373] [wazuh-agent] [info] [INFO] [process_options_unix.cpp:24] [StartAgent] Starting wazuh-agent
Jan 22 16:31:18 ubuntu2204.localdomain env[10964]: [2025-01-22 16:31:18.374] [wazuh-agent] [info] [INFO] [communicator.hpp:55] [Communicator] Using insecure connection.
Jan 22 16:31:18 ubuntu2204.localdomain env[10964]: [2025-01-22 16:31:18.378] [wazuh-agent] [info] [INFO] [communicator.cpp:28] [SendAuthenticationRequest] Successfully authenticated with the manager.
Jan 22 16:31:18 ubuntu2204.localdomain env[10964]: [2025-01-22 16:31:18.379] [wazuh-agent] [info] [INFO] [inventory.cpp:18] [Start] Inventory module started.
Jan 22 16:31:18 ubuntu2204.localdomain env[10964]: [2025-01-22 16:31:18.379] [wazuh-agent] [info] [INFO] [logcollector.cpp:32] [Start] Logcollector module started.
Jan 22 16:31:18 ubuntu2204.localdomain env[10964]: [2025-01-22 16:31:18.379] [wazuh-agent] [info] [INFO] [file_reader.cpp:61] [AddLocalfiles] Reading log file: /var/log/auth.log
Jan 22 16:31:18 ubuntu2204.localdomain env[10964]: [2025-01-22 16:31:18.380] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:1170] [SyncLoop] Module started.
Jan 22 16:31:18 ubuntu2204.localdomain env[10964]: [2025-01-22 16:31:18.380] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:1153] [Scan] Starting evaluation.
Jan 22 16:31:18 ubuntu2204.localdomain env[10964]: [2025-01-22 16:31:18.390] [wazuh-agent] [info] [INFO] [command_handler.hpp:146] [CleanUpInProgressCommands] Agent restarted successfully
...
```
