### PR TITLE
Update GitHub Artifact Actions to v4

### DIFF
--- a/.github/actions/clang_format/action.yml
+++ b/.github/actions/clang_format/action.yml
@@ -59,7 +59,7 @@ runs:
           fi
 
       # Upload errors as an artifact, when failed
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Clang-format errors - ${{ inputs.id }}

--- a/.github/actions/doxygen/action.yml
+++ b/.github/actions/doxygen/action.yml
@@ -16,9 +16,9 @@ inputs:
 
 runs:
   using: "composite"
-  steps:    
+  steps:
       # Dependencies for testing:
-      # - doxygen 
+      # - doxygen
       # - graphviz
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -56,7 +56,7 @@ runs:
           fi
 
       # Upload errors as an artifact, when failed
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Doxygen errors - ${{ inputs.id }}
@@ -64,7 +64,7 @@ runs:
           retention-days: 1
 
       # Upload the documentation as an artifact, when successful
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: Doxygen Documentation - ${{ inputs.id }}

--- a/.github/workflows/coverage_check.yml
+++ b/.github/workflows/coverage_check.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Upload Coverage Artifact
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: build/coverage.zip

--- a/.github/workflows/integration_tests_execd_tier_0_1_win.yml
+++ b/.github/workflows/integration_tests_execd_tier_0_1_win.yml
@@ -32,7 +32,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -56,7 +56,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration_tests_fim_tier_0_1_win.yml
+++ b/.github/workflows/integration_tests_fim_tier_0_1_win.yml
@@ -32,7 +32,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -56,7 +56,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration_tests_fim_tier_2_win.yml.yml
+++ b/.github/workflows/integration_tests_fim_tier_2_win.yml.yml
@@ -32,7 +32,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -56,7 +56,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration_tests_github_tier_0_1_win.yml
+++ b/.github/workflows/integration_tests_github_tier_0_1_win.yml
@@ -32,7 +32,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -56,7 +56,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration_tests_logcollector_tier_0_1_win.yml
+++ b/.github/workflows/integration_tests_logcollector_tier_0_1_win.yml
@@ -32,7 +32,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -56,7 +56,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration_tests_office365_tier_0_1_win.yml
+++ b/.github/workflows/integration_tests_office365_tier_0_1_win.yml
@@ -32,7 +32,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -56,7 +56,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration_tests_sca_tier_0_1_win.yml
+++ b/.github/workflows/integration_tests_sca_tier_0_1_win.yml
@@ -32,7 +32,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -56,7 +56,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\


### PR DESCRIPTION
|Related issue|
|---|
| Closes #423 |

## Description
This PR updates the GitHub Actions in all workflows to use the latest versions, as the legacy versions are deprecated and will be disabled by **January 30, 2025**.

## Changes Made
- Updated `actions/download-artifact@v3` to `actions/download-artifact@v4`.
- Updated `actions/upload-artifact@v3` to `actions/upload-artifact@v4`.

### Why this change?
The previous versions (`v3`) are no longer supported and will stop working after the deprecation date. By upgrading to `v4`, we ensure continued functionality and compatibility across all workflows.

## Tests

- [x] Coverage Check (which uses `upload-artifact@v4`)