### PR TITLE
Add server certificate validation to MacOS wazuh agent

### DIFF
--- a/src/agent/communicator/CMakeLists.txt
+++ b/src/agent/communicator/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(Communicator src/communicator.cpp src/http_client.cpp src/http_reque
 
 if(WIN32)
     set(VERIFY_UTILS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/src/https_socket_verify_utils_win.cpp")
+elseif(APPLE)
+    set(VERIFY_UTILS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/src/https_socket_verify_utils_mac.cpp")
 else()
     set(VERIFY_UTILS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/src/https_socket_verify_utils_lin.cpp")
 endif()
@@ -33,6 +35,8 @@ target_link_libraries(Communicator PUBLIC Config Boost::asio Boost::beast Boost:
 
 if(WIN32)
     target_link_libraries(Communicator PRIVATE Crypt32)
+elseif(APPLE)
+    target_link_libraries(Communicator PRIVATE "-framework Security" "-framework CoreFoundation")
 endif()
 
 include(../../cmake/ConfigureTarget.cmake)

--- a/src/agent/communicator/CMakeLists.txt
+++ b/src/agent/communicator/CMakeLists.txt
@@ -13,8 +13,6 @@ find_package(Boost REQUIRED COMPONENTS asio beast system url)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_path(JWT_CPP_INCLUDE_DIRS "jwt-cpp/base.h")
 
-add_library(Communicator src/communicator.cpp src/http_client.cpp src/http_request_params.cpp)
-
 if(WIN32)
     set(VERIFY_UTILS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/src/https_socket_verify_utils_win.cpp")
 elseif(APPLE)
@@ -23,7 +21,7 @@ else()
     set(VERIFY_UTILS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/src/https_socket_verify_utils_lin.cpp")
 endif()
 
-target_sources(Communicator PRIVATE ${VERIFY_UTILS_FILE})
+add_library(Communicator src/communicator.cpp src/http_client.cpp src/http_request_params.cpp ${VERIFY_UTILS_FILE})
 
 target_include_directories(Communicator PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/src/agent/communicator/src/https_socket_verify_utils_mac.cpp
+++ b/src/agent/communicator/src/https_socket_verify_utils_mac.cpp
@@ -1,0 +1,126 @@
+#include <https_socket_verify_utils.hpp>
+#include <logger.hpp>
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+#include <boost/asio/ssl.hpp>
+
+namespace https_socket_verify_utils
+{
+
+    bool VerifyCertificate([[maybe_unused]] bool preverified,
+                           boost::asio::ssl::verify_context& ctx,
+                           const std::string& mode,
+                           const std::string& host)
+    {
+        STACK_OF(X509)* certChain = X509_STORE_CTX_get_chain(ctx.native_handle());
+        if (!certChain || sk_X509_num(certChain) == 0)
+        {
+            LogError("No certificates in the chain.");
+            return false;
+        }
+
+        X509* cert = sk_X509_value(certChain, 0);
+        if (!cert)
+        {
+            LogError("The server certificate could not be obtained.");
+            return false;
+        }
+
+        CFDataRef cfCertData = nullptr;
+
+        unsigned char* certData = nullptr;
+        int certLen = i2d_X509(cert, &certData);
+        if (certLen <= 0)
+        {
+            LogError("Failed to encode certificate to DER.");
+            return false;
+        }
+
+        cfCertData = CFDataCreate(kCFAllocatorDefault, certData, certLen);
+        OPENSSL_free(certData);
+        if (!cfCertData)
+        {
+            LogError("Failed to create CFData for certificate.");
+            return false;
+        }
+
+        SecCertificateRef serverCert = SecCertificateCreateWithData(nullptr, cfCertData);
+        CFRelease(cfCertData);
+        if (!serverCert)
+        {
+            LogError("Failed to create SecCertificateRef.");
+            return false;
+        }
+
+        const void* certArrayValues[] = {serverCert};
+
+        CFArrayRef certArray = CFArrayCreate(kCFAllocatorDefault, certArrayValues, 1, &kCFTypeArrayCallBacks);
+        SecPolicyRef policy = SecPolicyCreateSSL(true, nullptr);
+        SecTrustRef trust = nullptr;
+
+        OSStatus status = SecTrustCreateWithCertificates(certArray, policy, &trust);
+        CFRelease(certArray);
+        CFRelease(policy);
+
+        if (status != errSecSuccess || !trust)
+        {
+            LogError("Failed to create SecTrust object.");
+            CFRelease(serverCert);
+            return false;
+        }
+
+        // Evaluate certificate trust using SecTrustEvaluateWithError
+        CFErrorRef error = nullptr;
+        bool trustResult = SecTrustEvaluateWithError(trust, &error);
+        if (!trustResult)
+        {
+            if (error)
+            {
+                CFStringRef errorDesc = CFErrorCopyDescription(error);
+                LogError("Trust evaluation failed: {}", CFStringGetCStringPtr(errorDesc, kCFStringEncodingUTF8));
+                CFRelease(errorDesc);
+                CFRelease(error);
+            }
+            CFRelease(trust);
+            CFRelease(serverCert);
+            return false;
+        }
+
+        // Validate the hostname if the mode is 'full'.
+        if (mode == "full")
+        {
+            CFStringRef sanString = SecCertificateCopySubjectSummary(serverCert);
+            if (!sanString)
+            {
+                LogError("Failed to retrieve SAN or CN for hostname validation.");
+                CFRelease(trust);
+                CFRelease(serverCert);
+                return false;
+            }
+
+            bool hostnameMatches = false;
+            char buffer[256];
+            if (CFStringGetCString(sanString, buffer, sizeof(buffer), kCFStringEncodingUTF8))
+            {
+                hostnameMatches = (host == buffer);
+            }
+
+            CFRelease(sanString);
+            if (!hostnameMatches)
+            {
+                LogError("The hostname does not match the certificate's SAN or CN.");
+                CFRelease(trust);
+                CFRelease(serverCert);
+                return false;
+            }
+        }
+
+        // Free resources
+        CFRelease(trust);
+        CFRelease(serverCert);
+
+        return true;
+    }
+
+} // namespace https_socket_verify_utils

--- a/src/agent/communicator/src/https_socket_verify_utils_mac.cpp
+++ b/src/agent/communicator/src/https_socket_verify_utils_mac.cpp
@@ -27,17 +27,15 @@ namespace https_socket_verify_utils
             return false;
         }
 
-        CFDataRef cfCertData = nullptr;
-
         unsigned char* certData = nullptr;
-        int certLen = i2d_X509(cert, &certData);
+        const int certLen = i2d_X509(cert, &certData);
         if (certLen <= 0)
         {
             LogError("Failed to encode certificate to DER.");
             return false;
         }
 
-        cfCertData = CFDataCreate(kCFAllocatorDefault, certData, certLen);
+        CFDataRef cfCertData = CFDataCreate(kCFAllocatorDefault, certData, certLen);
         OPENSSL_free(certData);
         if (!cfCertData)
         {
@@ -72,7 +70,8 @@ namespace https_socket_verify_utils
 
         // Evaluate certificate trust using SecTrustEvaluateWithError
         CFErrorRef error = nullptr;
-        bool trustResult = SecTrustEvaluateWithError(trust, &error);
+
+        const bool trustResult = SecTrustEvaluateWithError(trust, &error);
         if (!trustResult)
         {
             if (error)

--- a/src/agent/communicator/src/https_socket_verify_utils_mac.cpp
+++ b/src/agent/communicator/src/https_socket_verify_utils_mac.cpp
@@ -77,7 +77,9 @@ namespace https_socket_verify_utils
             if (error)
             {
                 CFStringRef errorDesc = CFErrorCopyDescription(error);
-                LogError("Trust evaluation failed: {}", CFStringGetCStringPtr(errorDesc, kCFStringEncodingUTF8));
+                char bufferError[256] = {0};
+                CFStringGetCString(errorDesc, bufferError, sizeof(bufferError), kCFStringEncodingUTF8);
+                LogError("Trust evaluation failed: {}", bufferError);
                 CFRelease(errorDesc);
                 CFRelease(error);
             }
@@ -99,7 +101,7 @@ namespace https_socket_verify_utils
             }
 
             bool hostnameMatches = false;
-            char buffer[256];
+            char buffer[256] = {0};
             if (CFStringGetCString(sanString, buffer, sizeof(buffer), kCFStringEncodingUTF8))
             {
                 hostnameMatches = (host == buffer);


### PR DESCRIPTION
|Related issue|
|---|
|#468|

## Description

This PR adds server certificate validation in the MacOS agent.

For server connections when the agent is already registered, a new configuration option is added to control which mode will be used:
```
agent:
  verification_mode: full
```

Possible Values:

- full (default):
  - Validates that the server certificate is signed by a trusted CA.
  - Ensures the server hostname matches the certificate's SAN or CN.
- certificate:
  - Validates that the server certificate is signed by a trusted CA.
  - Does not validate the server hostname.
- none:
  - Disables all certificate validation.
  - No checks are performed on the certificate's CA signature or the server hostname.
  - Note: This mode disables critical SSL/TLS security features and is not recommended for production environments.

To perform the registration of the agent, a new option was added to the CLI “--verification-mode”, the values that can take are the same as for the previous case:

`wazuh-agent --register-agent --user user --password pass --url https://serverIP:55000 --verification-mode certificate`


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X