### PR TITLE
Use the agent's UUID in the inventory id calculation

### DIFF
--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -29,7 +29,8 @@ Agent::Agent(const std::string& configFilePath, std::unique_ptr<ISignalHandler> 
           { return m_configurationParser->GetConfig<T>(std::move(table), std::move(key)); })
     , m_moduleManager([this](Message message) -> int { return m_messageQueue->push(std::move(message)); },
                       m_configurationParser,
-                      [this](std::function<void()> task) { m_taskManager.EnqueueTask(std::move(task)); })
+                      [this](std::function<void()> task) { m_taskManager.EnqueueTask(std::move(task)); },
+                      m_agentInfo.GetUUID())
     , m_commandHandler(m_dataPath)
 {
     // Check if agent is registered

--- a/src/modules/include/moduleManager.hpp
+++ b/src/modules/include/moduleManager.hpp
@@ -13,10 +13,12 @@ class ModuleManager {
 public:
     ModuleManager(const std::function<int(Message)>& pushMessage,
                 std::shared_ptr<configuration::ConfigurationParser> configurationParser,
-                const std::function<void(std::function<void()>)>& createTask)
+                const std::function<void(std::function<void()>)>& createTask,
+                std::string uuid)
         : m_pushMessage(pushMessage)
         , m_configurationParser(std::move(configurationParser))
         , m_createTask(createTask)
+        , m_agentUUID(std::move(uuid))
     {}
     ~ModuleManager() = default;
 
@@ -54,4 +56,5 @@ private:
     std::function<int(Message)> m_pushMessage;
     std::shared_ptr<configuration::ConfigurationParser> m_configurationParser;
     std::function<void(std::function<void()>)> m_createTask;
+    std::string m_agentUUID;
 };

--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -27,7 +27,6 @@ class Inventory {
             static Inventory s_instance;
             return s_instance;
         }
-
         void Start();
         void Setup(std::shared_ptr<const configuration::ConfigurationParser> configurationParser);
         void Stop();
@@ -41,6 +40,11 @@ class Inventory {
                     const std::string& normalizerConfigPath,
                     const std::string& normalizerType);
         virtual void SendDeltaEvent(const std::string& data);
+
+        const std::string& AgentUUID() const { return m_agentUUID; };
+        void SetAgentUUID(const std::string& agentUUID) {
+            m_agentUUID = agentUUID;
+        }
 
     private:
         Inventory();
@@ -83,6 +87,7 @@ class Inventory {
         std::string CalculateBase64Id(const nlohmann::json& data, const std::string& table);
 
         const std::string                           m_moduleName {"inventory"};
+        std::string                                 m_agentUUID {""};   // Agent UUID
         std::shared_ptr<ISysInfo>                   m_spInfo;
         std::function<void(const std::string&)>     m_reportDiffFunction;
         bool                                        m_enabled;          // Main switch

--- a/src/modules/inventory/tests/inventoryImp/inventoryImp_test.cpp
+++ b/src/modules/inventory/tests/inventoryImp/inventoryImp_test.cpp
@@ -99,31 +99,31 @@ TEST_F(InventoryImpTest, defaultCtor)
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"aW52ZW50b3J5OmhhcmR3YXJlOkludGVsIENvcnBvcmF0aW9u","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"OkludGVsIENvcnBvcmF0aW9u","operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"aW52ZW50b3J5OnN5c3RlbTpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"Ok1pY3Jvc29mdCBXaW5kb3dzIDc=","operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"aW52ZW50b3J5OnBhY2thZ2VzOnhzZXJ2ZXIteG9yZzoxOjcuNysxOXVidW50dTE0OmFtZDY0OmRlYjog","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"OnhzZXJ2ZXIteG9yZzoxOjcuNysxOXVidW50dTE0OmFtZDY0OmRlYjog","operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"aW52ZW50b3J5OnByb2Nlc3Nlczo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"OjQzMTYyNQ==","operation":"create","type":"processes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"aW52ZW50b3J5OmhvdGZpeGVzOktCMTIzNDU2Nzg=","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"OktCMTIzNDU2Nzg=","operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult6
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"aW52ZW50b3J5OnBvcnRzOjA6dGNwOjEyNy4wLjAuMTo2MzE=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"OjA6dGNwOjEyNy4wLjAuMTo2MzE=","operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"aW52ZW50b3J5Om5ldHdvcmtzOmRvY2tlcjA6OmlwdjQ6OjE3Mi4xNy4wLjE=","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"OmRvY2tlcjA6OmlwdjQ6OjE3Mi4xNy4wLjE=","operation":"create","type":"networks"})"
     };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(testing::AtLeast(1));
@@ -145,6 +145,7 @@ TEST_F(InventoryImpTest, defaultCtor)
                                         INVENTORY_DB_PATH,
                                         "",
                                         "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 
@@ -209,6 +210,7 @@ TEST_F(InventoryImpTest, intervalSeconds)
                                           INVENTORY_DB_PATH,
                                           "",
                                           "");
+            Inventory::Instance().SetAgentUUID("1234");
 
         }
     };
@@ -260,6 +262,7 @@ TEST_F(InventoryImpTest, noScanOnStart)
                                         INVENTORY_DB_PATH,
                                         "",
                                         "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 
@@ -308,27 +311,27 @@ TEST_F(InventoryImpTest, noHardware)
 
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"aW52ZW50b3J5OnN5c3RlbTpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"aW52ZW50b3J5OnBhY2thZ2VzOnhzZXJ2ZXIteG9yZzoxOjcuNysxOXVidW50dTE0OmFtZDY0OmRlYjog","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"aW52ZW50b3J5OnByb2Nlc3Nlczo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"aW52ZW50b3J5OmhvdGZpeGVzOktCMTIzNDU2Nzg=","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult6
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"aW52ZW50b3J5OnBvcnRzOjA6dGNwOjEyNy4wLjAuMTo2MzE=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"aW52ZW50b3J5Om5ldHdvcmtzOmRvY2tlcjA6OmlwdjQ6OjE3Mi4xNy4wLjE=","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
     };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
@@ -364,6 +367,7 @@ TEST_F(InventoryImpTest, noHardware)
                                         INVENTORY_DB_PATH,
                                         "",
                                         "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 
@@ -413,27 +417,27 @@ TEST_F(InventoryImpTest, noOs)
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"aW52ZW50b3J5OmhhcmR3YXJlOkludGVsIENvcnBvcmF0aW9u","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"aW52ZW50b3J5OnBhY2thZ2VzOnhzZXJ2ZXIteG9yZzoxOjcuNysxOXVidW50dTE0OmFtZDY0OmRlYjog","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"aW52ZW50b3J5OnByb2Nlc3Nlczo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"aW52ZW50b3J5OmhvdGZpeGVzOktCMTIzNDU2Nzg=","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"aW52ZW50b3J5OnBvcnRzOjA6dGNwOjEyNy4wLjAuMTo2MzE=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"aW52ZW50b3J5Om5ldHdvcmtzOmRvY2tlcjA6OmlwdjQ6OjE3Mi4xNy4wLjE=","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
     };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
@@ -469,6 +473,7 @@ TEST_F(InventoryImpTest, noOs)
                                           INVENTORY_DB_PATH,
                                           "",
                                           "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 
@@ -518,27 +523,27 @@ TEST_F(InventoryImpTest, noNetwork)
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"aW52ZW50b3J5OmhhcmR3YXJlOkludGVsIENvcnBvcmF0aW9u","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"aW52ZW50b3J5OnN5c3RlbTpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"aW52ZW50b3J5OnBhY2thZ2VzOnhzZXJ2ZXIteG9yZzoxOjcuNysxOXVidW50dTE0OmFtZDY0OmRlYjog","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"aW52ZW50b3J5OnByb2Nlc3Nlczo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"aW52ZW50b3J5OmhvdGZpeGVzOktCMTIzNDU2Nzg=","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult6
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"aW52ZW50b3J5OnBvcnRzOjA6dGNwOjEyNy4wLjAuMTo2MzE=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
     };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
@@ -574,6 +579,7 @@ TEST_F(InventoryImpTest, noNetwork)
                                         INVENTORY_DB_PATH,
                                         "",
                                         "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 
@@ -622,27 +628,27 @@ TEST_F(InventoryImpTest, noPackages)
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"aW52ZW50b3J5OmhhcmR3YXJlOkludGVsIENvcnBvcmF0aW9u","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"aW52ZW50b3J5OnN5c3RlbTpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"aW52ZW50b3J5OnByb2Nlc3Nlczo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"aW52ZW50b3J5OmhvdGZpeGVzOktCMTIzNDU2Nzg=","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"aW52ZW50b3J5OnBvcnRzOjA6dGNwOjEyNy4wLjAuMTo2MzE=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"aW52ZW50b3J5Om5ldHdvcmtzOmRvY2tlcjA6OmlwdjQ6OjE3Mi4xNy4wLjE=","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
     };
 
 
@@ -679,6 +685,7 @@ TEST_F(InventoryImpTest, noPackages)
                                           INVENTORY_DB_PATH,
                                           "",
                                           "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 
@@ -728,27 +735,27 @@ TEST_F(InventoryImpTest, noPorts)
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"aW52ZW50b3J5OmhhcmR3YXJlOkludGVsIENvcnBvcmF0aW9u","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"aW52ZW50b3J5OnN5c3RlbTpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"aW52ZW50b3J5OnBhY2thZ2VzOnhzZXJ2ZXIteG9yZzoxOjcuNysxOXVidW50dTE0OmFtZDY0OmRlYjog","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"aW52ZW50b3J5OnByb2Nlc3Nlczo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"aW52ZW50b3J5OmhvdGZpeGVzOktCMTIzNDU2Nzg=","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"aW52ZW50b3J5Om5ldHdvcmtzOmRvY2tlcjA6OmlwdjQ6OjE3Mi4xNy4wLjE=","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
     };
 
 
@@ -785,6 +792,7 @@ TEST_F(InventoryImpTest, noPorts)
                                           INVENTORY_DB_PATH,
                                           "",
                                           "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 
@@ -835,35 +843,35 @@ TEST_F(InventoryImpTest, noPortsAll)
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"aW52ZW50b3J5OmhhcmR3YXJlOkludGVsIENvcnBvcmF0aW9u","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"aW52ZW50b3J5OnN5c3RlbTpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"aW52ZW50b3J5OnBhY2thZ2VzOnhzZXJ2ZXIteG9yZzoxOjcuNysxOXVidW50dTE0OmFtZDY0OmRlYjog","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"aW52ZW50b3J5OnByb2Nlc3Nlczo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"aW52ZW50b3J5OmhvdGZpeGVzOktCMTIzNDU2Nzg=","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult6
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"7046b3f9cda975eb6567259c2469748e634dde49"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":""},"network":{"protocol":"udp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"aW52ZW50b3J5OnBvcnRzOjA6dWRwOjEyNy4wLjAuMTo2MzE=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"7046b3f9cda975eb6567259c2469748e634dde49"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":""},"network":{"protocol":"udp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnVkcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"aW52ZW50b3J5OnBvcnRzOjA6dGNwOjEyNy4wLjAuMTo2MzE=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
     };
     const auto expectedResult8
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"aW52ZW50b3J5Om5ldHdvcmtzOmRvY2tlcjA6OmlwdjQ6OjE3Mi4xNy4wLjE=","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
     };
 
 
@@ -902,6 +910,7 @@ TEST_F(InventoryImpTest, noPortsAll)
                                           INVENTORY_DB_PATH,
                                           "",
                                           "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 
@@ -950,27 +959,27 @@ TEST_F(InventoryImpTest, noProcesses)
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"aW52ZW50b3J5OmhhcmR3YXJlOkludGVsIENvcnBvcmF0aW9u","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"aW52ZW50b3J5OnN5c3RlbTpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"aW52ZW50b3J5OnBhY2thZ2VzOnhzZXJ2ZXIteG9yZzoxOjcuNysxOXVidW50dTE0OmFtZDY0OmRlYjog","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"aW52ZW50b3J5OmhvdGZpeGVzOktCMTIzNDU2Nzg=","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"aW52ZW50b3J5OnBvcnRzOjA6dGNwOjEyNy4wLjAuMTo2MzE=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"aW52ZW50b3J5Om5ldHdvcmtzOmRvY2tlcjA6OmlwdjQ6OjE3Mi4xNy4wLjE=","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
     };
 
 
@@ -1007,6 +1016,7 @@ TEST_F(InventoryImpTest, noProcesses)
                                           INVENTORY_DB_PATH,
                                           "",
                                           "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 
@@ -1057,27 +1067,27 @@ TEST_F(InventoryImpTest, noHotfixes)
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"aW52ZW50b3J5OmhhcmR3YXJlOkludGVsIENvcnBvcmF0aW9u","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"aW52ZW50b3J5OnN5c3RlbTpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"aW52ZW50b3J5OnBhY2thZ2VzOnhzZXJ2ZXIteG9yZzoxOjcuNysxOXVidW50dTE0OmFtZDY0OmRlYjog","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"aW52ZW50b3J5OnByb2Nlc3Nlczo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"aW52ZW50b3J5OnBvcnRzOjA6dGNwOjEyNy4wLjAuMTo2MzE=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"aW52ZW50b3J5Om5ldHdvcmtzOmRvY2tlcjA6OmlwdjQ6OjE3Mi4xNy4wLjE=","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
     };
 
 
@@ -1114,6 +1124,7 @@ TEST_F(InventoryImpTest, noHotfixes)
                                           INVENTORY_DB_PATH,
                                           "",
                                           "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 
@@ -1173,6 +1184,7 @@ TEST_F(InventoryImpTest, scanInvalidData)
                                           INVENTORY_DB_PATH,
                                           "",
                                           "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
     std::this_thread::sleep_for(std::chrono::seconds{1});
@@ -1263,27 +1275,28 @@ TEST_F(InventoryImpTest, portAllEnable)
         {
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
+            delta.erase("id");
             wrapper.callbackMock(delta.dump());
         }
     };
     const auto expectedResult1
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"12903a43db24ab10d872547cdd1d786a5876a0da"},"file":{"inode":43481},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":""},"network":{"protocol":"udp"},"process":{"name":"","pid":0},"source":{"ip":["0.0.0.0"],"port":47748}},"id":"aW52ZW50b3J5OnBvcnRzOjQzNDgxOnVkcDowLjAuMC4wOjQ3NzQ4","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"12903a43db24ab10d872547cdd1d786a5876a0da"},"file":{"inode":43481},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":""},"network":{"protocol":"udp"},"process":{"name":"","pid":0},"source":{"ip":["0.0.0.0"],"port":47748}},"operation":"create","type":"ports"})"
     };
 
     const auto expectedResult2
     {
-        R"({"data":{"destination":{"ip":["::"],"port":0},"device":{"id":"ca7c9aff241cb251c6ad31e30b806366ecb2ad5f"},"file":{"inode":43482},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":""},"network":{"protocol":"udp6"},"process":{"name":"","pid":0},"source":{"ip":["::"],"port":51087}},"id":"aW52ZW50b3J5OnBvcnRzOjQzNDgyOnVkcDY6Ojo6NTEwODc=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["::"],"port":0},"device":{"id":"ca7c9aff241cb251c6ad31e30b806366ecb2ad5f"},"file":{"inode":43482},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":""},"network":{"protocol":"udp6"},"process":{"name":"","pid":0},"source":{"ip":["::"],"port":51087}},"operation":"create","type":"ports"})"
     };
 
     const auto expectedResult3
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"8c790ef53962dd27f4516adb1d7f3f6096bc6d29"},"file":{"inode":50324},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":33060}},"id":"aW52ZW50b3J5OnBvcnRzOjUwMzI0OnRjcDoxMjcuMC4wLjE6MzMwNjA=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"8c790ef53962dd27f4516adb1d7f3f6096bc6d29"},"file":{"inode":50324},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":33060}},"operation":"create","type":"ports"})"
     };
 
     const auto expectedResult4
     {
-        R"({"data":{"destination":{"ip":["44.238.116.130"],"port":443},"device":{"id":"d5511242275bd3f2d57175f248108d6c3b39c438"},"file":{"inode":122575},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"established"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["192.168.0.104"],"port":39106}},"id":"aW52ZW50b3J5OnBvcnRzOjEyMjU3NTp0Y3A6MTkyLjE2OC4wLjEwNDozOTEwNg==","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["44.238.116.130"],"port":443},"device":{"id":"d5511242275bd3f2d57175f248108d6c3b39c438"},"file":{"inode":122575},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"established"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["192.168.0.104"],"port":39106}},"operation":"create","type":"ports"})"
     };
 
     EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);
@@ -1317,6 +1330,7 @@ TEST_F(InventoryImpTest, portAllEnable)
                                           INVENTORY_DB_PATH,
                                           "",
                                           "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 
@@ -1408,22 +1422,23 @@ TEST_F(InventoryImpTest, portAllDisable)
         {
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
+            delta.erase("id");
             wrapper.callbackMock(delta.dump());
         }
     };
     const auto expectedResult1
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"12903a43db24ab10d872547cdd1d786a5876a0da"},"file":{"inode":43481},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":""},"network":{"protocol":"udp"},"process":{"name":"","pid":0},"source":{"ip":["0.0.0.0"],"port":47748}},"id":"aW52ZW50b3J5OnBvcnRzOjQzNDgxOnVkcDowLjAuMC4wOjQ3NzQ4","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"12903a43db24ab10d872547cdd1d786a5876a0da"},"file":{"inode":43481},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":""},"network":{"protocol":"udp"},"process":{"name":"","pid":0},"source":{"ip":["0.0.0.0"],"port":47748}},"operation":"create","type":"ports"})"
     };
 
     const auto expectedResult2
     {
-        R"({"data":{"destination":{"ip":["::"],"port":0},"device":{"id":"ca7c9aff241cb251c6ad31e30b806366ecb2ad5f"},"file":{"inode":43482},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":""},"network":{"protocol":"udp6"},"process":{"name":"","pid":0},"source":{"ip":["::"],"port":51087}},"id":"aW52ZW50b3J5OnBvcnRzOjQzNDgyOnVkcDY6Ojo6NTEwODc=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["::"],"port":0},"device":{"id":"ca7c9aff241cb251c6ad31e30b806366ecb2ad5f"},"file":{"inode":43482},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":""},"network":{"protocol":"udp6"},"process":{"name":"","pid":0},"source":{"ip":["::"],"port":51087}},"operation":"create","type":"ports"})"
     };
 
     const auto expectedResult3
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"8c790ef53962dd27f4516adb1d7f3f6096bc6d29"},"file":{"inode":50324},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":33060}},"id":"aW52ZW50b3J5OnBvcnRzOjUwMzI0OnRjcDoxMjcuMC4wLjE6MzMwNjA=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"8c790ef53962dd27f4516adb1d7f3f6096bc6d29"},"file":{"inode":50324},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":33060}},"operation":"create","type":"ports"})"
     };
 
     EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);
@@ -1456,6 +1471,7 @@ TEST_F(InventoryImpTest, portAllDisable)
                                           INVENTORY_DB_PATH,
                                           "",
                                           "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 
@@ -1495,7 +1511,7 @@ TEST_F(InventoryImpTest, PackagesDuplicated)
 
     const auto expectedResult1
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"aW52ZW50b3J5OnBhY2thZ2VzOnhzZXJ2ZXIteG9yZzoxOjcuNysxOXVidW50dTE0OmFtZDY0OmRlYjog","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
     };
 
     EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);
@@ -1526,6 +1542,7 @@ TEST_F(InventoryImpTest, PackagesDuplicated)
                                           INVENTORY_DB_PATH,
                                           "",
                                           "");
+            Inventory::Instance().SetAgentUUID("1234");
         }
     };
 

--- a/src/modules/src/moduleManager.cpp
+++ b/src/modules/src/moduleManager.cpp
@@ -14,7 +14,9 @@ using logcollector::Logcollector;
 void ModuleManager::AddModules() {
 
 #ifdef ENABLE_INVENTORY
-    AddModule(Inventory::Instance());
+    Inventory& inventory = Inventory::Instance();
+    inventory.SetAgentUUID(m_agentUUID);
+    AddModule(inventory);
 #endif
 
 #ifdef ENABLE_LOGCOLLECTOR

--- a/src/modules/tests/moduleManager_test.cpp
+++ b/src/modules/tests/moduleManager_test.cpp
@@ -25,7 +25,7 @@ protected:
         : pushMessage([](const Message&) { return 0; }),
           configurationParser(std::make_shared<configuration::ConfigurationParser>()),
           createTask([](const std::function<void()>& task) { task(); }),
-          manager(pushMessage, configurationParser, createTask)
+          manager(pushMessage, configurationParser, createTask, "uuid1234")
     {}
 
     void SetUp() override {
@@ -35,7 +35,7 @@ protected:
 };
 
 TEST_F(ModuleManagerTest, Constructor) {
-    EXPECT_NO_THROW(ModuleManager(pushMessage, configurationParser, createTask));
+    EXPECT_NO_THROW(ModuleManager(pushMessage, configurationParser, createTask, "uuid1234"));
 }
 
 TEST_F(ModuleManagerTest, AddModule) {


### PR DESCRIPTION
|Related issue | Parent Issue |
|---|---|
|Close #405| #241 |

## Description
Improve the calculation of the inventory id.

## Configuration options

```yml
agent:
  server_url: https://localhost:27000
  registration_url: https://localhost:55000
  path.data: /var/lib/wazuh-agent
  retry_interval: 30s
events:
  batch_interval: 10s
  batch_size: 1000
inventory:
  enabled: true
  interval: 30s
  scan_on_start: true
  hardware: true
  system: true
  networks: true
  packages: true
  ports: true
  ports_all: true
  processes: true
  hotfixes: true
logcollector:
  enabled: true
  localfiles:
    - /var/log/auth.log
    - /tmp/logtest.log
  reload_interval: 1m
  file_wait: 500ms


```
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

```json
{
    "id": "NjI1NDFmZjAtZTAzNS00NjE1LWIwZTktOGQwY2JiZTU1OTJkOnB5dGhvbjMtYnJsYXBpOjYuNi00dWJ1bnR1NTphbWQ2NDpkZWI6IA==",
    "module": "inventory",
    "operation": "create",
    "type": "packages"
}
```