### PR TITLE
Fixed dependencies for Linux package generation

### DIFF
--- a/packages/debs/amd64/agent/Dockerfile
+++ b/packages/debs/amd64/agent/Dockerfile
@@ -57,6 +57,7 @@ RUN git config --global --add safe.directory /wazuh-local-src
 RUN apt update && apt install dirmngr gnupg apt-transport-https ca-certificates -y && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     sh -c 'echo "deb https://download.mono-project.com/repo/debian stable-buster main" > /etc/apt/sources.list.d/mono-official-stable.list' && \
-    apt update && apt install mono-devel -y
+    apt update && apt install mono-devel pip -y && \
+    pip install jinja2
 
 RUN curl -o /usr/local/bin/nuget https://dist.nuget.org/win-x86-commandline/v6.10.2/nuget.exe

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -100,11 +100,6 @@
       {
         "name": "zlib",
         "version>=": "1.3.1"
-      },
-      {
-        "name": "libsystemd",
-        "version>=": "256.4",
-        "platform": "linux"
       }
     ],
     "overrides": [


### PR DESCRIPTION
## Description

The following has been modified in this PR in order to generate packages correctly:
- Reverted the installation of the `libsystemd` dependency via `vcpkg`, because it was causing failures in _deb_ and _rpm_ package generation. 
  - The problem lies in the OSs used for package generation (mostly RPM - _CentOS 7_), as they are old and the dependencies of the official system packages have a deprecated version, causing errors in `vcpkg` compilation.

- Added `pip` package and `jinja2` dependency to avoid compilation problems in Debian. 


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux


- Deb: https://github.com/wazuh/wazuh-agent-packages/actions/runs/12834995556 - :green_circle: 
- RPM: https://github.com/wazuh/wazuh-agent-packages/actions/runs/12835000087 - :green_circle: 