### PR TITLE
Start command execution in order

### DIFF
--- a/src/agent/centralized_configuration/include/centralized_configuration.hpp
+++ b/src/agent/centralized_configuration/include/centralized_configuration.hpp
@@ -9,7 +9,6 @@
 
 #include <filesystem>
 #include <functional>
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -86,8 +85,5 @@ namespace centralized_configuration
 
         /// @brief Function to reload modules.
         ReloadModulesFunctionType m_reloadModulesFunction;
-
-        /// @brief Mutex to avoid concurrent execution of centralized configuration commands.
-        std::mutex m_mutex;
     };
 } // namespace centralized_configuration

--- a/src/agent/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/agent/centralized_configuration/src/centralized_configuration.cpp
@@ -86,9 +86,7 @@ namespace centralized_configuration
                 const std::filesystem::path tmpGroupFile =
                     m_fileSystemWrapper->temp_directory_path() / (groupId + config::DEFAULT_SHARED_FILE_EXTENSION);
 
-                // NOLINTBEGIN(cppcoreguidelines-no-suspend-with-lock)
                 const auto dlResult = co_await m_downloadGroupFilesFunction(groupId, tmpGroupFile.string());
-                // NOLINTEND(cppcoreguidelines-no-suspend-with-lock)
 
                 if (!dlResult)
                 {

--- a/src/agent/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/agent/centralized_configuration/src/centralized_configuration.cpp
@@ -10,8 +10,6 @@ namespace centralized_configuration
         const std::string command,       // NOLINT(performance-unnecessary-value-param)
         const nlohmann::json parameters) // NOLINT(performance-unnecessary-value-param)
     {
-        std::lock_guard<std::mutex> lock(m_mutex);
-
         try
         {
             std::vector<std::string> groupIds {};

--- a/src/agent/command_handler/src/command_handler.cpp
+++ b/src/agent/command_handler/src/command_handler.cpp
@@ -2,8 +2,10 @@
 
 namespace command_handler
 {
-    const std::unordered_map<std::string, std::string> VALID_COMMANDS_MAP = {
-        {"set-group", "CentralizedConfiguration"}, {"update-group", "CentralizedConfiguration"}};
+    const std::unordered_map<std::string, std::pair<std::string, module_command::CommandExecutionMode>>
+        VALID_COMMANDS_MAP = {
+            {"set-group", {"CentralizedConfiguration", module_command::CommandExecutionMode::SYNC}},
+            {"update-group", {"CentralizedConfiguration", module_command::CommandExecutionMode::SYNC}}};
 
     void CommandHandler::Stop()
     {
@@ -27,7 +29,8 @@ namespace command_handler
                 }
             }
 
-            cmd.Module = it->second;
+            cmd.Module = it->second.first;
+            cmd.ExecutionMode = it->second.second;
             return true;
         }
         else

--- a/src/agent/command_store/include/command_store.hpp
+++ b/src/agent/command_store/include/command_store.hpp
@@ -30,6 +30,11 @@ namespace command_store
         /// @return The module_command::Status value corresponding
         module_command::Status StatusFromInt(const int i);
 
+        /// @brief Converts an integer to a module_command::CommandExecutionMode value
+        /// @param i The integer to convert
+        /// @return The module_command::CommandExecutionMode value corresponding
+        module_command::CommandExecutionMode ExecutionModeFromInt(const int i);
+
     public:
         /// @brief CommandStore constructor
         /// @param dbFolderPath The path to the database folder

--- a/src/agent/command_store/tests/command_store_test.cpp
+++ b/src/agent/command_store/tests/command_store_test.cpp
@@ -30,19 +30,34 @@ TEST_F(CommandStoreTest, StoreCommandTest)
     m_commandStore->Clear();
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    module_command::CommandEntry cmd1(
-        TESTID_5, "Module1", "{CommandTextHERE}", {"Parameter1"}, "Result1", module_command::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd1(TESTID_5,
+                                      "Module1",
+                                      "{CommandTextHERE}",
+                                      {"Parameter1"},
+                                      module_command::CommandExecutionMode::ASYNC,
+                                      "Result1",
+                                      module_command::Status::IN_PROGRESS);
     bool retVal = m_commandStore->StoreCommand(cmd1);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    module_command::CommandEntry cmd2(
-        TESTID_9, "Module2", R"({"Some"="thing"})", {"Parameter2"}, "Result2", module_command::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd2(TESTID_9,
+                                      "Module2",
+                                      R"({"Some"="thing"})",
+                                      {"Parameter2"},
+                                      module_command::CommandExecutionMode::ASYNC,
+                                      "Result2",
+                                      module_command::Status::IN_PROGRESS);
     retVal = m_commandStore->StoreCommand(cmd2);
     ASSERT_EQ(retVal, true);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    module_command::CommandEntry cmd3(
-        TESTID_5, "Module3", "{CommandTextHERE}", {"Parameter3"}, "Result3", module_command::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd3(TESTID_5,
+                                      "Module3",
+                                      "{CommandTextHERE}",
+                                      {"Parameter3"},
+                                      module_command::CommandExecutionMode::ASYNC,
+                                      "Result3",
+                                      module_command::Status::IN_PROGRESS);
     retVal = m_commandStore->StoreCommand(cmd3);
     ASSERT_EQ(retVal, false);
 
@@ -58,6 +73,7 @@ TEST_F(CommandStoreTest, StoreCommandTestParameters)
                                       "Module1",
                                       "{CommandTextHERE}",
                                       {"Parameter1", "Parameter 2", "3"},
+                                      module_command::CommandExecutionMode::ASYNC,
                                       "Result1",
                                       module_command::Status::IN_PROGRESS);
     const bool retVal = m_commandStore->StoreCommand(cmd1);
@@ -75,6 +91,7 @@ TEST_F(CommandStoreTest, StoreCommandTestParameters)
         ASSERT_EQ(cmd.Command, "{CommandTextHERE}");
         std::vector<std::string> expected = {"Parameter1", "Parameter 2", "3"};
         ASSERT_EQ(cmd.Parameters, expected);
+        ASSERT_EQ(cmd.ExecutionMode, module_command::CommandExecutionMode::ASYNC);
         ASSERT_EQ(cmd.ExecutionResult.Message, "Result1");
         ASSERT_EQ(cmd.ExecutionResult.ErrorCode, module_command::Status::IN_PROGRESS);
     }
@@ -89,12 +106,22 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
     m_commandStore->Clear();
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    module_command::CommandEntry cmd1(
-        TESTID_5, "Module1", "{CommandTextHERE}", {"Parameter1"}, "Result1", module_command::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd1(TESTID_5,
+                                      "Module1",
+                                      "{CommandTextHERE}",
+                                      {"Parameter1"},
+                                      module_command::CommandExecutionMode::ASYNC,
+                                      "Result1",
+                                      module_command::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd1);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    module_command::CommandEntry cmd2(
-        TESTID_9, "Module2", R"({"Some"="thing"})", {"Parameter2"}, "Result2", module_command::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd2(TESTID_9,
+                                      "Module2",
+                                      R"({"Some"="thing"})",
+                                      {"Parameter2"},
+                                      module_command::CommandExecutionMode::ASYNC,
+                                      "Result2",
+                                      module_command::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd2);
 
     ASSERT_EQ(m_commandStore->GetCount(), 2);
@@ -104,6 +131,7 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
                                            "Updated Module",
                                            "Updated CommandEntry",
                                            {"Updated Parameter"},
+                                           module_command::CommandExecutionMode::ASYNC,
                                            "Updated Result",
                                            module_command::Status::SUCCESS);
 
@@ -128,8 +156,13 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
     }
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    module_command::CommandEntry cmdUpdate2(
-        TESTID_9, "", "", {}, "Newly Updated Result", module_command::Status::UNKNOWN);
+    module_command::CommandEntry cmdUpdate2(TESTID_9,
+                                            "",
+                                            "",
+                                            {},
+                                            module_command::CommandExecutionMode::ASYNC,
+                                            "Newly Updated Result",
+                                            module_command::Status::UNKNOWN);
 
     retVal = m_commandStore->UpdateCommand(cmdUpdate2);
     ASSERT_EQ(retVal, true);
@@ -143,6 +176,7 @@ TEST_F(CommandStoreTest, UpdateCommandTest)
         ASSERT_EQ(cmd.Module, "Updated Module");
         ASSERT_EQ(cmd.Command, "Updated CommandEntry");
         ASSERT_EQ(cmd.Parameters, std::vector<std::string> {"Updated Parameter"});
+        ASSERT_EQ(cmd.ExecutionMode, module_command::CommandExecutionMode::ASYNC);
         ASSERT_EQ(cmd.ExecutionResult.Message, "Newly Updated Result");
         ASSERT_EQ(cmd.ExecutionResult.ErrorCode, module_command::Status::SUCCESS);
     }
@@ -167,16 +201,31 @@ TEST_F(CommandStoreTest, GetCommandTest)
     m_commandStore->Clear();
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    module_command::CommandEntry cmd1(
-        TESTID_5, "Module1", "{CommandTextHERE}", {"Parameter1"}, "Result1", module_command::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd1(TESTID_5,
+                                      "Module1",
+                                      "{CommandTextHERE}",
+                                      {"Parameter1"},
+                                      module_command::CommandExecutionMode::SYNC,
+                                      "Result1",
+                                      module_command::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd1);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    module_command::CommandEntry cmd2(
-        TESTID_9, "Module2", "TestValue9", {"Parameter2"}, "Result2", module_command::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd2(TESTID_9,
+                                      "Module2",
+                                      "TestValue9",
+                                      {"Parameter2"},
+                                      module_command::CommandExecutionMode::SYNC,
+                                      "Result2",
+                                      module_command::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd2);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    module_command::CommandEntry cmd3(
-        TESTID_11, "Module3", "{CommandTextHERE}", {"Parameter3"}, "Result3", module_command::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd3(TESTID_11,
+                                      "Module3",
+                                      "{CommandTextHERE}",
+                                      {"Parameter3"},
+                                      module_command::CommandExecutionMode::SYNC,
+                                      "Result3",
+                                      module_command::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd3);
     ASSERT_EQ(m_commandStore->GetCount(), 3);
 
@@ -206,16 +255,31 @@ TEST_F(CommandStoreTest, GetCommandByStatusTest)
     m_commandStore->Clear();
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    module_command::CommandEntry cmd1(
-        TESTID_5, "Module1", "{CommandTextHERE}", {"Parameter1"}, "Result1", module_command::Status::SUCCESS);
+    module_command::CommandEntry cmd1(TESTID_5,
+                                      "Module1",
+                                      "{CommandTextHERE}",
+                                      {"Parameter1"},
+                                      module_command::CommandExecutionMode::SYNC,
+                                      "Result1",
+                                      module_command::Status::SUCCESS);
     m_commandStore->StoreCommand(cmd1);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    module_command::CommandEntry cmd2(
-        TESTID_9, "Module2", "TestValue9", {"Parameter2"}, "Result2", module_command::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd2(TESTID_9,
+                                      "Module2",
+                                      "TestValue9",
+                                      {"Parameter2"},
+                                      module_command::CommandExecutionMode::SYNC,
+                                      "Result2",
+                                      module_command::Status::IN_PROGRESS);
     m_commandStore->StoreCommand(cmd2);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    module_command::CommandEntry cmd3(
-        TESTID_11, "Module3", "{CommandTextHERE}", {"Parameter3"}, "Result3", module_command::Status::SUCCESS);
+    module_command::CommandEntry cmd3(TESTID_11,
+                                      "Module3",
+                                      "{CommandTextHERE}",
+                                      {"Parameter3"},
+                                      module_command::CommandExecutionMode::SYNC,
+                                      "Result3",
+                                      module_command::Status::SUCCESS);
     m_commandStore->StoreCommand(cmd3);
     ASSERT_EQ(m_commandStore->GetCount(), 3);
 

--- a/src/agent/module_command/include/module_command/command_entry.hpp
+++ b/src/agent/module_command/include/module_command/command_entry.hpp
@@ -17,6 +17,13 @@ namespace module_command
         UNKNOWN
     };
 
+    /// @enum Execution mode of a command
+    enum class CommandExecutionMode
+    {
+        SYNC,
+        ASYNC
+    };
+
     /// @struct Result of a command execution
     struct CommandExecutionResult
     {
@@ -55,6 +62,7 @@ namespace module_command
                      std::string module,
                      std::string command,
                      nlohmann::json parameters,
+                     CommandExecutionMode executionMode,
                      std::string result,
                      Status status)
             : Id(std::move(id))
@@ -62,6 +70,7 @@ namespace module_command
             , Command(std::move(command))
             , Parameters(std::move(parameters))
             , Time(0.0)
+            , ExecutionMode(executionMode)
             , ExecutionResult(status, std::move(result))
         {
         }
@@ -80,6 +89,9 @@ namespace module_command
 
         /// @brief Time of the command execution
         double Time;
+
+        /// @brief Execution mode (sync or async) of the command.
+        CommandExecutionMode ExecutionMode;
 
         /// @brief Result of the command execution
         CommandExecutionResult ExecutionResult;

--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -84,7 +84,13 @@ std::optional<module_command::CommandEntry> GetCommandFromQueue(std::shared_ptr<
         }
     }
 
-    module_command::CommandEntry cmd(id, "", command, parameters, "", module_command::Status::IN_PROGRESS);
+    module_command::CommandEntry cmd(id,
+                                     "",
+                                     command,
+                                     parameters,
+                                     module_command::CommandExecutionMode::ASYNC,
+                                     "",
+                                     module_command::Status::IN_PROGRESS);
     return cmd;
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/471|

This pull request introduces changes to execute centralized configuration commands in order, removing the use of mutexes. It also ensures compatibility of the `command_handler` to dispatch these commands while preserving the existing behavior for other types of commands.