### PR TITLE
Replace base64 with a hash sha1 function for document id

### DIFF
--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -84,7 +84,7 @@ class Inventory {
         static void LogErrorInventory(const std::string& log);
         nlohmann::json EcsData(const nlohmann::json& data, const std::string& table);
         std::string GetPrimaryKeys(const nlohmann::json& data, const std::string& table);
-        std::string CalculateBase64Id(const nlohmann::json& data, const std::string& table);
+        std::string CalculateHashId(const nlohmann::json& data, const std::string& table);
 
         const std::string                           m_moduleName {"inventory"};
         std::string                                 m_agentUUID {""};   // Agent UUID

--- a/src/modules/inventory/tests/inventoryImp/inventoryImp_test.cpp
+++ b/src/modules/inventory/tests/inventoryImp/inventoryImp_test.cpp
@@ -4,7 +4,7 @@
 #include "inventory.hpp"
 
 constexpr auto INVENTORY_DB_PATH {"TEMP.db"};
-constexpr int SLEEP_DURATION_SECONDS = 10;
+constexpr int SLEEP_DURATION_SECONDS = 3;
 
 void ReportFunction(const std::string& payload);
 
@@ -93,37 +93,38 @@ TEST_F(InventoryImpTest, defaultCtor)
         {
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
+            delta.erase("id");
             wrapperDelta.callbackMock(delta.dump());
         }
     };
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"OkludGVsIENvcnBvcmF0aW9u","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"Ok1pY3Jvc29mdCBXaW5kb3dzIDc=","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"OnhzZXJ2ZXIteG9yZzoxOjcuNysxOXVidW50dTE0OmFtZDY0OmRlYjog","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"OjQzMTYyNQ==","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"operation":"create","type":"processes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"OktCMTIzNDU2Nzg=","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult6
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"OjA6dGNwOjEyNy4wLjAuMTo2MzE=","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"OmRvY2tlcjA6OmlwdjQ6OjE3Mi4xNy4wLjE=","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"operation":"create","type":"networks"})"
     };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(testing::AtLeast(1));
@@ -305,33 +306,34 @@ TEST_F(InventoryImpTest, noHardware)
         {
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
+            delta.erase("id");
             wrapperDelta.callbackMock(delta.dump());
         }
     };
 
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"operation":"create","type":"processes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult6
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"operation":"create","type":"networks"})"
     };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
@@ -411,33 +413,34 @@ TEST_F(InventoryImpTest, noOs)
         {
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
+            delta.erase("id");
             wrapperDelta.callbackMock(delta.dump());
         }
     };
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"operation":"create","type":"packages"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"operation":"create","type":"processes"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"operation":"create","type":"networks"})"
     };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
@@ -517,33 +520,34 @@ TEST_F(InventoryImpTest, noNetwork)
         {
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
+            delta.erase("id");
             wrapperDelta.callbackMock(delta.dump());
         }
     };
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"operation":"create","type":"processes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult6
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"operation":"create","type":"ports"})"
     };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
@@ -622,33 +626,34 @@ TEST_F(InventoryImpTest, noPackages)
         {
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
+            delta.erase("id");
             wrapperDelta.callbackMock(delta.dump());
         }
     };
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"operation":"create","type":"processes"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"operation":"create","type":"networks"})"
     };
 
 
@@ -729,33 +734,34 @@ TEST_F(InventoryImpTest, noPorts)
         {
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
+            delta.erase("id");
             wrapperDelta.callbackMock(delta.dump());
         }
     };
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"operation":"create","type":"processes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"operation":"create","type":"networks"})"
     };
 
 
@@ -837,41 +843,42 @@ TEST_F(InventoryImpTest, noPortsAll)
         {
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
+            delta.erase("id");
             wrapperDelta.callbackMock(delta.dump());
         }
     };
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"operation":"create","type":"processes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult6
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"7046b3f9cda975eb6567259c2469748e634dde49"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":""},"network":{"protocol":"udp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnVkcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"7046b3f9cda975eb6567259c2469748e634dde49"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":""},"network":{"protocol":"udp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"operation":"create","type":"ports"})"
     };
     const auto expectedResult8
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"operation":"create","type":"networks"})"
     };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
@@ -952,33 +959,34 @@ TEST_F(InventoryImpTest, noProcesses)
         {
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
+            delta.erase("id");
             wrapperDelta.callbackMock(delta.dump());
         }
     };
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"id":"MTIzNDpLQjEyMzQ1Njc4","operation":"create","type":"hotfixes"})"
+        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"operation":"create","type":"hotfixes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"operation":"create","type":"networks"})"
     };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
@@ -1059,33 +1067,34 @@ TEST_F(InventoryImpTest, noHotfixes)
         {
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
+            delta.erase("id");
             wrapperDelta.callbackMock(delta.dump());
         }
     };
 
     const auto expectedResult1
     {
-        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"id":"MTIzNDpJbnRlbCBDb3Jwb3JhdGlvbg==","operation":"create","type":"hardware"})"
+        R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":0},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"operation":"create","type":"hardware"})"
     };
     const auto expectedResult2
     {
-        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"MTIzNDpNaWNyb3NvZnQgV2luZG93cyA3","operation":"create","type":"system"})"
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"operation":"create","type":"system"})"
     };
     const auto expectedResult3
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"operation":"create","type":"packages"})"
     };
     const auto expectedResult4
     {
-        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"id":"MTIzNDo0MzE2MjU=","operation":"create","type":"processes"})"
+        R"({"data":{"process":{"args":"","command_line":"","group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"operation":"create","type":"processes"})"
     };
     const auto expectedResult5
     {
-        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"id":"MTIzNDowOnRjcDoxMjcuMC4wLjE6NjMx","operation":"create","type":"ports"})"
+        R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"device":{"id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":"","pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"operation":"create","type":"ports"})"
     };
     const auto expectedResult7
     {
-        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"id":"MTIzNDpkb2NrZXIwOjppcHY0OjoxNzIuMTcuMC4x","operation":"create","type":"networks"})"
+        R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"protocol":"","type":"ipv4"},"observer":{"ingress":{"interface":{"alias":"","name":"docker0"}}}},"operation":"create","type":"networks"})"
     };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
@@ -1420,6 +1429,7 @@ TEST_F(InventoryImpTest, portAllDisable)
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
             delta.erase("id");
+            delta.erase("id");
             wrapper.callbackMock(delta.dump());
         }
     };
@@ -1502,13 +1512,14 @@ TEST_F(InventoryImpTest, PackagesDuplicated)
         {
             auto delta = nlohmann::json::parse(data);
             delta["data"].erase("@timestamp");
+            delta.erase("id");
             wrapper.callbackMock(delta.dump());
         }
     };
 
     const auto expectedResult1
     {
-        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"id":"MTIzNDp4c2VydmVyLXhvcmc6MTo3LjcrMTl1YnVudHUxNDphbWQ2NDpkZWI6IA==","operation":"create","type":"packages"})"
+        R"({"data":{"package":{"architecture":"amd64","description":"","installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"operation":"create","type":"packages"})"
     };
 
     EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);
@@ -1552,9 +1563,74 @@ TEST_F(InventoryImpTest, PackagesDuplicated)
     }
 }
 
+TEST_F(InventoryImpTest, hashId)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
+        R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})"
+    )));
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+            delta["data"].erase("@timestamp");
+            wrapperDelta.callbackMock(delta.dump());
+        }
+    };
+
+    const auto expectedResult2
+    {
+        R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":"","kernel":"7601","name":"Microsoft Windows 7","platform":"","type":"","version":"6.1.7601"}}},"id":"6bd3291be0d2314de0329e8ac36be434a085eb32","operation":"create","type":"system"})"
+    };
+
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
+
+    std::string inventoryConfig = R"(
+        inventory:
+            enabled: true
+            interval: 3600
+            scan_on_start: true
+            hardware: false
+            system: true
+            networks: false
+            packages: false
+            ports: false
+            ports_all: false
+            processes: false
+            hotfixes: false
+    )";
+    auto configParser = std::make_shared<configuration::ConfigurationParser>(inventoryConfig);
+    Inventory::Instance().Setup(configParser);
+
+    std::thread t
+    {
+        [&spInfoWrapper, &callbackDataDelta]()
+        {
+            Inventory::Instance().Init(spInfoWrapper,
+                                        callbackDataDelta,
+                                        INVENTORY_DB_PATH,
+                                        "",
+                                        "");
+            Inventory::Instance().SetAgentUUID("1234");
+        }
+    };
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    Inventory::Instance().Stop();
+
+    if (t.joinable())
+    {
+        t.join();
+    }
+
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-


### PR DESCRIPTION
|Related issue|
|---|
|Close #416|

## Description

### Hashing with SHA1:

The SHA1 function from computes a 20-byte hash of the input data.
This hash is suitable for scenarios requiring shorter output compared to Base64, and it adheres to the 512-byte limit.

### Conversion to Hexadecimal:

The binary hash is converted into a human-readable hexadecimal, this ensures that the hash remains compatible with textual storage.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

```yml
agent:
  server_url: https://localhost:27000
  path.data: /var/lib/wazuh-agent
  retry_interval: 30s
events:
  batch_interval: 10s
  batch_size: 1000
inventory:
  enabled: true
  interval: 30s
  scan_on_start: true
  hardware: true
  system: true
  networks: true
  packages: true
  ports: true
  ports_all: true
  processes: true
  hotfixes: true
logcollector:
  enabled: true
  localfiles:
    - /var/log/auth.log
    - /tmp/logtest.log
  reload_interval: 1m
  file_wait: 500ms

```

