### PR TITLE
Fix GLIBCXX version error on Linux by adjusting CMAKE_SYSTEM_NAME check

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,13 +2,13 @@ cmake_minimum_required(VERSION 3.22)
 
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++")
-endif()
-
 get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
 get_filename_component(CONFIG_FOLDER ${CMAKE_SOURCE_DIR}/../etc/config/ ABSOLUTE)
 project(wazuh-agent)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++")
+endif()
 
 include(cmake/CommonSettings.cmake)
 set_common_settings()


### PR DESCRIPTION
|Related issue|
|---|
|Close #441|

## Description
This PR resolves the GLIBCXX version error observed when running the Wazuh agent on Linux after installing the latest RPM package.

The issue was caused by the CMAKE_SYSTEM_NAME check being executed before the project() declaration in the CMakeLists.txt file, which prevented proper detection of the system type.

This fix adjusts the location of the CMAKE_SYSTEM_NAME check to ensure it is evaluated after the project is initialized.

## Root Cause

The following condition was evaluated too early:

```cmakelist
if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++")
endif()
```

As a result, the -static-libstdc++ linker flag was not applied correctly during the build process for Linux.
