### PR TITLE
fix: set rpm config directory to /usr/lib/rpm

### DIFF
--- a/src/ports-overlay/librpm/portfile.cmake
+++ b/src/ports-overlay/librpm/portfile.cmake
@@ -6,6 +6,11 @@ vcpkg_from_github(
   HEAD_REF rpm-4.18.2-release
 )
 
+vcpkg_replace_string("${SOURCE_PATH}/configure.ac"
+  "RPMCONFIGDIR=\"`echo \${usrprefix}/lib/rpm`\""
+  "RPMCONFIGDIR=\"/usr/lib/rpm\""
+)
+
 vcpkg_configure_make(
   SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS


### PR DESCRIPTION
|Related issue|
|---|
| #404 |

## Description

This PR fixes the error:

```log
Dec 06 14:56:25 rhel-agent env[8242]: [2024-12-06 14:56:25.548] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:900] [Scan] Starting evaluation.
Dec 06 14:56:25 rhel-agent env[8242]: error: Unable to open /build_wazuh/rpmbuild/BUILD/wazuh-agent-5.0.0/src/build/vcpkg_installed/x64-linux/debug/lib/rpm/rpmrc for reading: No such file or directory.
Dec 06 14:56:25 rhel-agent env[8242]: [2024-12-06 14:56:25.968] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:912] [Scan] Evaluation finished.
```

which occurs when the _Inventory_ module starts scanning packages. This causes no `“type”: “packages”` events to be generated in environments that use _rpm_ as package manager.

## Tests

### Agent RHEL9 (rpm installed)
After applying the fix the error disappears:

```log
Dec 12 15:27:52 rhel-agent env[4759]: [2024-12-12 15:27:52.851] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:816] [ScanPackages] Starting packages scan
Dec 12 15:27:53 rhel-agent env[4759]: [2024-12-12 15:27:53.310] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:852] [ScanPackages] Ending packages scan
```

And the _rpm_ packages are scanned generating _Inventory_ events:

```log
Dec 12 16:06:03 rhel-agent env[4913]: [2024-12-12 16:06:03.482] [wazuh-agent] [trace] [TRACE] [inventory.cpp:92] [SendDeltaEvent] Stateful event queued: {"data":{"@timestamp":"2024-12-12T16:06:02.062Z","package":{"architecture":"x86_64","description":"Rsyslog is an enhanced, multi-threaded syslog daemon. It supports MySQL,\nsyslog/TCP, RFC 3195, permitted sender lists, filtering on any message part,\nand fine grain output format control. It is compatible with stock sysklogd\nand can be used as a drop-in replacement. Rsyslog is simple to set up, with\nadvanced features suitable for enterprise-class, encryption-protected syslog\nrelay chains.","installed":"1704913202","name":"rsyslog","path":" ","size":2597069,"type":"rpm","version":"8.2102.0-117.el9"}},"id":"YzcyMWIzZjQtNjdhZS00M2M5LWE0ZTAtNTc0NWEyNjYwMGJkOnJzeXNsb2c6OC4yMTAyLjAtMTE3LmVsOTp4ODZfNjQ6cnBtOiA=","operation":"create","type":"packages"}, metadata {"id":"YzcyMWIzZjQtNjdhZS00M2M5LWE0ZTAtNTc0NWEyNjYwMGJkOnJzeXNsb2c6OC4yMTAyLjAtMTE3LmVsOTp4ODZfNjQ6cnBtOiA=","module":"inventory","operation":"create","type":"packages"}
Dec 12 16:06:03 rhel-agent env[4913]: [2024-12-12 16:06:03.483] [wazuh-agent] [trace] [TRACE] [inventory.cpp:92] [SendDeltaEvent] Stateful event queued: {"data":{"@timestamp":"2024-12-12T16:06:02.062Z","package":{"architecture":"x86_64","description":"This subpackage contains the default logrotate configuration for rsyslog.","installed":"1704913202","name":"rsyslog-logrotate","path":" ","size":226,"type":"rpm","version":"8.2102.0-117.el9"}},"id":"YzcyMWIzZjQtNjdhZS00M2M5LWE0ZTAtNTc0NWEyNjYwMGJkOnJzeXNsb2ctbG9ncm90YXRlOjguMjEwMi4wLTExNy5lbDk6eDg2XzY0OnJwbTog","operation":"create","type":"packages"}, metadata {"id":"YzcyMWIzZjQtNjdhZS00M2M5LWE0ZTAtNTc0NWEyNjYwMGJkOnJzeXNsb2ctbG9ncm90YXRlOjguMjEwMi4wLTExNy5lbDk6eDg2XzY0OnJwbTog","module":"inventory","operation":"create","type":"packages"}
Dec 12 16:06:03 rhel-agent env[4913]: [2024-12-12 16:06:03.486] [wazuh-agent] [trace] [TRACE] [inventory.cpp:92] [SendDeltaEvent] Stateful event queued: {"data":{"@timestamp":"2024-12-12T16:06:02.062Z","package":{"architecture":"noarch","description":"RPM macros for building Rust source packages.","installed":"1704914307","name":"rust-srpm-macros","path":" ","size":2447,"type":"rpm","version":"17-4.el9"}},"id":"YzcyMWIzZjQtNjdhZS00M2M5LWE0ZTAtNTc0NWEyNjYwMGJkOnJ1c3Qtc3JwbS1tYWNyb3M6MTctNC5lbDk6bm9hcmNoOnJwbTog","operation":"create","type":"packages"}, metadata {"id":"YzcyMWIzZjQtNjdhZS00M2M5LWE0ZTAtNTc0NWEyNjYwMGJkOnJ1c3Qtc3JwbS1tYWNyb3M6MTctNC5lbDk6bm9hcmNoOnJwbTog","module":"inventory","operation":"create","type":"packages"}
Dec 12 16:06:03 rhel-agent env[4913]: [2024-12-12 16:06:03.487] [wazuh-agent] [trace] [TRACE] [inventory.cpp:92] [SendDeltaEvent] Stateful event queued: {"data":{"@timestamp":"2024-12-12T16:06:02.062Z","package":{"architecture":"x86_64","description":"The sed (Stream EDitor) editor is a stream or batch (non-interactive)\neditor.  Sed takes text as input, performs an operation or set of\noperations on the text and outputs the modified text.  The operations\nthat sed performs (substitutions, deletions, insertions, etc.) can be\nspecified in a script file or from the command line.","installed":"1704913096","name":"sed","path":" ","size":813599,"type":"rpm","version":"4.8-9.el9"}},"id":"YzcyMWIzZjQtNjdhZS00M2M5LWE0ZTAtNTc0NWEyNjYwMGJkOnNlZDo0LjgtOS5lbDk6eDg2XzY0OnJwbTog","operation":"create","type":"packages"}, metadata {"id":"YzcyMWIzZjQtNjdhZS00M2M5LWE0ZTAtNTc0NWEyNjYwMGJkOnNlZDo0LjgtOS5lbDk6eDg2XzY0OnJwbTog","module":"inventory","operation":"create","type":"packages"}
Dec 12 16:06:03 rhel-agent env[4913]: [2024-12-12 16:06:03.488] [wazuh-agent] [trace] [TRACE] [inventory.cpp:92] [SendDeltaEvent] Stateful event queued: {"data":{"@timestamp":"2024-12-12T16:06:02.062Z","package":{"architecture":"noarch","description":"SELinux core policy package.\nOriginally based off of reference policy,\nthe policy has been adjusted to provide support for Fedora.","installed":"1704913176","name":"selinux-policy","path":" ","size":25744,"type":"rpm","version":"38.1.23-1.el9"}},"id":"YzcyMWIzZjQtNjdhZS00M2M5LWE0ZTAtNTc0NWEyNjYwMGJkOnNlbGludXgtcG9saWN5OjM4LjEuMjMtMS5lbDk6bm9hcmNoOnJwbTog","operation":"create","type":"packages"}, metadata {"id":"YzcyMWIzZjQtNjdhZS00M2M5LWE0ZTAtNTc0NWEyNjYwMGJkOnNlbGludXgtcG9saWN5OjM4LjEuMjMtMS5lbDk6bm9hcmNoOnJwbTog","module":"inventory","operation":"create","type":"packages"}

```

**Wazuh agent rpm package:** [wazuh-agent_5.0.0-0_x86_64_b76198d.rpm](https://github.com/wazuh/wazuh-agent-packages/actions/runs/12297430522/artifacts/2311804173)

### Agent Ubuntu 24.04

Inventory scan without error:

```log
Dec 12 15:59:17 noble env[61324]: [2024-12-12 15:59:17.492] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:981] [Scan] Starting evaluation.
Dec 12 15:59:19 noble env[61324]: [2024-12-12 15:59:19.414] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:993] [Scan] Evaluation finished.
```

Inventory package events:

```log
Dec 12 16:06:47 noble env[62545]: [2024-12-12 16:06:47.500] [wazuh-agent] [trace] [TRACE] [inventory.cpp:92] [SendDeltaEvent] Stateful event queued: {"data":{"@timestamp":"2024-12-12T19:06:46.297Z","package":{"architecture":"all","description":"Python 3 library for Apport crash report handling","installed":null,"name":"python3-apport","path":" ","size":494592,"type":"deb","version":"2.28.1-0ubuntu3.1"}},"id":"NzUwMWVkYjAtOWE2Yy00MjcyLTliZDAtNmY3MzJiNDk0MDliOnB5dGhvbjMtYXBwb3J0OjIuMjguMS0wdWJ1bnR1My4xOmFsbDpkZWI6IA==","operation":"create","type":"packages"}, metadata {"id":"NzUwMWVkYjAtOWE2Yy00MjcyLTliZDAtNmY3MzJiNDk0MDliOnB5dGhvbjMtYXBwb3J0OjIuMjguMS0wdWJ1bnR1My4xOmFsbDpkZWI6IA==","module":"inventory","operation":"create","type":"packages"}
Dec 12 16:06:47 noble env[62545]: [2024-12-12 16:06:47.502] [wazuh-agent] [trace] [TRACE] [inventory.cpp:92] [SendDeltaEvent] Stateful event queued: {"data":{"@timestamp":"2024-12-12T19:06:46.297Z","package":{"architecture":"amd64","description":"Python 3 interface to libapt-pkg","installed":null,"name":"python3-apt","path":" ","size":710656,"type":"deb","version":"2.7.7ubuntu3"}},"id":"NzUwMWVkYjAtOWE2Yy00MjcyLTliZDAtNmY3MzJiNDk0MDliOnB5dGhvbjMtYXB0OjIuNy43dWJ1bnR1MzphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"}, metadata {"id":"NzUwMWVkYjAtOWE2Yy00MjcyLTliZDAtNmY3MzJiNDk0MDliOnB5dGhvbjMtYXB0OjIuNy43dWJ1bnR1MzphbWQ2NDpkZWI6IA==","module":"inventory","operation":"create","type":"packages"}
Dec 12 16:06:47 noble env[62545]: [2024-12-12 16:06:47.503] [wazuh-agent] [trace] [TRACE] [inventory.cpp:92] [SendDeltaEvent] Stateful event queued: {"data":{"@timestamp":"2024-12-12T19:06:46.297Z","package":{"architecture":"all","description":"bash tab completion for argparse (for Python 3)","installed":null,"name":"python3-argcomplete","path":" ","size":153600,"type":"deb","version":"3.1.4-1ubuntu0.1"}},"id":"NzUwMWVkYjAtOWE2Yy00MjcyLTliZDAtNmY3MzJiNDk0MDliOnB5dGhvbjMtYXJnY29tcGxldGU6My4xLjQtMXVidW50dTAuMTphbGw6ZGViOiA=","operation":"create","type":"packages"}, metadata {"id":"NzUwMWVkYjAtOWE2Yy00MjcyLTliZDAtNmY3MzJiNDk0MDliOnB5dGhvbjMtYXJnY29tcGxldGU6My4xLjQtMXVidW50dTAuMTphbGw6ZGViOiA=","module":"inventory","operation":"create","type":"packages"}
Dec 12 16:06:47 noble env[62545]: [2024-12-12 16:06:47.505] [wazuh-agent] [trace] [TRACE] [inventory.cpp:92] [SendDeltaEvent] Stateful event queued: {"data":{"@timestamp":"2024-12-12T19:06:46.297Z","package":{"architecture":"all","description":"Attributes without boilerplate (Python 3)","installed":null,"name":"python3-attr","path":" ","size":241664,"type":"deb","version":"23.2.0-2"}},"id":"NzUwMWVkYjAtOWE2Yy00MjcyLTliZDAtNmY3MzJiNDk0MDliOnB5dGhvbjMtYXR0cjoyMy4yLjAtMjphbGw6ZGViOiA=","operation":"create","type":"packages"}, metadata {"id":"NzUwMWVkYjAtOWE2Yy00MjcyLTliZDAtNmY3MzJiNDk0MDliOnB5dGhvbjMtYXR0cjoyMy4yLjAtMjphbGw6ZGViOiA=","module":"inventory","operation":"create","type":"packages"}
Dec 12 16:06:47 noble env[62545]: [2024-12-12 16:06:47.506] [wazuh-agent] [trace] [TRACE] [inventory.cpp:92] [SendDeltaEvent] Stateful event queued: {"data":{"@timestamp":"2024-12-12T19:06:46.297Z","package":{"architecture":"all","description":"Self-service finite-state machines for the programmer on the go","installed":null,"name":"python3-automat","path":" ","size":126976,"type":"deb","version":"22.10.0-2"}},"id":"NzUwMWVkYjAtOWE2Yy00MjcyLTliZDAtNmY3MzJiNDk0MDliOnB5dGhvbjMtYXV0b21hdDoyMi4xMC4wLTI6YWxsOmRlYjog","operation":"create","type":"packages"}, metadata {"id":"NzUwMWVkYjAtOWE2Yy00MjcyLTliZDAtNmY3MzJiNDk0MDliOnB5dGhvbjMtYXV0b21hdDoyMi4xMC4wLTI6YWxsOmRlYjog","module":"inventory","operation":"create","type":"packages"}
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X