### PR TITLE
Fix race condition associated to module reload and modulemanager

### DIFF
--- a/src/agent/include/agent.hpp
+++ b/src/agent/include/agent.hpp
@@ -13,7 +13,9 @@
 
 #include <sysInfo.hpp>
 
+#include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 
 /// @brief Agent class
@@ -76,4 +78,13 @@ private:
 
     /// @brief Centralized configuration
     centralized_configuration::CentralizedConfiguration m_centralizedConfiguration;
+
+    /// @brief Mutex to coordinate agent reload
+    std::mutex m_reloadMutex;
+
+    /// @brief Indicates if the agent is running
+    std::atomic<bool> m_running = true;
+
+    /// @brief Agent thread count
+    size_t m_agentThreadCount;
 };

--- a/src/agent/src/signal_handler.cpp
+++ b/src/agent/src/signal_handler.cpp
@@ -17,6 +17,7 @@ void SignalHandler::HandleSignal([[maybe_unused]] int signal)
 
 void SignalHandler::WaitForSignal()
 {
+    KeepRunning.store(true);
     std::unique_lock<std::mutex> lock(m_cvMutex);
     m_cv.wait(lock, [] { return !KeepRunning.load(); });
 }

--- a/src/agent/task_manager/include/task_manager.hpp
+++ b/src/agent/task_manager/include/task_manager.hpp
@@ -7,6 +7,7 @@
 
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -53,4 +54,7 @@ private:
 
     /// @brief Number of enqueued threads
     size_t m_numEnqueuedThreads = 0;
+
+    /// @brief Mutex to control Start and Stop operations
+    mutable std::mutex m_mutex;
 };

--- a/src/modules/include/moduleManager.hpp
+++ b/src/modules/include/moduleManager.hpp
@@ -1,14 +1,17 @@
 #pragma once
 
-#include <map>
-#include <memory>
-#include <string>
-#include <thread>
 #include <multitype_queue.hpp>
 #include <moduleWrapper.hpp>
 #include <task_manager.hpp>
 
 #include <boost/asio/awaitable.hpp>
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
 
 class ModuleManager {
 public:
@@ -46,6 +49,15 @@ public:
 
     void AddModules();
     std::shared_ptr<ModuleWrapper> GetModule(const std::string & name);
+
+    /// @brief Start the modules
+    ///
+    /// This function begins the procedure to start the modules and blocks until the Start function
+    /// for each module has been called. However, it does not guarantee that the modules are fully
+    /// operational upon return; they may still be in the process of initializing.
+    ///
+    /// @note Call this function before interacting with the modules to ensure the startup process is initiated.
+    /// @warning Ensure the modules have fully started before performing any operations that depend on them.
     void Start();
     void Setup();
     void Stop();
@@ -56,4 +68,6 @@ private:
     std::function<int(Message)> m_pushMessage;
     std::shared_ptr<configuration::ConfigurationParser> m_configurationParser;
     std::string m_agentUUID;
+    std::mutex m_mutex;
+    std::atomic<int> m_started {0};
 };


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/432|


## Description

As described in the issue, the possibility of reloading modules requires some mechanism to avoid race conditions, in particular that the Agent stops the module manager when shutting down right before a ReloadModules command is received, resulting in two `ModuleManager::Stop` calls followed by a `ModuleManager::Start` halting the application.

The changes introduced by this PR are focused on improving thread safety and control mechanisms within the Wazuh Agent.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
