### PR TITLE
Catch exceptions thrown from Agent

### DIFF
--- a/src/agent/include/agent.hpp
+++ b/src/agent/include/agent.hpp
@@ -26,6 +26,8 @@ public:
     /// @brief Constructor
     /// @param configFilePath Path to the configuration file
     /// @param signalHandler Pointer to a custom ISignalHandler implementation
+    /// @throws std::runtime_error If the Agent is not registered
+    /// @throws Any exception propagated from dependencies used within the constructor
     Agent(const std::string& configFilePath,
           std::unique_ptr<ISignalHandler> signalHandler = std::make_unique<SignalHandler>());
 

--- a/src/agent/src/process_options_unix.cpp
+++ b/src/agent/src/process_options_unix.cpp
@@ -22,8 +22,16 @@ void StartAgent(const std::string& configFilePath)
     }
 
     LogInfo("Starting wazuh-agent");
-    Agent agent(configFilePath);
-    agent.Run();
+
+    try
+    {
+        Agent agent(configFilePath);
+        agent.Run();
+    }
+    catch (const std::exception& e)
+    {
+        LogError("Exception thrown in wazuh-agent: {}", e.what());
+    }
 
     lockFileHandler.removeLockFile();
 }

--- a/src/agent/src/windows/windows_service.cpp
+++ b/src/agent/src/windows/windows_service.cpp
@@ -239,13 +239,23 @@ namespace WindowsService
             LogDebug("Using default configuration.");
         }
 
-        Agent agent(configFilePath);
-        agent.Run();
+        auto error = NO_ERROR;
+
+        try
+        {
+            Agent agent(configFilePath);
+            agent.Run();
+        }
+        catch (const std::exception& e)
+        {
+            LogError("Exception thrown in wazuh-agent: {}", e.what());
+            error = ERROR_EXCEPTION_IN_SERVICE;
+        }
 
         WaitForSingleObject(g_ServiceStopEvent, INFINITE);
 
         CloseHandle(g_ServiceStopEvent);
-        ReportServiceStatus(SERVICE_STOPPED, NO_ERROR, 0);
+        ReportServiceStatus(SERVICE_STOPPED, error, 0);
     }
 
     void WINAPI ServiceCtrlHandler(DWORD ctrlCode)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/241|

## Description

Some Windows tests revealed that if the agent
was not registered, the service exited without
showing an error and without logging what was
the cause of the unexpected exit.

This PR encloses the Agent in a try catch block
and logs the exceptions catched, if any.

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
