### PR TITLE
Expand success responses from 200 to 2xx

### DIFF
--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -236,7 +236,8 @@ namespace communicator
 
         const auto result = m_httpClient->PerformHttpRequestDownload(reqParams, dstFilePath);
 
-        return result.result() == boost::beast::http::status::ok;
+        return result.result() >= boost::beast::http::status::ok &&
+               result.result() < boost::beast::http::status::multiple_choices;
     }
 
     void Communicator::Stop()

--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -209,7 +209,8 @@ namespace http_client
 
             std::time_t timerSleep = A_SECOND_IN_MILLIS;
 
-            if (res.result() == boost::beast::http::status::ok)
+            if (res.result() >= boost::beast::http::status::ok &&
+                res.result() < boost::beast::http::status::multiple_choices)
             {
                 if (onSuccess != nullptr)
                 {
@@ -263,7 +264,8 @@ namespace http_client
 
         const auto res = PerformHttpRequest(reqParams);
 
-        if (res.result() != boost::beast::http::status::ok)
+        if (res.result() < boost::beast::http::status::ok ||
+            res.result() >= boost::beast::http::status::multiple_choices)
         {
             if (res.result() == boost::beast::http::status::unauthorized ||
                 res.result() == boost::beast::http::status::forbidden)
@@ -321,7 +323,8 @@ namespace http_client
 
         const auto res = PerformHttpRequest(reqParams);
 
-        if (res.result() != boost::beast::http::status::ok)
+        if (res.result() < boost::beast::http::status::ok ||
+            res.result() >= boost::beast::http::status::multiple_choices)
         {
             LogWarn("Error: {}.", res.result_int());
             return std::nullopt;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/401|

## Description

This PR treates all 2xx error codes as success.


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
