### PR TITLE
Fix logcollector stop

### DIFF
--- a/src/agent/task_manager/include/task_manager.hpp
+++ b/src/agent/task_manager/include/task_manager.hpp
@@ -53,7 +53,7 @@ private:
     std::vector<std::thread> m_threads;
 
     /// @brief Number of enqueued threads
-    size_t m_numEnqueuedThreads = 0;
+    std::atomic<size_t> m_numEnqueuedThreads = 0;
 
     /// @brief Mutex to control Start and Stop operations
     mutable std::mutex m_mutex;

--- a/src/agent/task_manager/src/task_manager.cpp
+++ b/src/agent/task_manager/src/task_manager.cpp
@@ -56,6 +56,7 @@ void TaskManager::Stop()
             }
         }
         m_threads.clear();
+        m_numEnqueuedThreads = 0;
     }
 
     m_ioContext.reset();
@@ -113,6 +114,5 @@ void TaskManager::EnqueueTask(boost::asio::awaitable<void> task, const std::stri
 
 size_t TaskManager::GetNumEnqueuedThreads() const
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
     return m_numEnqueuedThreads;
 }

--- a/src/cmake/config.cmake
+++ b/src/cmake/config.cmake
@@ -22,7 +22,7 @@ set(DEFAULT_RETRY_INTERVAL 30000 CACHE STRING "Default Agent retry interval (30s
 
 set(DEFAULT_BATCH_INTERVAL 10000 CACHE STRING "Default Agent batch interval (10s)")
 
-set(DEFAULT_BATCH_SIZE 1000ULL CACHE STRING "Default Agent batch size limit (1000)")
+set(DEFAULT_BATCH_SIZE 1000000ULL CACHE STRING "Default Agent batch size limit (1MB)")
 
 set(DEFAULT_LOGCOLLECTOR_ENABLED true CACHE BOOL "Default Logcollector enabled")
 

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -33,8 +33,7 @@ void Inventory::Start() {
         LogErrorInventory(ex.what());
     }
 
-    LogInfo("Inventory module finished.");
-
+    LogInfo("Inventory module stopped.");
 }
 
 void Inventory::Setup(std::shared_ptr<const configuration::ConfigurationParser> configurationParser) {
@@ -59,7 +58,7 @@ void Inventory::Setup(std::shared_ptr<const configuration::ConfigurationParser> 
 }
 
 void Inventory::Stop() {
-    LogInfo("Inventory module stopped.");
+    LogInfo("Inventory module stopping...");
     Inventory::Instance().Destroy();
 }
 

--- a/src/modules/logcollector/include/logcollector.hpp
+++ b/src/modules/logcollector/include/logcollector.hpp
@@ -4,6 +4,7 @@
 #include <list>
 
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/steady_timer.hpp>
 
 #include <moduleWrapper.hpp>
 #include <multitype_queue.hpp>
@@ -102,6 +103,12 @@ private:
 
     /// @brief Indicates if number of logs being monitorized
     std::atomic<int> m_activeReaders = 0;
+
+    /// @brief Mutex to access steady timers list
+    std::mutex m_timersMutex;
+
+    /// @brief List of steady timers
+    std::list<boost::asio::steady_timer*> m_timers;
 };
 
 }

--- a/src/modules/logcollector/include/logcollector.hpp
+++ b/src/modules/logcollector/include/logcollector.hpp
@@ -81,6 +81,9 @@ protected:
     /// @param configurationParser Configuration parser
     void SetupFileReader(const std::shared_ptr<const configuration::ConfigurationParser> configurationParser);
 
+    /// @brief Clean all readers
+    void CleanAllReaders();
+
 private:
     /// @brief Module name
     const std::string m_moduleName = "logcollector";
@@ -96,6 +99,9 @@ private:
 
     /// @brief List of readers
     std::list<std::shared_ptr<IReader>> m_readers;
+
+    /// @brief Indicates if number of logs being monitorized
+    std::atomic<int> m_activeReaders = 0;
 };
 
 }

--- a/src/modules/logcollector/src/file_reader.hpp
+++ b/src/modules/logcollector/src/file_reader.hpp
@@ -78,6 +78,9 @@ public:
     /// @return Awaitable result
     Awaitable Run();
 
+    /// @brief Stops the file reader
+    void Stop();
+
     /// @brief Reloads the file list
     ///
     /// Expands wildcards in the file pattern. Adds the new files to the list,

--- a/src/modules/logcollector/src/reader.hpp
+++ b/src/modules/logcollector/src/reader.hpp
@@ -21,7 +21,13 @@ public:
     /// @return Awaitable result
     virtual Awaitable Run() = 0;
 
+    /// @brief Stops the log reader
+    virtual void Stop() = 0;
+
 protected:
+    /// @brief Indicates if the log reader should keep running
+    std::atomic<bool> m_keepRunning = true;
+
     /// @brief Logcollector instance
     Logcollector& m_logcollector;
 };

--- a/src/modules/src/moduleManager.cpp
+++ b/src/modules/src/moduleManager.cpp
@@ -9,6 +9,10 @@
 using logcollector::Logcollector;
 #endif
 
+namespace {
+    constexpr int MODULES_START_WAIT_SECS = 60;
+}
+
 void ModuleManager::AddModules() {
 
 #ifdef ENABLE_INVENTORY
@@ -53,13 +57,19 @@ void ModuleManager::Start()
         );
     }
 
-    cv.wait(
+    cv.wait_for(
         lock,
+        std::chrono::seconds(MODULES_START_WAIT_SECS),
         [this]
         {
             return m_started.load() == static_cast<int>(m_modules.size());
         }
     );
+
+    if (m_started.load() != static_cast<int>(m_modules.size()))
+    {
+        LogError("Error when starting some modules. Modules started: {}", m_started.load());
+    }
 }
 
 void ModuleManager::Setup()


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/450 https://github.com/wazuh/wazuh-agent/issues/449|

## Description

This PR includes the following fixes in log collector:
- Notify the coroutines to stop execution.
- Wait until coroutines terminate to clean readers.
- Cancel timer tasks to avoid agent process to hang in exit.

Besides, the default batch size is changed to 1MB.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X