### PR TITLE
Update statful message to avoid sending the body

### DIFF
--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -20,7 +20,7 @@ GetMessagesFromQueue(std::shared_ptr<IMultiTypeQueue> multiTypeQueue,
 
     for (const auto& message : messages)
     {
-        output += "\n" + message.metaData + "\n" + message.data.dump();
+        output += "\n" + message.metaData + (message.data.dump() == "{}" ? "" : "\n" + message.data.dump());
     }
 
     co_return std::tuple<int, std::string> {static_cast<int>(messages.size()), output};

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -78,7 +78,7 @@ void Inventory::SendDeltaEvent(const std::string& data) {
     metadata["operation"] = jsonData["operation"];
     metadata["id"] = jsonData["id"];
 
-    const Message statefulMessage{ MessageType::STATEFUL, jsonData["data"], Name(), jsonData["type"], metadata.dump() };
+    const Message statefulMessage{ MessageType::STATEFUL, metadata["operation"] == "delete" ? "{}"_json : jsonData["data"], Name(), jsonData["type"], metadata.dump() };
 
     if(!m_pushMessage(statefulMessage)) {
         LogWarn("Stateful event can't be pushed into the message queue: {}", data);

--- a/src/modules/inventory/src/inventoryImp.cpp
+++ b/src/modules/inventory/src/inventoryImp.cpp
@@ -898,7 +898,7 @@ void Inventory::ScanProcesses()
 void Inventory::Scan()
 {
     LogInfo("Starting evaluation.");
-    m_scanTime = Utils::getCurrentTimestamp();
+    m_scanTime = Utils::getCurrentISO8601();
 
     TryCatchTask([&]() { ScanHardware(); });
     TryCatchTask([&]() { ScanOs(); });


### PR DESCRIPTION
|Related issue|
|---|
|Close #390 |

## Description

This PR removes the body field for stateful event responses that are operation `delete`, and also updates the date to `timestamp` format.

Update datetime format for Inventory stateful events.


## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

Delete events without body

```json
{"id":"aW52ZW50b3J5OnBvcnRzOjM3NDY4Njp0Y3A6MTI3LjAuMC4xOjQ2ODQw","module":"inventory","operation":"delete","type":"ports"}
{"id":"aW52ZW50b3J5OnBvcnRzOjM3NjQyNTp0Y3A6MTI3LjAuMC4xOjI3MDAw","module":"inventory","operation":"delete","type":"ports"}

```

New timestamp
```json
{"id":"aW52ZW50b3J5Om5ldHdvcmtzOmVucDBzODo6aXB2NDo6MTkyLjE2OC41Ni4xMDI=","module":"inventory","operation":"update","type":"networks"}
{"@timestamp":"2024-12-05T13:36:01.183Z","host":{"ip":["192.168.56.102"],"mac":"08:00:27:70:ef:90","network":{"egress":{"bytes":1751309,"drops":0,"errors":0,"packets":23079},"ingress":{"bytes":6623874,"drops":0,"errors":0,"packets":27799}}},"interface":{"mtu":1500,"state":"up","type":"ethernet"},"network":{"broadcast":["192.168.56.255"],"dhcp":"unknown","gateway":[" "],"metric":"101","netmask":["255.255.255.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"enp0s8"}}}}

```