### PR TITLE
Preserve `wazuh-agent.yml` file when mac OS agent is updated

### DIFF
--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -176,7 +176,7 @@ function build_package() {
         # cp -R "${WAZUH_PATH}/src/symbols"  "${DESTINATION}"
         # zip -r "${DESTINATION}/${symbols_pkg_name}.zip" "${DESTINATION}/symbols"
         # rm -rf "${DESTINATION}/symbols"
-        pkg_name=$(ls "$DESTINATION" | grep '.pkg')
+        pkg_name=$(awk -F'"' '/"name":/ {print $4}' $CURRENT_PATH/wazuh-agent/build-info.json)
         sign_pkg
         if [[ "${CHECKSUM}" == "yes" ]]; then
             shasum -a512 "${DESTINATION}/$pkg_name" > "${DESTINATION}/$pkg_name.sha512"

--- a/packages/macos/package_files/postinstall.sh
+++ b/packages/macos/package_files/postinstall.sh
@@ -17,46 +17,42 @@ SERVICE_FILE="/Library/LaunchDaemons/com.wazuh.agent.plist"
 UPGRADE_FILE_FLAG="${AGENT_DIR}/WAZUH_PKG_UPGRADE"
 
 
-if [ -f "${AGENT_DIR}/WAZUH_RESTART" ]; then
+if [ -f "${AGENT_DIR}"/WAZUH_RESTART ]; then
     restart="true"
-    rm -f ${AGENT_DIR}/WAZUH_RESTART
+    rm -f "${AGENT_DIR}"/WAZUH_RESTART
 fi
 
 if [ -f "${UPGRADE_FILE_FLAG}" ]; then
     upgrade="true"
-    rm -f ${UPGRADE_FILE_FLAG}
-    echo "Restoring configuration files from ${CONF_DIR}/config_files/ to ${CONF_DIR}/etc/"
-    rm -f ${CONF_DIR}/wazuh-agent.yml
-    cp -rf ${CONF_DIR}/config_files/* ${CONF_DIR}
-    rm -rf ${CONF_DIR}/config_files/
+    rm -f "${UPGRADE_FILE_FLAG}"
+    echo "Restoring configuration files from "${CONF_DIR}"/config_files/ to "${CONF_DIR}"/etc/"
+    rm -f "${CONF_DIR}"/wazuh-agent.yml
+    cp -rf "${CONF_DIR}"/config_files/* "${CONF_DIR}"
+    rm -rf "${CONF_DIR}"/config_files/
 fi
 
 # Default for all directories
 echo "Seting permissions and ownership for directories and files"
-chmod -R 750 ${AGENT_DIR}/
-chown -R root:${GROUP} ${AGENT_DIR}/
-chown -R root:wheel ${AGENT_DIR}/bin
+chmod -R 750 "${AGENT_DIR}"/
+chown -R root:"${GROUP}" "${AGENT_DIR}"/
+chown -R root:wheel "${AGENT_DIR}"/bin
 
-chmod 770 ${DATA_DIR}
-chown -R ${USER}:${GROUP} ${DATA_DIR}
+chmod 770 "${DATA_DIR}"
+chown -R "${USER}":"${GROUP}" "${DATA_DIR}"
 
-chmod 770 ${CONF_DIR}
-chown ${USER}:${GROUP} ${CONF_DIR}
+chmod 770 "${CONF_DIR}"
+chown "${USER}":"${GROUP}" "${CONF_DIR}"
 
-sudo chown root:wheel $SERVICE_FILE
-sudo chmod 644 $SERVICE_FILE
-
-# Remove temporary directory
-echo "Removing temporary files..."
-rm -rf ${DIR}/packages_files
+sudo chown root:wheel "$SERVICE_FILE"
+sudo chmod 644 "$SERVICE_FILE"
 
 # Remove old ossec user and group if exists and change ownwership of files
 if [[ $(dscl . -read /Groups/ossec) ]]; then
     echo "Changing group from Ossec to Wazuh"
-    find ${AGENT_DIR}/ -group ossec -user root -exec chown root:wazuh {} \ > /dev/null 2>&1 || true
+    find "${AGENT_DIR}"/ -group ossec -user root -exec chown root:wazuh {} \ > /dev/null 2>&1 || true
     if [[ $(dscl . -read /Users/ossec) ]]; then
         echo "Changing user from Ossec to Wazuh"
-        find ${AGENT_DIR}/ -group ossec -user ossec -exec chown wazuh:wazuh {} \ > /dev/null 2>&1 || true
+        find "${AGENT_DIR}"/ -group ossec -user ossec -exec chown wazuh:wazuh {} \ > /dev/null 2>&1 || true
         echo "Removing Ossec user"
         sudo /usr/bin/dscl . -delete "/Users/ossec"
     fi
@@ -66,5 +62,6 @@ fi
 
 if [ -n "${upgrade}" ] && [ -n "${restart}" ]; then
     echo "Restarting Wazuh..."
-    ${AGENT_DIR}/bin/wazuh-control restart
+    launchctl bootout system "${SERVICE_FILE}"
+    launchctl bootstrap system "${SERVICE_FILE}"
 fi

--- a/packages/macos/package_files/preinstall.sh
+++ b/packages/macos/package_files/preinstall.sh
@@ -41,23 +41,22 @@ check_arch
 
 if [ -d "${AGENT_DIR}" ]; then
     echo "A Wazuh agent installation was found in ${AGENT_DIR}. Will perform an upgrade."
-    upgrade="true"
-    touch "${AGENT_DIR}/WAZUH_PKG_UPGRADE"
+    touch "${AGENT_DIR}"/WAZUH_PKG_UPGRADE
 
-    if [ -f "${AGENT_DIR}/WAZUH_RESTART" ]; then
-        rm -f "${AGENT_DIR}/WAZUH_RESTART"
+    if [ -f "${AGENT_DIR}"/WAZUH_RESTART ]; then
+        rm -f "${AGENT_DIR}"/WAZUH_RESTART
     fi
 
     # Stops the agent before upgrading it
     if ${AGENT_DIR}/bin/wazuh-agent --status | grep "is running" > /dev/null 2>&1; then
-        touch "${AGENT_DIR}/WAZUH_RESTART"
-        ${AGENT_DIR}/bin/wazuh-agent --stop
+        touch "${AGENT_DIR}"/WAZUH_RESTART
+        launchctl bootout system $SERVICE_FILE
         restart="true"
     fi
 
     echo "Backing up configuration files to ${CONF_DIR}/config_files/"
-    mkdir -p ${CONF_DIR}/config_files/
-    cp -r ${CONF_DIR}/* ${CONF_DIR}/config_files/
+    mkdir -p "${CONF_DIR}"/config_files/
+    cp -r "${CONF_DIR}"/* "${CONF_DIR}"/config_files/
 
     if pkgutil --pkgs | grep -i wazuh-agent-etc > /dev/null 2>&1 ; then
         echo "Removing previous package receipt for wazuh-agent-etc"


### PR DESCRIPTION
|Related issue|
|---|
|#135|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team,

This PR fix ensures that if a mac OS package is being updated, the previous config file is backed up and restored after the package update is finished.

This mechanism was already implemented, but it was not working properly due to problems with the path names and the whitespace they contain.

## Tests

* The package is installed with the command: `sudo installer -pkg wazuh-agent_5.0.0-1_intel64_715f7661c.pkg -target /`

* The agent configuration is modified, the `retry_interval` is changed to 45s:
```
vagrant@idr-1931-sonoma-14-7632 output % sudo nano /Library/Application\ Support/Wazuh\ agent.app/etc/wazuh-agent.yml
vagrant@idr-1931-sonoma-14-7632 output % sudo cat /Library/Application\ Support/Wazuh\ agent.app/etc/wazuh-agent.yml | grep "retry_interval"
  retry_interval: 45s
```

* The package is updated reinstalling it:
```
vagrant@idr-1931-sonoma-14-7632 output % sudo installer -pkg wazuh-agent_5.0.0-1_intel64_715f7661c.pkg -target /
installer: Package name is wazuh-agent_5.0.0-1_intel64_715f7661c
installer: Upgrading at base path /
installer: The upgrade was successful.
```

* After the updated, the modified value is preserved:
```
vagrant@idr-1931-sonoma-14-7632 output % sudo cat /Library/Application\ Support/Wazuh\ agent.app/etc/wazuh-agent.yml | grep "retry_interval"
  retry_interval: 45s
```
