### PR TITLE
Avoid blocking agent stop in SyncLoop

### DIFF
--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -137,7 +137,7 @@ private:
     bool m_portsAll;             // Scan only listening ports or all
     bool m_processes;            // Running processes inventory
     bool m_hotfixes;             // Windows hotfixes installed
-    bool m_stopping;
+    std::atomic<bool> m_stopping;
     bool m_notify;
     std::unique_ptr<DBSync> m_spDBSync;
     std::condition_variable m_cv;

--- a/src/modules/inventory/src/inventoryImp.cpp
+++ b/src/modules/inventory/src/inventoryImp.cpp
@@ -983,7 +983,11 @@ void Inventory::SyncLoop()
             std::unique_lock<std::mutex> lock {m_mutex};
             m_cv.wait_for(lock, std::chrono::milliseconds {m_intervalValue}, [&]() { return m_stopping; });
         }
-        Scan();
+
+        if (!m_stopping)
+        {
+            Scan();
+        }
     }
     std::unique_lock<std::mutex> lock {m_mutex};
     m_spDBSync.reset(nullptr);

--- a/src/modules/inventory/src/inventoryImp.cpp
+++ b/src/modules/inventory/src/inventoryImp.cpp
@@ -783,11 +783,17 @@ void Inventory::ScanPackages()
                                  NotifyChange(result, data, PACKAGES_TABLE);
                              }};
 
+        Stopper stopper;
         std::unique_lock<std::mutex> lock {m_mutex};
         DBSyncTxn txn {m_spDBSync->handle(), nlohmann::json {PACKAGES_TABLE}, 0, QUEUE_SIZE, callback};
         m_spInfo->packages(
-            [this, &txn](nlohmann::json& rawData)
+            [this, &txn, &stopper](nlohmann::json& rawData)
             {
+                if(stopper.IsStop(m_stopping))
+                {
+                    return;
+                }
+
                 nlohmann::json input;
 
                 input["table"] = PACKAGES_TABLE;

--- a/src/modules/inventory/src/inventoryImp.cpp
+++ b/src/modules/inventory/src/inventoryImp.cpp
@@ -643,7 +643,7 @@ void Inventory::ScanHardware()
         UpdateChanges(HARDWARE_TABLE, hwData, m_hardwareFirstScan);
         LogTrace("Ending hardware scan");
 
-        if (!m_hardwareFirstScan)
+        if (!m_hardwareFirstScan && !m_stopping.load())
         {
             WriteMetadata(TABLE_TO_KEY_MAP.at(HARDWARE_TABLE), Utils::getCurrentISO8601());
             m_hardwareFirstScan = true;
@@ -661,7 +661,7 @@ void Inventory::ScanSystem()
         UpdateChanges(SYSTEM_TABLE, SystemData, m_systemFirstScan);
         LogTrace("Ending os scan");
 
-        if (!m_systemFirstScan)
+        if (!m_systemFirstScan && !m_stopping.load())
         {
             WriteMetadata(TABLE_TO_KEY_MAP.at(SYSTEM_TABLE), Utils::getCurrentISO8601());
             m_systemFirstScan = true;
@@ -761,7 +761,7 @@ void Inventory::ScanNetwork()
             }
         }
 
-        if (!m_networksFirstScan)
+        if (!m_networksFirstScan && !m_stopping.load())
         {
             WriteMetadata(TABLE_TO_KEY_MAP.at(NETWORKS_TABLE), Utils::getCurrentISO8601());
             m_networksFirstScan = true;
@@ -804,7 +804,7 @@ void Inventory::ScanPackages()
             });
         txn.getDeletedRows(callback);
 
-        if (!m_packagesFirstScan)
+        if (!m_packagesFirstScan && !m_stopping.load())
         {
             WriteMetadata(TABLE_TO_KEY_MAP.at(PACKAGES_TABLE), Utils::getCurrentISO8601());
             m_packagesFirstScan = true;
@@ -826,7 +826,7 @@ void Inventory::ScanHotfixes()
             UpdateChanges(HOTFIXES_TABLE, hotfixes, m_hotfixesFirstScan);
         }
 
-        if (!m_hotfixesFirstScan)
+        if (!m_hotfixesFirstScan && !m_stopping.load())
         {
             WriteMetadata(TABLE_TO_KEY_MAP.at(HOTFIXES_TABLE), Utils::getCurrentISO8601());
             m_hotfixesFirstScan = true;
@@ -905,7 +905,7 @@ void Inventory::ScanPorts()
         UpdateChanges(PORTS_TABLE, portsData, m_portsFirstScan);
         LogTrace("Ending ports scan");
 
-        if (!m_portsFirstScan)
+        if (!m_portsFirstScan && !m_stopping.load())
         {
             WriteMetadata(TABLE_TO_KEY_MAP.at(PORTS_TABLE), Utils::getCurrentISO8601());
             m_portsFirstScan = true;
@@ -940,7 +940,7 @@ void Inventory::ScanProcesses()
             }));
         txn.getDeletedRows(callback);
 
-        if (!m_processesFirstScan)
+        if (!m_processesFirstScan && !m_stopping.load())
         {
             WriteMetadata(TABLE_TO_KEY_MAP.at(PROCESSES_TABLE), Utils::getCurrentISO8601());
             m_processesFirstScan = true;


### PR DESCRIPTION
|Related issue|
|---|
| Closes #445 |

## Description

Prevents the agent from taking a long time to interrupt its execution, where [a benchmark has shown](https://github.com/wazuh/wazuh-agent/issues/445#issuecomment-2620463407) that the `syncTxnRow` calls inside `ScanPackages` and `ScanProcesses` where taking a long time to execute.

## Proposed Changes

The `bool m_stopping` flag has been changed into `std::atomic<bool> m_stopping`, and it's being used to avoid `syncTxnRow` from being called in case it's `true`, minimizing the amount of time it takes for the process to terminate. 

Also, the metadata which contains the scan timestamp is now only saved if the first scan has been successfully completed.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [X]  Relevant evidence provided
- [x] Tests cover the new functionality
- [X] Meets requirements and/or definition of done
- [X] No unresolved dependencies with other issues


<!--
Include any additional information relevant to the review process.
-->
