### PR TITLE
Add server certificate validation to wazuh agent (Linux and Windows)

### DIFF
--- a/etc/config/wazuh-agent.yml
+++ b/etc/config/wazuh-agent.yml
@@ -2,6 +2,7 @@ agent:
   thread_count: 4
   server_url: https://localhost:27000
   retry_interval: 30s
+  verification_mode: full
 events:
   batch_interval: 10s
   batch_size: 1MB

--- a/etc/config/wazuh-agent.yml
+++ b/etc/config/wazuh-agent.yml
@@ -2,7 +2,7 @@ agent:
   thread_count: 4
   server_url: https://localhost:27000
   retry_interval: 30s
-  verification_mode: full
+  verification_mode: none # TODO: change this setting to full
 events:
   batch_interval: 10s
   batch_size: 1MB

--- a/src/agent/communicator/CMakeLists.txt
+++ b/src/agent/communicator/CMakeLists.txt
@@ -15,6 +15,14 @@ find_path(JWT_CPP_INCLUDE_DIRS "jwt-cpp/base.h")
 
 add_library(Communicator src/communicator.cpp src/http_client.cpp src/http_request_params.cpp)
 
+if(WIN32)
+    set(VERIFY_UTILS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/src/https_socket_verify_utils_win.cpp")
+else()
+    set(VERIFY_UTILS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/src/https_socket_verify_utils_lin.cpp")
+endif()
+
+target_sources(Communicator PRIVATE ${VERIFY_UTILS_FILE})
+
 target_include_directories(Communicator PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         SYSTEM PRIVATE
@@ -22,6 +30,10 @@ target_include_directories(Communicator PUBLIC
 
 target_compile_definitions(Communicator PRIVATE -DJWT_DISABLE_PICOJSON=ON)
 target_link_libraries(Communicator PUBLIC Config Boost::asio Boost::beast Boost::system Boost::url Logger PRIVATE OpenSSL::SSL OpenSSL::Crypto nlohmann_json::nlohmann_json)
+
+if(WIN32)
+    target_link_libraries(Communicator PRIVATE Crypt32)
+endif()
 
 include(../../cmake/ConfigureTarget.cmake)
 configure_target(Communicator)

--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -66,6 +66,19 @@ namespace communicator
                 LogWarn("batch_size must be between 1KB and 100MB. Using default value.");
                 m_batchSize = config::agent::DEFAULT_BATCH_SIZE;
             }
+
+            m_verificationMode = getConfigValue.template operator()<std::string>("agent", "verification_mode")
+                                     .value_or(config::agent::DEFAULT_VERIFICATION_MODE);
+
+            if (std::find(std::begin(config::agent::VALID_VERIFICATION_MODES),
+                          std::end(config::agent::VALID_VERIFICATION_MODES),
+                          m_verificationMode) == std::end(config::agent::VALID_VERIFICATION_MODES))
+            {
+                LogWarn("Incorrect value for 'verification_mode', in case of HTTPS connections the default value '{}' "
+                        "is used.",
+                        config::agent::DEFAULT_VERIFICATION_MODE);
+                m_verificationMode = config::agent::DEFAULT_VERIFICATION_MODE;
+            }
         }
 
         /// @brief Sends an authentication request to the manager
@@ -149,5 +162,8 @@ namespace communicator
 
         /// @brief Timer to wait for token expiration
         std::unique_ptr<boost::asio::steady_timer> m_tokenExpTimer;
+
+        /// @brief The verification mode
+        std::string m_verificationMode;
     };
 } // namespace communicator

--- a/src/agent/communicator/include/http_client.hpp
+++ b/src/agent/communicator/include/http_client.hpp
@@ -71,22 +71,26 @@ namespace http_client
         /// @param userAgent User agent header
         /// @param uuid Unique user identifier
         /// @param key Authentication key
+        /// @param verificationMode Verification mode
         /// @return Authentication token if successful, otherwise nullopt
         std::optional<std::string> AuthenticateWithUuidAndKey(const std::string& serverUrl,
                                                               const std::string& userAgent,
                                                               const std::string& uuid,
-                                                              const std::string& key) override;
+                                                              const std::string& key,
+                                                              const std::string& verificationMode) override;
 
         /// @brief Authenticates using username and password
         /// @param serverUrl Server URL for authentication
         /// @param userAgent User agent header
         /// @param user Username for authentication
         /// @param password User password
+        /// @param verificationMode Verification mode
         /// @return Authentication token if successful, otherwise nullopt
         std::optional<std::string> AuthenticateWithUserPassword(const std::string& serverUrl,
                                                                 const std::string& userAgent,
                                                                 const std::string& user,
-                                                                const std::string& password) override;
+                                                                const std::string& password,
+                                                                const std::string& verificationMode) override;
 
     private:
         /// @brief Performs an HTTP request with a response handler

--- a/src/agent/communicator/include/http_request_params.hpp
+++ b/src/agent/communicator/include/http_request_params.hpp
@@ -26,6 +26,7 @@ namespace http_client
         /// @param serverUrl The server URL for the request
         /// @param endpoint The endpoint for the request
         /// @param userAgent The user agent property for the request header
+        /// @param verificationMode The verification mode for the request
         /// @param token Optional token for authorization
         /// @param userPass Optional user credentials for basic authentication
         /// @param body Optional body for the request

--- a/src/agent/communicator/include/http_request_params.hpp
+++ b/src/agent/communicator/include/http_request_params.hpp
@@ -15,6 +15,7 @@ namespace http_client
         std::string Port;
         std::string Endpoint;
         std::string User_agent;
+        std::string Verification_Mode;
         std::string Token;
         std::string User_pass;
         std::string Body;
@@ -32,6 +33,7 @@ namespace http_client
                           const std::string& serverUrl,
                           std::string endpoint,
                           std::string userAgent,
+                          std::string verificationMode,
                           std::string token = "",
                           std::string userPass = "",
                           std::string body = "");

--- a/src/agent/communicator/include/https_socket_verify_utils.hpp
+++ b/src/agent/communicator/include/https_socket_verify_utils.hpp
@@ -1,0 +1,17 @@
+#include <boost/asio/ssl.hpp>
+
+#include <string>
+
+namespace https_socket_verify_utils
+{
+    /// @brief Verifies the certificate of the HTTPS connection
+    /// @param preverified The result of the pre-verification
+    /// @param ctx The verification context
+    /// @param mode The verification mode to use
+    /// @param host The hostname to verify against
+    /// @return True if the certificate is valid, false otherwise
+    bool VerifyCertificate(bool preverified,
+                           boost::asio::ssl::verify_context& ctx,
+                           const std::string& mode,
+                           const std::string& host);
+} // namespace https_socket_verify_utils

--- a/src/agent/communicator/include/https_socket_verify_utils.hpp
+++ b/src/agent/communicator/include/https_socket_verify_utils.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <boost/asio/ssl.hpp>
 
 #include <string>

--- a/src/agent/communicator/include/ihttp_client.hpp
+++ b/src/agent/communicator/include/ihttp_client.hpp
@@ -62,22 +62,26 @@ namespace http_client
         /// @param userAgent The user agent header
         /// @param uuid The UUID
         /// @param key The key
+        /// @param verificationMode The verification mode
         /// @return The authentication token
         virtual std::optional<std::string> AuthenticateWithUuidAndKey(const std::string& serverUrl,
                                                                       const std::string& userAgent,
                                                                       const std::string& uuid,
-                                                                      const std::string& key) = 0;
+                                                                      const std::string& key,
+                                                                      const std::string& verificationMode) = 0;
 
         /// @brief Authenticate with a user and password
         /// @param serverUrl The URL of the server
         /// @param userAgent The user agent header
         /// @param user The user
         /// @param password The password
+        /// @param verificationMode The verification mode
         /// @return The authentication token
         virtual std::optional<std::string> AuthenticateWithUserPassword(const std::string& serverUrl,
                                                                         const std::string& userAgent,
                                                                         const std::string& user,
-                                                                        const std::string& password) = 0;
+                                                                        const std::string& password,
+                                                                        const std::string& verificationMode) = 0;
 
         /// @brief Perform an HTTP request, receive the response and write it to a file
         /// @param params The parameters for the request

--- a/src/agent/communicator/include/ihttp_socket.hpp
+++ b/src/agent/communicator/include/ihttp_socket.hpp
@@ -15,6 +15,11 @@ namespace http_client
         /// @brief Virtual destructor
         virtual ~IHttpSocket() = default;
 
+        /// @brief Sets the verification mode for the host
+        /// @param host The host name
+        /// @param verificationMode The verification mode to set
+        virtual void SetVerificationMode(const std::string& host, const std::string& verificationMode) = 0;
+
         /// @brief Connects the socket to the given endpoints
         /// @param endpoints The endpoints to connect to
         /// @param ec The error code, if any occurred

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -19,7 +19,7 @@ namespace communicator
     boost::beast::http::status Communicator::SendAuthenticationRequest()
     {
         const auto token = m_httpClient->AuthenticateWithUuidAndKey(
-            m_serverUrl, m_getHeaderInfo ? m_getHeaderInfo() : "", m_uuid, m_key);
+            m_serverUrl, m_getHeaderInfo ? m_getHeaderInfo() : "", m_uuid, m_key, m_verificationMode);
 
         if (token.has_value())
         {
@@ -78,8 +78,11 @@ namespace communicator
             return m_keepRunning.load();
         };
 
-        const auto reqParams = http_client::HttpRequestParams(
-            boost::beast::http::verb::get, m_serverUrl, "/api/v1/commands", m_getHeaderInfo ? m_getHeaderInfo() : "");
+        const auto reqParams = http_client::HttpRequestParams(boost::beast::http::verb::get,
+                                                              m_serverUrl,
+                                                              "/api/v1/commands",
+                                                              m_getHeaderInfo ? m_getHeaderInfo() : "",
+                                                              m_verificationMode);
         co_await m_httpClient->Co_PerformHttpRequest(
             m_token, reqParams, {}, onAuthenticationFailed, m_retryInterval, m_batchSize, onSuccess, loopCondition);
     }
@@ -156,7 +159,8 @@ namespace communicator
         const auto reqParams = http_client::HttpRequestParams(boost::beast::http::verb::post,
                                                               m_serverUrl,
                                                               "/api/v1/events/stateful",
-                                                              m_getHeaderInfo ? m_getHeaderInfo() : "");
+                                                              m_getHeaderInfo ? m_getHeaderInfo() : "",
+                                                              m_verificationMode);
         co_await m_httpClient->Co_PerformHttpRequest(m_token,
                                                      reqParams,
                                                      getMessages,
@@ -184,7 +188,8 @@ namespace communicator
         const auto reqParams = http_client::HttpRequestParams(boost::beast::http::verb::post,
                                                               m_serverUrl,
                                                               "/api/v1/events/stateless",
-                                                              m_getHeaderInfo ? m_getHeaderInfo() : "");
+                                                              m_getHeaderInfo ? m_getHeaderInfo() : "",
+                                                              m_verificationMode);
         co_await m_httpClient->Co_PerformHttpRequest(m_token,
                                                      reqParams,
                                                      getMessages,
@@ -223,6 +228,7 @@ namespace communicator
                                                               "/api/v1/files?file_name=" + groupName +
                                                                   config::DEFAULT_SHARED_FILE_EXTENSION,
                                                               m_getHeaderInfo ? m_getHeaderInfo() : "",
+                                                              m_verificationMode,
                                                               *m_token);
 
         const auto result = m_httpClient->PerformHttpRequestDownload(reqParams, dstFilePath);

--- a/src/agent/communicator/src/http_client_utils.hpp
+++ b/src/agent/communicator/src/http_client_utils.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <ihttp_socket.hpp>
 
 #include <boost/asio.hpp>

--- a/src/agent/communicator/src/http_request_params.cpp
+++ b/src/agent/communicator/src/http_request_params.cpp
@@ -9,12 +9,14 @@ namespace http_client
                                          const std::string& serverUrl,
                                          std::string endpoint,
                                          std::string userAgent,
+                                         std::string verificationMode,
                                          std::string token,
                                          std::string userPass,
                                          std::string body)
         : Method(method)
         , Endpoint(std::move(endpoint))
         , User_agent(std::move(userAgent))
+        , Verification_Mode(std::move(verificationMode))
         , Token(std::move(token))
         , User_pass(std::move(userPass))
         , Body(std::move(body))
@@ -49,7 +51,7 @@ namespace http_client
     bool HttpRequestParams::operator==(const HttpRequestParams& other) const
     {
         return Method == other.Method && Host == other.Host && Port == other.Port && Endpoint == other.Endpoint &&
-               User_agent == other.User_agent && Token == other.Token && User_pass == other.User_pass &&
-               Body == other.Body && Use_Https == other.Use_Https;
+               User_agent == other.User_agent && Verification_Mode == other.Verification_Mode && Token == other.Token &&
+               User_pass == other.User_pass && Body == other.Body && Use_Https == other.Use_Https;
     }
 } // namespace http_client

--- a/src/agent/communicator/src/http_resolver.hpp
+++ b/src/agent/communicator/src/http_resolver.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <ihttp_resolver.hpp>
 #include <logger.hpp>
 

--- a/src/agent/communicator/src/http_socket.hpp
+++ b/src/agent/communicator/src/http_socket.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "http_client_utils.hpp"
 #include <ihttp_socket.hpp>
 #include <logger.hpp>

--- a/src/agent/communicator/src/http_socket.hpp
+++ b/src/agent/communicator/src/http_socket.hpp
@@ -22,6 +22,15 @@ namespace http_client
         {
         }
 
+        /// @brief Sets the verification mode for the host
+        /// @param host The host name
+        /// @param verificationMode The verification mode to set
+        void SetVerificationMode([[maybe_unused]] const std::string& host,
+                                 [[maybe_unused]] const std::string& verificationMode) override
+        {
+            // No functionality for HTTP sockets
+        }
+
         /// @brief Connects the socket to the given endpoints
         /// @param endpoints The endpoints to connect to
         /// @param ec The error code, if any occurred

--- a/src/agent/communicator/src/https_socket.hpp
+++ b/src/agent/communicator/src/https_socket.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <https_socket_verify_utils.hpp>
 #include <ihttp_socket.hpp>
 #include <logger.hpp>

--- a/src/agent/communicator/src/https_socket_verify_utils_lin.cpp
+++ b/src/agent/communicator/src/https_socket_verify_utils_lin.cpp
@@ -1,0 +1,24 @@
+#include <boost/asio/ssl.hpp>
+#include <https_socket_verify_utils.hpp>
+
+#include <string>
+
+namespace https_socket_verify_utils
+{
+    bool VerifyCertificate(bool preverified,
+                           boost::asio::ssl::verify_context& ctx,
+                           const std::string& mode,
+                           const std::string& host)
+    {
+        if (mode == "certificate")
+        {
+            return preverified;
+        }
+        else if (mode == "full")
+        {
+            boost::asio::ssl::rfc2818_verification verifier(host);
+            return verifier(preverified, ctx);
+        }
+        return false;
+    }
+} // namespace https_socket_verify_utils

--- a/src/agent/communicator/src/https_socket_verify_utils_win.cpp
+++ b/src/agent/communicator/src/https_socket_verify_utils_win.cpp
@@ -1,0 +1,149 @@
+#include <https_socket_verify_utils.hpp>
+#include <logger.hpp>
+
+#include <boost/asio/ssl.hpp>
+#include <wincrypt.h>
+#include <windows.h>
+
+namespace https_socket_verify_utils
+{
+    bool VerifyCertificate([[maybe_unused]] bool preverified,
+                           boost::asio::ssl::verify_context& ctx,
+                           const std::string& mode,
+                           const std::string& host)
+    {
+        X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
+        if (!cert)
+        {
+            LogError("The server certificate could not be obtained.");
+            return false;
+        }
+
+        // Convert certificate to DER format
+        unsigned char* der = nullptr;
+        int derLen = i2d_X509(cert, &der);
+        if (derLen <= 0)
+        {
+            LogError("Certificate conversion to DER failed.");
+            return false;
+        }
+
+        // Create the certificate context
+        PCCERT_CONTEXT certCtx = CertCreateCertificateContext(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, der, derLen);
+        OPENSSL_free(der);
+
+        if (!certCtx)
+        {
+            LogError("The certificate context could not be created.");
+            return false;
+        }
+
+        // Open the Windows certificate store
+        HCERTSTORE hStore = CertOpenSystemStoreA(NULL, "ROOT");
+        if (!hStore)
+        {
+            LogError("The Windows certificate store could not be opened.");
+            CertFreeCertificateContext(certCtx);
+            return false;
+        }
+
+        // Create the certificate chain context
+        CERT_CHAIN_PARA chainPara = {sizeof(CERT_CHAIN_PARA)};
+        PCCERT_CHAIN_CONTEXT chainCtx = nullptr;
+
+        bool result = CertGetCertificateChain(NULL, certCtx, NULL, hStore, &chainPara, 0, NULL, &chainCtx);
+
+        if (!result || !chainCtx)
+        {
+            LogError("The certificate chain could not be verified.");
+        }
+
+        // Validate the SSL policy of the chain
+        CERT_CHAIN_POLICY_PARA policyPara = {sizeof(CERT_CHAIN_POLICY_PARA)};
+        CERT_CHAIN_POLICY_STATUS policyStatus = {sizeof(CERT_CHAIN_POLICY_STATUS)};
+        policyPara.dwFlags = 0;
+
+        if (!CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_BASE, chainCtx, &policyPara, &policyStatus))
+        {
+            LogError("Error verifying certificate chain policy.");
+            result = false;
+        }
+        else if (policyStatus.dwError != 0)
+        {
+            LogError("Certification policy error: {}", policyStatus.dwError);
+            result = false;
+        }
+
+        if (result && mode == "full")
+        {
+            // Obtain SAN from the certificate
+            STACK_OF(GENERAL_NAME)* sanNames =
+                static_cast<STACK_OF(GENERAL_NAME)*>(X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, NULL));
+            bool hostValidated = false;
+
+            if (sanNames)
+            {
+                int sanCount = sk_GENERAL_NAME_num(sanNames);
+                for (int i = 0; i < sanCount; ++i)
+                {
+                    const GENERAL_NAME* san = sk_GENERAL_NAME_value(sanNames, i);
+                    if (san->type == GEN_DNS)
+                    {
+                        const char* dnsName = reinterpret_cast<const char*>(ASN1_STRING_get0_data(san->d.dNSName));
+                        if (host == dnsName)
+                        {
+                            hostValidated = true;
+                            break;
+                        }
+                    }
+                }
+                GENERAL_NAMES_free(sanNames);
+            }
+
+            // If no SAN was found, check the CN
+            if (!hostValidated)
+            {
+                DWORD subjectSize = CertGetNameStringA(certCtx, CERT_NAME_SIMPLE_DISPLAY_TYPE, 0, NULL, NULL, 0);
+
+                if (subjectSize > 0)
+                {
+                    std::string subjectName(subjectSize, '\0');
+                    CertGetNameStringA(
+                        certCtx, CERT_NAME_SIMPLE_DISPLAY_TYPE, 0, NULL, subjectName.data(), subjectSize);
+
+                    subjectName.pop_back();
+
+                    if (host == subjectName)
+                    {
+                        hostValidated = true;
+                    }
+                    else
+                    {
+                        LogError("The host name does not match the CN of the certificate.");
+                    }
+                }
+                else
+                {
+                    LogError("The name of the subject of the certificate could not be obtained.");
+                }
+            }
+
+            if (!hostValidated)
+            {
+                LogError("The host name does not match the SAN or the CN.");
+                result = false;
+            }
+        }
+
+        // Free resources
+        if (chainCtx)
+        {
+            CertFreeCertificateChain(chainCtx);
+        }
+        CertCloseStore(hStore, 0);
+        CertFreeCertificateContext(certCtx);
+
+        return result;
+    }
+
+} // namespace https_socket_verify_utils

--- a/src/agent/communicator/src/https_socket_verify_utils_win.cpp
+++ b/src/agent/communicator/src/https_socket_verify_utils_win.cpp
@@ -12,7 +12,14 @@ namespace https_socket_verify_utils
                            const std::string& mode,
                            const std::string& host)
     {
-        X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
+        STACK_OF(X509)* certChain = X509_STORE_CTX_get_chain(ctx.native_handle());
+        if (!certChain || sk_X509_num(certChain) == 0)
+        {
+            LogError("No certificates in the chain.");
+            return false;
+        }
+
+        X509* cert = sk_X509_value(certChain, 0);
         if (!cert)
         {
             LogError("The server certificate could not be obtained.");

--- a/src/agent/communicator/tests/communicator_test.cpp
+++ b/src/agent/communicator/tests/communicator_test.cpp
@@ -100,12 +100,13 @@ TEST(CommunicatorTest, WaitForTokenExpirationAndAuthenticate_FailedAuthenticatio
         std::make_shared<communicator::Communicator>(std::move(mockHttpClient), "uuid", "key", nullptr, FUNC);
 
     // A failed authentication won't return a token
-    EXPECT_CALL(*mockHttpClientPtr, AuthenticateWithUuidAndKey(_, _, _, _))
+    EXPECT_CALL(*mockHttpClientPtr, AuthenticateWithUuidAndKey(_, _, _, _, _))
         .WillOnce(Invoke(
             [communicatorPtr]([[maybe_unused]] const std::string& host,
                               [[maybe_unused]] const std::string& userAgent,
                               [[maybe_unused]] const std::string& uuid,
-                              [[maybe_unused]] const std::string& key) -> std::optional<std::string>
+                              [[maybe_unused]] const std::string& key,
+                              [[maybe_unused]] const std::string& verificationMode) -> std::optional<std::string>
             {
                 communicatorPtr->Stop();
                 return std::nullopt;
@@ -158,12 +159,14 @@ TEST(CommunicatorTest, StatelessMessageProcessingTask_CallsWithValidToken)
         std::make_shared<communicator::Communicator>(std::move(mockHttpClient), "uuid", "key", nullptr, FUNC);
 
     const auto mockedToken = CreateToken();
-    EXPECT_CALL(*mockHttpClientPtr, AuthenticateWithUuidAndKey(_, _, _, _))
+    EXPECT_CALL(*mockHttpClientPtr, AuthenticateWithUuidAndKey(_, _, _, _, _))
         .WillOnce(Invoke(
-            [communicatorPtr, mockedToken]([[maybe_unused]] const std::string& host,
-                                           [[maybe_unused]] const std::string& userAgent,
-                                           [[maybe_unused]] const std::string& uuid,
-                                           [[maybe_unused]] const std::string& key) -> std::optional<std::string>
+            [communicatorPtr,
+             mockedToken]([[maybe_unused]] const std::string& host,
+                          [[maybe_unused]] const std::string& userAgent,
+                          [[maybe_unused]] const std::string& uuid,
+                          [[maybe_unused]] const std::string& key,
+                          [[maybe_unused]] const std::string& verificationMode) -> std::optional<std::string>
             {
                 communicatorPtr->Stop();
                 return mockedToken;

--- a/src/agent/communicator/tests/http_client_test.cpp
+++ b/src/agent/communicator/tests/http_client_test.cpp
@@ -120,8 +120,8 @@ protected:
 TEST(CreateHttpRequestTest, BasicGetRequest)
 {
     auto httpClient = http_client::HttpClient();
-    const auto reqParams =
-        http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost", "/test", "Wazuh 5.0.0");
+    const auto reqParams = http_client::HttpRequestParams(
+        boost::beast::http::verb::get, "https://localhost", "/test", "Wazuh 5.0.0", "full");
     const auto req = httpClient.CreateHttpRequest(reqParams);
 
     EXPECT_EQ(req.method(), boost::beast::http::verb::get);
@@ -137,7 +137,7 @@ TEST(CreateHttpRequestTest, PostRequestWithBody)
     auto httpClient = http_client::HttpClient();
     const std::string body = R"({"key": "value"})";
     const auto reqParams = http_client::HttpRequestParams(
-        boost::beast::http::verb::post, "https://localhost:8080", "/submit", "Wazuh 5.0.0", "", "", body);
+        boost::beast::http::verb::post, "https://localhost:8080", "/submit", "Wazuh 5.0.0", "full", "", "", body);
     const auto req = httpClient.CreateHttpRequest(reqParams);
 
     EXPECT_EQ(req.method(), boost::beast::http::verb::post);
@@ -154,8 +154,8 @@ TEST(CreateHttpRequestTest, AuthorizationBearerToken)
 {
     auto httpClient = http_client::HttpClient();
     const std::string token = "dummy_token";
-    const auto reqParams =
-        http_client::HttpRequestParams(boost::beast::http::verb::get, "localhost", "/secure", "Wazuh 5.0.0", token);
+    const auto reqParams = http_client::HttpRequestParams(
+        boost::beast::http::verb::get, "localhost", "/secure", "Wazuh 5.0.0", "full", token);
     const auto req = httpClient.CreateHttpRequest(reqParams);
 
     EXPECT_EQ(req[boost::beast::http::field::user_agent], "Wazuh 5.0.0");
@@ -167,7 +167,7 @@ TEST(CreateHttpRequestTest, AuthorizationBasic)
     auto httpClient = http_client::HttpClient();
     const std::string user_pass = "username:password";
     const auto reqParams = http_client::HttpRequestParams(
-        boost::beast::http::verb::get, "https://localhost:8080", "/secure", "Wazuh 5.0.0", "", user_pass);
+        boost::beast::http::verb::get, "https://localhost:8080", "/secure", "Wazuh 5.0.0", "full", "", user_pass);
     const auto req = httpClient.CreateHttpRequest(reqParams);
 
     EXPECT_EQ(req[boost::beast::http::field::user_agent], "Wazuh 5.0.0");
@@ -185,7 +185,7 @@ TEST_F(HttpClientTest, PerformHttpRequest_Success)
     EXPECT_CALL(*mockSocket, Read(_, _)).WillOnce([](auto& res, auto&) { res.result(boost::beast::http::status::ok); });
 
     const http_client::HttpRequestParams params(
-        boost::beast::http::verb::get, "https://localhost:80", "/", "Wazuh 5.0.0");
+        boost::beast::http::verb::get, "https://localhost:80", "/", "Wazuh 5.0.0", "full");
     const auto response = client->PerformHttpRequest(params);
 
     EXPECT_EQ(response.result(), boost::beast::http::status::ok);
@@ -198,7 +198,7 @@ TEST_F(HttpClientTest, PerformHttpRequest_ExceptionThrown)
     EXPECT_CALL(*mockResolver, Resolve(_, _)).WillOnce(Throw(std::runtime_error("Simulated resolution failure")));
 
     const http_client::HttpRequestParams params(
-        boost::beast::http::verb::get, "https://localhost:80", "/", "Wazuh 5.0.0");
+        boost::beast::http::verb::get, "https://localhost:80", "/", "Wazuh 5.0.0", "full");
     const auto response = client->PerformHttpRequest(params);
 
     EXPECT_EQ(response.result(), boost::beast::http::status::internal_server_error);
@@ -240,8 +240,8 @@ TEST_P(HttpClientTest, Co_PerformHttpRequest_Success)
         return std::exchange(loopCondition, false);
     };
 
-    const auto reqParams =
-        http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0");
+    const auto reqParams = http_client::HttpRequestParams(
+        boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0", "full");
 
     auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
                                               reqParams,
@@ -294,8 +294,8 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_CallbacksNotCalledIfCannotConnect)
         unauthorizedCalled = true;
     };
 
-    const auto reqParams =
-        http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0");
+    const auto reqParams = http_client::HttpRequestParams(
+        boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0", "full");
     auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
                                               reqParams,
                                               getMessages,
@@ -347,8 +347,8 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncWriteFails
         return std::exchange(loopCondition, false);
     };
 
-    const auto reqParams =
-        http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0");
+    const auto reqParams = http_client::HttpRequestParams(
+        boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0", "full");
     auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
                                               reqParams,
                                               getMessages,
@@ -402,8 +402,8 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_OnSuccessNotCalledIfAsyncReadFails)
         return std::exchange(loopCondition, false);
     };
 
-    const auto reqParams =
-        http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0");
+    const auto reqParams = http_client::HttpRequestParams(
+        boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0", "full");
     auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
                                               reqParams,
                                               getMessages,
@@ -456,8 +456,8 @@ TEST_F(HttpClientTest, Co_PerformHttpRequest_UnauthorizedCalledWhenAuthorization
         return std::exchange(loopCondition, false);
     };
 
-    const auto reqParams =
-        http_client::HttpRequestParams(boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0");
+    const auto reqParams = http_client::HttpRequestParams(
+        boost::beast::http::verb::get, "https://localhost:8080", "/", "Wazuh 5.0.0", "full");
     auto task = client->Co_PerformHttpRequest(std::make_shared<std::string>("token"),
                                               reqParams,
                                               getMessages,
@@ -493,7 +493,7 @@ TEST_F(HttpClientTest, AuthenticateWithUuidAndKey_Success)
             });
 
     const auto token =
-        client->AuthenticateWithUuidAndKey("https://localhost:8080", "Wazuh 5.0.0", "test-uuid", "test-key");
+        client->AuthenticateWithUuidAndKey("https://localhost:8080", "Wazuh 5.0.0", "test-uuid", "test-key", "full");
 
     ASSERT_TRUE(token.has_value());
 
@@ -518,7 +518,7 @@ TEST_F(HttpClientTest, AuthenticateWithUuidAndKey_Failure)
             });
 
     const auto token =
-        client->AuthenticateWithUuidAndKey("https://localhost:8080", "Wazuh 5.0.0", "test-uuid", "test-key");
+        client->AuthenticateWithUuidAndKey("https://localhost:8080", "Wazuh 5.0.0", "test-uuid", "test-key", "full");
 
     EXPECT_FALSE(token.has_value());
 }
@@ -539,8 +539,9 @@ TEST_F(HttpClientTest, AuthenticateWithUuidAndKey_FailureThrowsException)
                 boost::beast::ostream(res.body()) << R"({"message":"Invalid key"})";
             });
 
-    EXPECT_THROW(client->AuthenticateWithUuidAndKey("https://localhost:8080", "Wazuh 5.0.0", "test-uuid", "test-key"),
-                 std::runtime_error);
+    EXPECT_THROW(
+        client->AuthenticateWithUuidAndKey("https://localhost:8080", "Wazuh 5.0.0", "test-uuid", "test-key", "full"),
+        std::runtime_error);
 }
 
 TEST_F(HttpClientTest, AuthenticateWithUserPassword_Success)
@@ -560,7 +561,7 @@ TEST_F(HttpClientTest, AuthenticateWithUserPassword_Success)
             });
 
     const auto token =
-        client->AuthenticateWithUserPassword("https://localhost:8080", "Wazuh 5.0.0", "user", "password");
+        client->AuthenticateWithUserPassword("https://localhost:8080", "Wazuh 5.0.0", "user", "password", "full");
 
     ASSERT_TRUE(token.has_value());
 
@@ -580,7 +581,7 @@ TEST_F(HttpClientTest, AuthenticateWithUserPassword_Failure)
         .WillOnce([](auto& res, auto&) { res.result(boost::beast::http::status::unauthorized); });
 
     const auto token =
-        client->AuthenticateWithUserPassword("https://localhost:8080", "Wazuh 5.0.0", "user", "password");
+        client->AuthenticateWithUserPassword("https://localhost:8080", "Wazuh 5.0.0", "user", "password", "full");
 
     EXPECT_FALSE(token.has_value());
 }
@@ -598,7 +599,7 @@ TEST_F(HttpClientTest, PerformHttpRequestDownload_Success)
                      [[maybe_unused]] auto& dstFilePath) { res.result(boost::beast::http::status::ok); });
 
     const http_client::HttpRequestParams params(
-        boost::beast::http::verb::get, "https://localhost:80", "/", "Wazuh 5.0.0");
+        boost::beast::http::verb::get, "https://localhost:80", "/", "Wazuh 5.0.0", "full");
     const std::string dstFilePath = "dstFilePath";
     const auto response = client->PerformHttpRequestDownload(params, dstFilePath);
 
@@ -612,7 +613,7 @@ TEST_F(HttpClientTest, PerformHttpRequestDownload_ExceptionThrown)
     EXPECT_CALL(*mockResolver, Resolve(_, _)).WillOnce(Throw(std::runtime_error("Simulated resolution failure")));
 
     const http_client::HttpRequestParams params(
-        boost::beast::http::verb::get, "https://localhost:80", "/", "Wazuh 5.0.0");
+        boost::beast::http::verb::get, "https://localhost:80", "/", "Wazuh 5.0.0", "full");
     const std::string dstFilePath = "dstFilePath";
     const auto response = client->PerformHttpRequestDownload(params, dstFilePath);
 

--- a/src/agent/communicator/tests/mocks/mock_http_client.hpp
+++ b/src/agent/communicator/tests/mocks/mock_http_client.hpp
@@ -29,17 +29,23 @@ public:
                 (const http_client::HttpRequestParams& params),
                 (override));
 
-    MOCK_METHOD(
-        std::optional<std::string>,
-        AuthenticateWithUuidAndKey,
-        (const std::string& host, const std::string& userAgent, const std::string& uuid, const std::string& key),
-        (override));
+    MOCK_METHOD(std::optional<std::string>,
+                AuthenticateWithUuidAndKey,
+                (const std::string& host,
+                 const std::string& userAgent,
+                 const std::string& uuid,
+                 const std::string& key,
+                 const std::string& verificationMode),
+                (override));
 
-    MOCK_METHOD(
-        std::optional<std::string>,
-        AuthenticateWithUserPassword,
-        (const std::string& host, const std::string& userAgent, const std::string& user, const std::string& password),
-        (override));
+    MOCK_METHOD(std::optional<std::string>,
+                AuthenticateWithUserPassword,
+                (const std::string& host,
+                 const std::string& userAgent,
+                 const std::string& user,
+                 const std::string& password,
+                 const std::string& verificationMode),
+                (override));
 
     MOCK_METHOD(boost::beast::http::response<boost::beast::http::dynamic_body>,
                 PerformHttpRequestDownload,

--- a/src/agent/communicator/tests/mocks/mock_http_socket.hpp
+++ b/src/agent/communicator/tests/mocks/mock_http_socket.hpp
@@ -5,6 +5,7 @@
 class MockHttpSocket : public http_client::IHttpSocket
 {
 public:
+    MOCK_METHOD(void, SetVerificationMode, (const std::string& host, const std::string& verificationMode), (override));
     MOCK_METHOD(void,
                 Connect,
                 (const boost::asio::ip::tcp::resolver::results_type& endpoints, boost::system::error_code& code),

--- a/src/agent/include/agent_registration.hpp
+++ b/src/agent/include/agent_registration.hpp
@@ -43,8 +43,9 @@ namespace agent_registration
         /// @brief Registers the agent with the manager.
         ///
         /// @param httpClient The HTTP client to use for registration.
+        /// @param verificationMode The verification mode to use for registration.
         /// @return True if the registration was successful, false otherwise.
-        bool Register(http_client::IHttpClient& httpClient);
+        bool Register(http_client::IHttpClient& httpClient, const std::string& verificationMode);
 
     private:
         /// @brief The system's information.

--- a/src/agent/include/agent_registration.hpp
+++ b/src/agent/include/agent_registration.hpp
@@ -33,19 +33,20 @@ namespace agent_registration
         /// @param key The agent's key.
         /// @param name The agent's name.
         /// @param dbFolderPath The path to the database folder.
+        /// @param verificationMode The connection verification mode.
         AgentRegistration(std::string url,
                           std::string user,
                           std::string password,
                           const std::string& key,
                           const std::string& name,
-                          const std::string& dbFolderPath);
+                          const std::string& dbFolderPath,
+                          std::string verificationMode);
 
         /// @brief Registers the agent with the manager.
         ///
         /// @param httpClient The HTTP client to use for registration.
-        /// @param verificationMode The verification mode to use for registration.
         /// @return True if the registration was successful, false otherwise.
-        bool Register(http_client::IHttpClient& httpClient, const std::string& verificationMode);
+        bool Register(http_client::IHttpClient& httpClient);
 
     private:
         /// @brief The system's information.
@@ -62,5 +63,8 @@ namespace agent_registration
 
         /// @brief The user's password.
         std::string m_password;
+
+        /// @brief The connection verification mode.
+        std::string m_verificationMode;
     };
 } // namespace agent_registration

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -35,8 +35,8 @@ namespace agent_registration
 
     bool AgentRegistration::Register(http_client::IHttpClient& httpClient, const std::string& verificationMode)
     {
-        const auto token =
-            httpClient.AuthenticateWithUserPassword(m_serverUrl, m_agentInfo.GetHeaderInfo(), m_user, m_password, verificationMode);
+        const auto token = httpClient.AuthenticateWithUserPassword(
+            m_serverUrl, m_agentInfo.GetHeaderInfo(), m_user, m_password, verificationMode);
 
         if (!token.has_value())
         {

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -15,12 +15,14 @@ namespace agent_registration
                                          std::string password,
                                          const std::string& key,
                                          const std::string& name,
-                                         const std::string& dbFolderPath)
+                                         const std::string& dbFolderPath,
+                                         std::string verificationMode)
         : m_agentInfo(
               dbFolderPath, [this]() { return m_sysInfo.os(); }, [this]() { return m_sysInfo.networks(); })
         , m_serverUrl(std::move(url))
         , m_user(std::move(user))
         , m_password(std::move(password))
+        , m_verificationMode(std::move(verificationMode))
     {
         if (!m_agentInfo.SetKey(key))
         {
@@ -33,10 +35,10 @@ namespace agent_registration
         }
     }
 
-    bool AgentRegistration::Register(http_client::IHttpClient& httpClient, const std::string& verificationMode)
+    bool AgentRegistration::Register(http_client::IHttpClient& httpClient)
     {
         const auto token = httpClient.AuthenticateWithUserPassword(
-            m_serverUrl, m_agentInfo.GetHeaderInfo(), m_user, m_password, verificationMode);
+            m_serverUrl, m_agentInfo.GetHeaderInfo(), m_user, m_password, m_verificationMode);
 
         if (!token.has_value())
         {
@@ -48,7 +50,7 @@ namespace agent_registration
                                                               m_serverUrl,
                                                               "/agents",
                                                               m_agentInfo.GetHeaderInfo(),
-                                                              verificationMode,
+                                                              m_verificationMode,
                                                               token.value(),
                                                               "",
                                                               m_agentInfo.GetMetadataInfo(true));

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -33,10 +33,10 @@ namespace agent_registration
         }
     }
 
-    bool AgentRegistration::Register(http_client::IHttpClient& httpClient)
+    bool AgentRegistration::Register(http_client::IHttpClient& httpClient, const std::string& verificationMode)
     {
         const auto token =
-            httpClient.AuthenticateWithUserPassword(m_serverUrl, m_agentInfo.GetHeaderInfo(), m_user, m_password);
+            httpClient.AuthenticateWithUserPassword(m_serverUrl, m_agentInfo.GetHeaderInfo(), m_user, m_password, verificationMode);
 
         if (!token.has_value())
         {
@@ -48,6 +48,7 @@ namespace agent_registration
                                                               m_serverUrl,
                                                               "/agents",
                                                               m_agentInfo.GetHeaderInfo(),
+                                                              verificationMode,
                                                               token.value(),
                                                               "",
                                                               m_agentInfo.GetMetadataInfo(true));

--- a/src/agent/src/main.cpp
+++ b/src/agent/src/main.cpp
@@ -19,6 +19,7 @@ static const auto OPT_USER {"user"};
 static const auto OPT_PASS {"password"};
 static const auto OPT_KEY {"key"};
 static const auto OPT_NAME {"name"};
+static const auto OPT_VERIFICATION_MODE {"verification-mode"};
 #ifdef _WIN32
 static const auto OPT_INSTALL_SERVICE {"install-service"};
 static const auto OPT_REMOVE_SERVICE {"remove-service"};
@@ -41,7 +42,10 @@ int main(int argc, char* argv[])
             OPT_USER, program_options::value<std::string>(), "User to authenticate with the server management API")(
             OPT_PASS, program_options::value<std::string>(), "Password to authenticate with the server management API")(
             OPT_KEY, program_options::value<std::string>(), "Key to register the agent (optional)")(
-            OPT_NAME, program_options::value<std::string>(), "Name to register the agent (optional)");
+            OPT_NAME, program_options::value<std::string>(), "Name to register the agent (optional)")(
+            OPT_VERIFICATION_MODE,
+            program_options::value<std::string>(),
+            "Verification mode to be applied on HTTPS connection to the server (optional)");
 
 #ifdef _WIN32
         cmdParser.add_options()(OPT_INSTALL_SERVICE, "Use this option to install Wazuh as a Windows service")(
@@ -55,12 +59,14 @@ int main(int argc, char* argv[])
 
         if (validOptions.count(OPT_REGISTER_AGENT) > 0)
         {
-            RegisterAgent(validOptions.count(OPT_URL) ? validOptions[OPT_URL].as<std::string>() : "",
-                          validOptions.count(OPT_USER) ? validOptions[OPT_USER].as<std::string>() : "",
-                          validOptions.count(OPT_PASS) ? validOptions[OPT_PASS].as<std::string>() : "",
-                          validOptions.count(OPT_KEY) ? validOptions[OPT_KEY].as<std::string>() : "",
-                          validOptions.count(OPT_NAME) ? validOptions[OPT_NAME].as<std::string>() : "",
-                          validOptions.count(OPT_CONFIG_FILE) ? validOptions[OPT_CONFIG_FILE].as<std::string>() : "");
+            RegisterAgent(
+                validOptions.count(OPT_URL) ? validOptions[OPT_URL].as<std::string>() : "",
+                validOptions.count(OPT_USER) ? validOptions[OPT_USER].as<std::string>() : "",
+                validOptions.count(OPT_PASS) ? validOptions[OPT_PASS].as<std::string>() : "",
+                validOptions.count(OPT_KEY) ? validOptions[OPT_KEY].as<std::string>() : "",
+                validOptions.count(OPT_NAME) ? validOptions[OPT_NAME].as<std::string>() : "",
+                validOptions.count(OPT_CONFIG_FILE) ? validOptions[OPT_CONFIG_FILE].as<std::string>() : "",
+                validOptions.count(OPT_VERIFICATION_MODE) ? validOptions[OPT_VERIFICATION_MODE].as<std::string>() : "");
         }
         else if (validOptions.count(OPT_STATUS) > 0)
         {

--- a/src/agent/src/process_options.cpp
+++ b/src/agent/src/process_options.cpp
@@ -43,7 +43,7 @@ void RegisterAgent(const std::string& url,
             agent_registration::AgentRegistration reg(url, user, password, key, name, dbFolderPath);
 
             http_client::HttpClient httpClient;
-            if (reg.Register(httpClient))
+            if (reg.Register(httpClient, verificationMode))
             {
                 std::cout << "wazuh-agent registered\n";
             }

--- a/src/agent/src/process_options.cpp
+++ b/src/agent/src/process_options.cpp
@@ -28,10 +28,10 @@ void RegisterAgent(const std::string& url,
         {
             std::cout << "Starting wazuh-agent registration\n";
 
-            agent_registration::AgentRegistration reg(url, user, password, key, name, dbFolderPath);
+            agent_registration::AgentRegistration reg(url, user, password, key, name, dbFolderPath, verificationMode);
 
             http_client::HttpClient httpClient;
-            if (reg.Register(httpClient, verificationMode))
+            if (reg.Register(httpClient))
             {
                 std::cout << "wazuh-agent registered\n";
             }

--- a/src/agent/src/process_options.cpp
+++ b/src/agent/src/process_options.cpp
@@ -13,7 +13,8 @@ void RegisterAgent(const std::string& url,
                    const std::string& password,
                    const std::string& key,
                    const std::string& name,
-                   const std::string& configFilePath)
+                   const std::string& configFilePath,
+                   const std::string& verificationMode)
 {
     auto configurationParser = configFilePath.empty()
                                    ? configuration::ConfigurationParser()
@@ -21,24 +22,11 @@ void RegisterAgent(const std::string& url,
     auto dbFolderPath =
         configurationParser.GetConfig<std::string>("agent", "path.data").value_or(config::DEFAULT_DATA_PATH);
 
-    auto verificationMode = configurationParser.GetConfig<std::string>("agent", "verification_mode")
-                                .value_or(config::agent::DEFAULT_VERIFICATION_MODE);
-
     if (!url.empty() && !user.empty() && !password.empty())
     {
         try
         {
             std::cout << "Starting wazuh-agent registration\n";
-
-            if (std::find(std::begin(config::agent::VALID_VERIFICATION_MODES),
-                          std::end(config::agent::VALID_VERIFICATION_MODES),
-                          verificationMode) == std::end(config::agent::VALID_VERIFICATION_MODES))
-            {
-                LogWarn("Incorrect value for 'verification_mode', in case of HTTPS connections the default value '{}' "
-                        "is used.",
-                        config::agent::DEFAULT_VERIFICATION_MODE);
-                verificationMode = config::agent::DEFAULT_VERIFICATION_MODE;
-            }
 
             agent_registration::AgentRegistration reg(url, user, password, key, name, dbFolderPath);
 

--- a/src/agent/src/process_options.cpp
+++ b/src/agent/src/process_options.cpp
@@ -21,11 +21,24 @@ void RegisterAgent(const std::string& url,
     auto dbFolderPath =
         configurationParser.GetConfig<std::string>("agent", "path.data").value_or(config::DEFAULT_DATA_PATH);
 
+    auto verificationMode = configurationParser.GetConfig<std::string>("agent", "verification_mode")
+                                .value_or(config::agent::DEFAULT_VERIFICATION_MODE);
+
     if (!url.empty() && !user.empty() && !password.empty())
     {
         try
         {
             std::cout << "Starting wazuh-agent registration\n";
+
+            if (std::find(std::begin(config::agent::VALID_VERIFICATION_MODES),
+                          std::end(config::agent::VALID_VERIFICATION_MODES),
+                          verificationMode) == std::end(config::agent::VALID_VERIFICATION_MODES))
+            {
+                LogWarn("Incorrect value for 'verification_mode', in case of HTTPS connections the default value '{}' "
+                        "is used.",
+                        config::agent::DEFAULT_VERIFICATION_MODE);
+                verificationMode = config::agent::DEFAULT_VERIFICATION_MODE;
+            }
 
             agent_registration::AgentRegistration reg(url, user, password, key, name, dbFolderPath);
 

--- a/src/agent/src/process_options.hpp
+++ b/src/agent/src/process_options.hpp
@@ -10,12 +10,14 @@
 /// @param key The key to use for registration.
 /// @param name The name to use for the agent.
 /// @param configFilePath The path to the configuration file.
+/// @param verificationMode The verification mode to use.
 void RegisterAgent(const std::string& url,
                    const std::string& user,
                    const std::string& password,
                    const std::string& key,
                    const std::string& name,
-                   const std::string& configFilePath);
+                   const std::string& configFilePath,
+                   const std::string& verificationMode);
 
 /// @brief Starts the agent using the specified configuration file.
 /// @param configFilePath The file path to the configuration file used for starting the agent.

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -40,7 +40,7 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
     agent->Save();
 
     registration = std::make_unique<agent_registration::AgentRegistration>(
-        "https://localhost:55000", "user", "password", agent->GetKey(), agent->GetName(), ".");
+        "https://localhost:55000", "user", "password", agent->GetKey(), agent->GetName(), ".", "full");
 
     MockHttpClient mockHttpClient;
 
@@ -65,7 +65,7 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
     EXPECT_CALL(mockHttpClient, PerformHttpRequest(testing::Eq(reqParams))).WillOnce(testing::Return(expectedResponse));
 
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    const bool res = registration->Register(mockHttpClient, "full");
+    const bool res = registration->Register(mockHttpClient);
     ASSERT_TRUE(res);
 }
 
@@ -74,8 +74,13 @@ TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
     AgentInfoPersistance agentInfoPersistance(".");
     agentInfoPersistance.ResetToDefault();
 
-    registration = std::make_unique<agent_registration::AgentRegistration>(
-        "https://localhost:55000", "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name", ".");
+    registration = std::make_unique<agent_registration::AgentRegistration>("https://localhost:55000",
+                                                                           "user",
+                                                                           "password",
+                                                                           "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj",
+                                                                           "agent_name",
+                                                                           ".",
+                                                                           "certificate");
     agent = std::make_unique<AgentInfo>(".");
 
     MockHttpClient mockHttpClient;
@@ -84,7 +89,7 @@ TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
         .WillOnce(testing::Return(std::nullopt));
 
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    const bool res = registration->Register(mockHttpClient, "full");
+    const bool res = registration->Register(mockHttpClient);
     ASSERT_FALSE(res);
 }
 
@@ -94,7 +99,7 @@ TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
     agentInfoPersistance.ResetToDefault();
 
     registration = std::make_unique<agent_registration::AgentRegistration>(
-        "https://localhost:55000", "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name", ".");
+        "https://localhost:55000", "user", "password", "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj", "agent_name", ".", "none");
     agent = std::make_unique<AgentInfo>(".");
 
     MockHttpClient mockHttpClient;
@@ -108,7 +113,7 @@ TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
     EXPECT_CALL(mockHttpClient, PerformHttpRequest(testing::_)).WillOnce(testing::Return(expectedResponse));
 
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    const bool res = registration->Register(mockHttpClient, "full");
+    const bool res = registration->Register(mockHttpClient);
     ASSERT_FALSE(res);
 }
 
@@ -121,7 +126,7 @@ TEST_F(RegisterTest, RegisteringWithoutAKeyGeneratesOneAutomatically)
     EXPECT_TRUE(agent->GetKey().empty());
 
     registration = std::make_unique<agent_registration::AgentRegistration>(
-        "https://localhost:55000", "user", "password", "", "agent_name", ".");
+        "https://localhost:55000", "user", "password", "", "agent_name", ".", "full");
 
     MockHttpClient mockHttpClient;
 
@@ -135,7 +140,7 @@ TEST_F(RegisterTest, RegisteringWithoutAKeyGeneratesOneAutomatically)
     EXPECT_CALL(mockHttpClient, PerformHttpRequest(testing::_)).WillOnce(testing::Return(expectedResponse));
 
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    const bool res = registration->Register(mockHttpClient, "full");
+    const bool res = registration->Register(mockHttpClient);
     ASSERT_TRUE(res);
 
     agent = std::make_unique<AgentInfo>(".");
@@ -145,7 +150,7 @@ TEST_F(RegisterTest, RegisteringWithoutAKeyGeneratesOneAutomatically)
 TEST_F(RegisterTest, RegistrationTestFailWithBadKey)
 {
     ASSERT_THROW(agent_registration::AgentRegistration(
-                     "https://localhost:55000", "user", "password", "badKey", "agent_name", "."),
+                     "https://localhost:55000", "user", "password", "badKey", "agent_name", ".", "full"),
                  std::invalid_argument);
 }
 

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -44,7 +44,8 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
 
     MockHttpClient mockHttpClient;
 
-    EXPECT_CALL(mockHttpClient, AuthenticateWithUserPassword(testing::_, testing::_, testing::_, testing::_))
+    EXPECT_CALL(mockHttpClient,
+                AuthenticateWithUserPassword(testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Return("token"));
 
     const auto bodyJson = agent->GetMetadataInfo(true);
@@ -53,6 +54,7 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
                                              "https://localhost:55000",
                                              "/agents",
                                              agent->GetHeaderInfo(),
+                                             "full",
                                              "token",
                                              "",
                                              bodyJson);
@@ -63,7 +65,7 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
     EXPECT_CALL(mockHttpClient, PerformHttpRequest(testing::Eq(reqParams))).WillOnce(testing::Return(expectedResponse));
 
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    const bool res = registration->Register(mockHttpClient);
+    const bool res = registration->Register(mockHttpClient, "full");
     ASSERT_TRUE(res);
 }
 
@@ -78,11 +80,11 @@ TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
 
     MockHttpClient mockHttpClient;
 
-    EXPECT_CALL(mockHttpClient, AuthenticateWithUserPassword(testing::_, testing::_, "user", "password"))
+    EXPECT_CALL(mockHttpClient, AuthenticateWithUserPassword(testing::_, testing::_, "user", "password", testing::_))
         .WillOnce(testing::Return(std::nullopt));
 
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    const bool res = registration->Register(mockHttpClient);
+    const bool res = registration->Register(mockHttpClient, "full");
     ASSERT_FALSE(res);
 }
 
@@ -97,7 +99,7 @@ TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
 
     MockHttpClient mockHttpClient;
 
-    EXPECT_CALL(mockHttpClient, AuthenticateWithUserPassword(testing::_, testing::_, "user", "password"))
+    EXPECT_CALL(mockHttpClient, AuthenticateWithUserPassword(testing::_, testing::_, "user", "password", testing::_))
         .WillOnce(testing::Return("token"));
 
     boost::beast::http::response<boost::beast::http::dynamic_body> expectedResponse;
@@ -106,7 +108,7 @@ TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
     EXPECT_CALL(mockHttpClient, PerformHttpRequest(testing::_)).WillOnce(testing::Return(expectedResponse));
 
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    const bool res = registration->Register(mockHttpClient);
+    const bool res = registration->Register(mockHttpClient, "full");
     ASSERT_FALSE(res);
 }
 
@@ -123,7 +125,8 @@ TEST_F(RegisterTest, RegisteringWithoutAKeyGeneratesOneAutomatically)
 
     MockHttpClient mockHttpClient;
 
-    EXPECT_CALL(mockHttpClient, AuthenticateWithUserPassword(testing::_, testing::_, testing::_, testing::_))
+    EXPECT_CALL(mockHttpClient,
+                AuthenticateWithUserPassword(testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Return("token"));
 
     boost::beast::http::response<boost::beast::http::dynamic_body> expectedResponse;
@@ -132,7 +135,7 @@ TEST_F(RegisterTest, RegisteringWithoutAKeyGeneratesOneAutomatically)
     EXPECT_CALL(mockHttpClient, PerformHttpRequest(testing::_)).WillOnce(testing::Return(expectedResponse));
 
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    const bool res = registration->Register(mockHttpClient);
+    const bool res = registration->Register(mockHttpClient, "full");
     ASSERT_TRUE(res);
 
     agent = std::make_unique<AgentInfo>(".");

--- a/src/cmake/config.cmake
+++ b/src/cmake/config.cmake
@@ -24,6 +24,8 @@ set(DEFAULT_BATCH_INTERVAL 10000 CACHE STRING "Default Agent batch interval (10s
 
 set(DEFAULT_BATCH_SIZE 1000ULL CACHE STRING "Default Agent batch size limit (1000)")
 
+set(DEFAULT_VERIFICATION_MODE "full" CACHE STRING "Default Agent verification mode")
+
 set(DEFAULT_LOGCOLLECTOR_ENABLED true CACHE BOOL "Default Logcollector enabled")
 
 set(BUFFER_SIZE 4096 CACHE STRING "Default Logcollector reading buffer size")

--- a/src/common/config/include/config.h.in
+++ b/src/common/config/include/config.h.in
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 namespace config
 {
     constexpr auto PROJECT_NAME = "@PROJECT_NAME@";
@@ -19,6 +21,8 @@ namespace config
         constexpr auto DEFAULT_BATCH_SIZE = @DEFAULT_BATCH_SIZE@;
         constexpr auto QUEUE_STATUS_REFRESH_TIMER = @QUEUE_STATUS_REFRESH_TIMER@;
         constexpr auto QUEUE_DEFAULT_SIZE = @QUEUE_DEFAULT_SIZE@;
+        constexpr auto DEFAULT_VERIFICATION_MODE = "@DEFAULT_VERIFICATION_MODE@";
+        constexpr std::array<const char*, 3> VALID_VERIFICATION_MODES = {"full", "certificate", "none"};
     }
 
     namespace logcollector


### PR DESCRIPTION
|Related issue|
|---|
|#389|

## Description

This PR adds server certificate validation in the Windows and Linux agent.

Note: verification for macOS agent will be added in a separate PR.

For server connections when the agent is already registered, a new configuration option is added to control which mode will be used:
```
agent:
  verification_mode: full
```

Possible Values:

- full (default):
  - Validates that the server certificate is signed by a trusted CA.
  - Ensures the server hostname matches the certificate's SAN or CN.
- certificate:
  - Validates that the server certificate is signed by a trusted CA.
  - Does not validate the server hostname.
- none:
  - Disables all certificate validation.
  - No checks are performed on the certificate's CA signature or the server hostname.
  - Note: This mode disables critical SSL/TLS security features and is not recommended for production environments.

To perform the registration of the agent, a new option was added to the CLI “--verification-mode”, the values that can take are the same as for the previous case:

`wazuh-agent --register-agent --user user --password pass --url https://serverIP:55000 --verification-mode certificate`


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
