### PR TITLE
Fixes to ModuleManager and CentralizedConfiguration concurrency issues

### DIFF
--- a/src/agent/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/agent/centralized_configuration/include/centralized_configuration.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
+#include <filesystem_wrapper.hpp>
+#include <ifilesystem.hpp>
 #include <module_command/command_entry.hpp>
 
 #include <boost/asio/awaitable.hpp>
-
 #include <nlohmann/json.hpp>
 
 #include <filesystem>
-#include <filesystem_wrapper.hpp>
 #include <functional>
-#include <ifilesystem.hpp>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -86,5 +86,8 @@ namespace centralized_configuration
 
         /// @brief Function to reload modules.
         ReloadModulesFunctionType m_reloadModulesFunction;
+
+        /// @brief Mutex to avoid concurrent execution of centralized configuration commands.
+        std::mutex m_mutex;
     };
 } // namespace centralized_configuration

--- a/src/agent/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/agent/centralized_configuration/src/centralized_configuration.cpp
@@ -10,6 +10,8 @@ namespace centralized_configuration
         const std::string command,       // NOLINT(performance-unnecessary-value-param)
         const nlohmann::json parameters) // NOLINT(performance-unnecessary-value-param)
     {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
         try
         {
             std::vector<std::string> groupIds {};

--- a/src/modules/src/moduleManager.cpp
+++ b/src/modules/src/moduleManager.cpp
@@ -13,23 +13,28 @@ namespace {
     constexpr int MODULES_START_WAIT_SECS = 60;
 }
 
-void ModuleManager::AddModules() {
+void ModuleManager::AddModules()
+{
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
 
 #ifdef ENABLE_INVENTORY
-    Inventory& inventory = Inventory::Instance();
-    inventory.SetAgentUUID(m_agentUUID);
-    AddModule(inventory);
+        Inventory& inventory = Inventory::Instance();
+        inventory.SetAgentUUID(m_agentUUID);
+        AddModule(inventory);
 #endif
 
 #ifdef ENABLE_LOGCOLLECTOR
-    AddModule(Logcollector::Instance());
+        AddModule(Logcollector::Instance());
 #endif
+    }
 
     Setup();
 }
 
 std::shared_ptr<ModuleWrapper> ModuleManager::GetModule(const std::string & name)
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
     if (auto it = m_modules.find(name); it != m_modules.end())
     {
         return it->second;
@@ -39,7 +44,7 @@ std::shared_ptr<ModuleWrapper> ModuleManager::GetModule(const std::string & name
 
 void ModuleManager::Start()
 {
-    std::unique_lock<std::mutex> lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
 
     m_taskManager.Start(m_modules.size());
 


### PR DESCRIPTION
## Description

This PR introduces fixes to some concurrency issues we've noticed during stress testing of the Agent. A mutex/lock is added to CentralizedConfiguration to avoid running at the same time more than one command that requires to downloadfiles and reload the ModuleManager. It also changes the mechanism in ModuleManager::Start to busy waiting on the dispatched tasks to the TaskManager that will run the modules.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X