### PR TITLE
Catch exception to release database access

### DIFF
--- a/src/agent/multitype_queue/src/sqlitestorage.cpp
+++ b/src/agent/multitype_queue/src/sqlitestorage.cpp
@@ -69,7 +69,6 @@ int SQLiteStorage::Store(const nlohmann::json& message,
                          const std::string& moduleType,
                          const std::string& metadata)
 {
-
     std::string insertQuery;
 
     constexpr std::string_view INSERT_QUERY {
@@ -103,10 +102,17 @@ int SQLiteStorage::Store(const nlohmann::json& message,
     }
     else
     {
-        SQLite::Transaction transaction(*m_db);
-        query.bind(1, message.dump());
-        result = query.exec();
-        transaction.commit();
+        try
+        {
+            SQLite::Transaction transaction(*m_db);
+            query.bind(1, message.dump());
+            result = query.exec();
+            transaction.commit();
+        }
+        catch (const std::exception& e)
+        {
+            LogError("Error during Store operation: {}.", e.what());
+        }
     }
     ReleaseDatabaseAccess();
 


### PR DESCRIPTION
## Description

I found a deadlock when trying to shutdown the Agent via CTRL+C. Upon first inspection it was the Inventory module that was preventing the normal shutdown of the application. Looking into the cause of the deadlock I came to this point:

```c++
void Inventory::UpdateChanges(const std::string& table,
                                 const nlohmann::json& values)
{
    const auto callback
    {
        [this, table](ReturnTypeCallback result, const nlohmann::json & data)
        {
            NotifyChange(result, data, table);
        }
    };

    std::unique_lock<std::mutex> lock{m_mutex};
    DBSyncTxn txn
    {
        m_spDBSync->handle(),
        nlohmann::json{table},
        0,
        QUEUE_SIZE,
        callback
    };
    nlohmann::json input;
    input["table"] = table;
    input["data"] = values;
    txn.syncTxnRow(input);
    txn.getDeletedRows(callback);
}
```

The lock wasn't release because `txn.syncTxnRow(input)` was not returning. Following the subsequent function calls through `Inventory::NotifyChange`, `Inventory::m_reportDiffFunction (Inventory::SendDeltaEvent)`, `Inventory::m_pushMessage (MultiTypeQueue::push)`, `SQLiteStorage::Store`, I found that in this last function, a lock on the database is acquired and when the message to push was not a json list it fell on an `else` statement that attempted a write in the DB without a try catch block, which caused the coroutine to end when an exception was thrown, without releasing the lock. Eventually this locked the Inventory module and shutdown was prevented. By adding a try catch block the problem is solved.

Another clue was given by the logs output:

```
[2024-12-13 17:18:30.993] [wazuh-agent] [error] [ERROR] [task_manager.cpp:97] [operator()] FetchCommands coroutine task exited with an exception: attempt to write a readonly database
```

To reproduce this error it was only necessary to put the db in readonly mode.

Though this fixes this particular issue, we should investigate if `Inventory::UpdateChanges` should be a blocking call all the way through and if it can perform some part of this flow asynchronously.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X

