### PR TITLE
Set default port when not specified

### DIFF
--- a/src/agent/communicator/src/http_client.cpp
+++ b/src/agent/communicator/src/http_client.cpp
@@ -402,7 +402,7 @@ namespace http_client
         }
         catch (std::exception const& e)
         {
-            LogError("Error: {}.", e.what());
+            LogError("Error: {}", e.what());
 
             res.result(boost::beast::http::status::internal_server_error);
             boost::beast::ostream(res.body()) << "Internal server error: " << e.what();

--- a/src/agent/communicator/src/http_request_params.cpp
+++ b/src/agent/communicator/src/http_request_params.cpp
@@ -23,14 +23,27 @@ namespace http_client
 
         if (!result)
         {
-            LogError("Invalid URL: {}", result.error().message());
+            LogError("Invalid URL: {}. Error: {}", serverUrl, result.error().message());
             return;
         }
 
         const auto& url = *result;
-        Use_Https = url.scheme().empty() || url.scheme() == "https";
+
+        if (url.scheme() != "http" && url.scheme() != "https")
+        {
+            LogError("Invalid URL scheme: {}", serverUrl);
+            return;
+        }
+
+        if (url.host().empty())
+        {
+            LogError("Invalid URL host: {}", serverUrl);
+            return;
+        }
+
+        Use_Https = url.scheme() == "https";
         Host = url.host();
-        Port = url.port();
+        Port = !url.port().empty() ? url.port() : (Use_Https ? "443" : "80");
     }
 
     bool HttpRequestParams::operator==(const HttpRequestParams& other) const


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/366|

## Description

This PR improves the URL validation.

It also sets the following default value for port when not specified:

- `https`: 443
- `http`: 80

## Logs

- Empty scheme:

```
# SPDLOG_LEVEL=debug ./wazuh-agent --config-file wazuh-agent.yml --register-agent --url localhost:55000 --user wazuh --password topsecret --name dummy
[2024-12-10 18:31:00.542] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:50] [LoadLocalConfig] Loading local config file: wazuh-agent.yml.
Starting wazuh-agent registration
[2024-12-10 18:31:00.547] [wazuh-agent] [error] [ERROR] [http_request_params.cpp:34] [HttpRequestParams] Invalid URL scheme: localhost:55000
[2024-12-10 18:31:00.548] [wazuh-agent] [debug] [DEBUG] [http_resolver.hpp:44] [Resolve] Failed to resolve host:  port:  with error: Host not found (authoritative)
[2024-12-10 18:31:00.548] [wazuh-agent] [error] [ERROR] [http_client.cpp:405] [PerformHttpRequestInternal] Error: Failed to resolve host.
[2024-12-10 18:31:00.548] [wazuh-agent] [warning] [WARN] [http_client.cpp:329] [AuthenticateWithUserPassword] Error: 500.
Failed to authenticate with the manager
wazuh-agent registration failed
```

- Invalid scheme:

```
# SPDLOG_LEVEL=debug ./wazuh-agent --config-file wazuh-agent.yml --register-agent --url httk://localhost:55000 --user wazuh --password topsecret --name dummy
[2024-12-10 18:31:43.352] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:50] [LoadLocalConfig] Loading local config file: wazuh-agent.yml.
Starting wazuh-agent registration
[2024-12-10 18:31:43.357] [wazuh-agent] [error] [ERROR] [http_request_params.cpp:34] [HttpRequestParams] Invalid URL scheme: httk://localhost:55000
[2024-12-10 18:31:43.357] [wazuh-agent] [debug] [DEBUG] [http_resolver.hpp:44] [Resolve] Failed to resolve host:  port:  with error: Host not found (authoritative)
[2024-12-10 18:31:43.357] [wazuh-agent] [error] [ERROR] [http_client.cpp:405] [PerformHttpRequestInternal] Error: Failed to resolve host.
[2024-12-10 18:31:43.357] [wazuh-agent] [warning] [WARN] [http_client.cpp:329] [AuthenticateWithUserPassword] Error: 500.
Failed to authenticate with the manager
wazuh-agent registration failed
```

- Invalid host:

```
# SPDLOG_LEVEL=debug ./wazuh-agent --config-file wazuh-agent.yml --register-agent --url https:/localhost:55000 --user wazuh --password topsecret --name dummy
[2024-12-10 18:32:23.291] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:50] [LoadLocalConfig] Loading local config file: wazuh-agent.yml.
Starting wazuh-agent registration
[2024-12-10 18:32:23.295] [wazuh-agent] [error] [ERROR] [http_request_params.cpp:40] [HttpRequestParams] Invalid URL host: https:/localhost:55000
[2024-12-10 18:32:23.295] [wazuh-agent] [debug] [DEBUG] [http_resolver.hpp:44] [Resolve] Failed to resolve host:  port:  with error: Host not found (authoritative)
[2024-12-10 18:32:23.295] [wazuh-agent] [error] [ERROR] [http_client.cpp:405] [PerformHttpRequestInternal] Error: Failed to resolve host.
[2024-12-10 18:32:23.295] [wazuh-agent] [warning] [WARN] [http_client.cpp:329] [AuthenticateWithUserPassword] Error: 500.
Failed to authenticate with the manager
wazuh-agent registration failed
```

- Default port https:

```
# SPDLOG_LEVEL=debug ./wazuh-agent --config-file wazuh-agent.yml --register-agent --url https://localhost --user wazuh --password topsecret --name dummy
[2024-12-10 18:32:58.230] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:50] [LoadLocalConfig] Loading local config file: wazuh-agent.yml.
Starting wazuh-agent registration
[2024-12-10 18:32:58.286] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:400] [PerformHttpRequestInternal] Request /security/user/authenticate: Status 200
[2024-12-10 18:32:58.303] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:400] [PerformHttpRequestInternal] Request /agents: Status 201
wazuh-agent registered
```

- Default port http:

```
# SPDLOG_LEVEL=debug ./wazuh-agent --config-file wazuh-agent.yml --register-agent --url http://localhost --user wazuh --password topsecret --name dummy
[2024-12-10 18:33:37.207] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:50] [LoadLocalConfig] Loading local config file: wazuh-agent.yml.
Starting wazuh-agent registration
[2024-12-10 18:33:37.342] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:400] [PerformHttpRequestInternal] Request /security/user/authenticate: Status 200
[2024-12-10 18:33:37.469] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:400] [PerformHttpRequestInternal] Request /agents: Status 201
wazuh-agent registered
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X