### PR TITLE
Always register agents as new

### DIFF
--- a/docs/ref/messages.md
+++ b/docs/ref/messages.md
@@ -1,0 +1,188 @@
+# Messages
+
+## Registration requests
+
+- **API**: Server Management
+
+### Authentication
+
+- **Endpoint**: `/security/user/authenticate`
+
+- **Method**: POST
+
+- **Headers**:
+  - **Authorization**: Basic `base64(user:pass)`
+  - **User-Agent**:
+    - Product name
+    - Agent's version
+    - Agent's type
+    - Architecture
+    - OS type
+
+Example: `WazuhXDR/5.0.0 (Endpoint; x86_64; Linux)`
+
+- **Body**: _empty_
+
+### Registration
+
+- **Endpoint**: `/agents`
+
+- **Method**: POST
+
+- **Headers**:
+  - **Authorization**: Bearer `token`
+  - **User-Agent**:
+    - Product name
+    - Agent's version
+    - Agent's type
+    - Architecture
+    - OS type
+
+Example: `WazuhXDR/5.0.0 (Endpoint; x86_64; Linux)`
+
+- **Body**: _json_
+  - **id**: Agent's UUID
+  - **name**: Agent's name
+  - **key**: Agent's alphanumeric key (32 characters)
+  - **type**: Agent's type
+  - **version**: Agent's version
+  - **host**:
+    - **os**:
+      - **name**: OS name
+      - **type**: OS type
+      - **version**: OS version
+    - **architecture**: Architecture
+    - **hostname**: Hostname
+    - **ip**: List of IPs
+
+Example:
+
+```json
+{
+    "id": "0194857f-39b5-7bfb-a7bc-c5c6835f03d1",
+    "name": "agent_name",
+    "key": "eJdcN3mtVcLuyNwLj1Kx0NCvH53R16no",
+    "type": "Endpoint",
+    "version": "5.0.0",
+    "host": {
+        "architecture": "aarch64",
+        "hostname": "desktop",
+        "ip": ["172.20.0.1"],
+        "os": {
+            "name": "Ubuntu",
+            "type": "Linux",
+            "version": "24.04"
+        }
+    }
+}
+```
+
+> **_NOTE:_** An agent will always register as new regardless of whether it has previously registered.
+
+## Communication requests
+
+- **API**: Agent Comms
+
+### Authentication
+
+- **Endpoint**: `/api/v1/authentication`
+
+- **Method**: POST
+
+- **Headers**:
+  - **User-Agent**:
+    - Product name
+    - Agent's version
+    - Agent's type
+    - Architecture
+    - OS type
+
+Example: `WazuhXDR/5.0.0 (Endpoint; x86_64; Linux)`
+
+- **Body**: _json_
+  - **uuid**: Agent's UUID
+  - **key**: Agent's alphanumeric key (32 characters)
+
+Example:
+
+```json
+{
+    "uuid": "0194857f-39b5-7bfb-a7bc-c5c6835f03d1",
+    "key": "eJdcN3mtVcLuyNwLj1Kx0NCvH53R16no"
+}
+```
+
+### Sateful/stateless
+
+- **Endpoint**: `/api/v1/events/stateful` & `/api/v1/events/stateless`
+
+- **Method**: POST
+
+- **Headers**:
+  - **Authorization**: Bearer `token`
+  - **User-Agent**:
+    - Product name
+    - Agent's version
+    - Agent's type
+    - Architecture
+    - OS type
+
+Example: `WazuhXDR/5.0.0 (Endpoint; x86_64; Linux)`
+
+- **Body**: _json_
+  - **id**: Agent's UUID
+  - **name**: Agent's name
+  - **type**: Agent's type
+  - **version**: Agent's version
+  - **groups**: Agent's groups
+  - **host**:
+    - **os**:
+      - **name**: OS name
+      - **type**: OS type
+      - **version**: OS version
+    - **architecture**: Architecture
+    - **hostname**: Hostname
+    - **ip**: List of IPs
+
+Example:
+
+```json
+{
+    "agent": {
+        "id": "0194857f-39b5-7bfb-a7bc-c5c6835f03d1",
+        "name": "agent_name",
+        "type": "Endpoint",
+        "version": "5.0.0",
+        "groups": [],
+        "host": {
+            "architecture": "aarch64",
+            "hostname": "desktop",
+            "ip": ["172.20.0.1"],
+            "os": {
+                "name": "Ubuntu",
+                "type": "Linux",
+                "version": "24.04"
+            }
+        }
+    }
+}
+```
+
+### Commands
+
+- **Endpoint**: `/api/v1/commands`
+
+- **Method**: GET
+
+- **Headers**:
+  - **Authorization**: Bearer `token`
+  - **User-Agent**:
+    - Product name
+    - Agent's version
+    - Agent's type
+    - Architecture
+    - OS type
+
+Example: `WazuhXDR/5.0.0 (Endpoint; x86_64; Linux)`
+
+- **Body**: _empty_

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -24,9 +24,11 @@ public:
     /// @param dbFolderPath Path to the database folder.
     /// @param getOSInfo Function to retrieve OS information in JSON format.
     /// @param getNetworksInfo Function to retrieve network information in JSON format.
+    /// @param agentIsRegistering True if the agent is being registered, false otherwise.
     AgentInfo(std::string dbFolderPath = config::DEFAULT_DATA_PATH,
               std::function<nlohmann::json()> getOSInfo = nullptr,
-              std::function<nlohmann::json()> getNetworksInfo = nullptr);
+              std::function<nlohmann::json()> getNetworksInfo = nullptr,
+              bool agentIsRegistering = false);
 
     /// @brief Gets the agent's name.
     /// @return The agent's name.
@@ -75,11 +77,10 @@ public:
     std::string GetHeaderInfo() const;
 
     /// @brief Gets all the information about the agent.
-    /// @param agentIsRegistering Indicates if the agent is about to register.
     /// @return A string with all information about the agent.
-    std::string GetMetadataInfo(const bool agentIsRegistering) const;
+    std::string GetMetadataInfo() const;
 
-    /// @brief Saves the agent's information to the database.
+    /// @brief Restores and saves the agent's information to the database.
     void Save() const;
 
     /// @brief Saves the agent's group information to the database.
@@ -137,4 +138,7 @@ private:
 
     /// @brief The networks information
     std::function<nlohmann::json()> m_getNetworksInfo;
+
+    /// @brief Specify if the agent is about to register.
+    bool m_agentIsRegistering;
 };

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -130,9 +130,9 @@ TEST_F(AgentInfoTest, TestSaveGroups)
 
 TEST_F(AgentInfoTest, TestLoadMetadataInfoNoSysInfo)
 {
-    const AgentInfo agentInfo(".");
+    const AgentInfo agentInfo(".", nullptr, nullptr, true);
 
-    auto metadataInfo = nlohmann::json::parse(agentInfo.GetMetadataInfo(true));
+    auto metadataInfo = nlohmann::json::parse(agentInfo.GetMetadataInfo());
 
     EXPECT_TRUE(metadataInfo != nullptr);
 
@@ -142,7 +142,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoNoSysInfo)
     EXPECT_EQ(metadataInfo["id"], agentInfo.GetUUID());
     EXPECT_EQ(metadataInfo["name"], agentInfo.GetName());
     EXPECT_EQ(metadataInfo["key"], agentInfo.GetKey());
-    EXPECT_TRUE(metadataInfo["groups"] != nullptr);
+    EXPECT_TRUE(metadataInfo["groups"] == nullptr);
 
     // Endpoint information
     EXPECT_TRUE(metadataInfo["host"] == nullptr);
@@ -176,9 +176,9 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
 
     networks["iface"].push_back(ip);
 
-    const AgentInfo agentInfo(".", [os]() { return os; }, [networks]() { return networks; });
+    const AgentInfo agentInfo(".", [os]() { return os; }, [networks]() { return networks; }, true);
 
-    auto metadataInfo = nlohmann::json::parse(agentInfo.GetMetadataInfo(true));
+    auto metadataInfo = nlohmann::json::parse(agentInfo.GetMetadataInfo());
 
     EXPECT_TRUE(metadataInfo != nullptr);
 
@@ -188,7 +188,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
     EXPECT_EQ(metadataInfo["id"], agentInfo.GetUUID());
     EXPECT_EQ(metadataInfo["name"], agentInfo.GetName());
     EXPECT_EQ(metadataInfo["key"], agentInfo.GetKey());
-    EXPECT_TRUE(metadataInfo["groups"] != nullptr);
+    EXPECT_TRUE(metadataInfo["groups"] == nullptr);
 
     // Endpoint information
     EXPECT_TRUE(metadataInfo["host"] != nullptr);
@@ -229,7 +229,7 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoConnected)
 
     const AgentInfo agentInfo(".", [os]() { return os; }, [networks]() { return networks; });
 
-    auto metadataInfo = nlohmann::json::parse(agentInfo.GetMetadataInfo(false));
+    auto metadataInfo = nlohmann::json::parse(agentInfo.GetMetadataInfo());
 
     EXPECT_TRUE(metadataInfo["agent"] != nullptr);
 

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -125,8 +125,7 @@ void Agent::Run()
                                       return GetMessagesFromQueue(m_messageQueue,
                                                                   MessageType::STATEFUL,
                                                                   numMessages,
-                                                                  [this]()
-                                                                  { return m_agentInfo.GetMetadataInfo(false); });
+                                                                  [this]() { return m_agentInfo.GetMetadataInfo(); });
                                   },
                                   [this]([[maybe_unused]] const int messageCount, const std::string&)
                                   { PopMessagesFromQueue(m_messageQueue, MessageType::STATEFUL, messageCount); }),
@@ -138,8 +137,7 @@ void Agent::Run()
                                       return GetMessagesFromQueue(m_messageQueue,
                                                                   MessageType::STATELESS,
                                                                   numMessages,
-                                                                  [this]()
-                                                                  { return m_agentInfo.GetMetadataInfo(false); });
+                                                                  [this]() { return m_agentInfo.GetMetadataInfo(); });
                                   },
                                   [this]([[maybe_unused]] const int messageCount, const std::string&)
                                   { PopMessagesFromQueue(m_messageQueue, MessageType::STATELESS, messageCount); }),

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -18,7 +18,7 @@ namespace agent_registration
                                          const std::string& dbFolderPath,
                                          std::string verificationMode)
         : m_agentInfo(
-              dbFolderPath, [this]() { return m_sysInfo.os(); }, [this]() { return m_sysInfo.networks(); })
+              dbFolderPath, [this]() { return m_sysInfo.os(); }, [this]() { return m_sysInfo.networks(); }, true)
         , m_serverUrl(std::move(url))
         , m_user(std::move(user))
         , m_password(std::move(password))
@@ -53,7 +53,7 @@ namespace agent_registration
                                                               m_verificationMode,
                                                               token.value(),
                                                               "",
-                                                              m_agentInfo.GetMetadataInfo(true));
+                                                              m_agentInfo.GetMetadataInfo());
 
         const auto res = httpClient.PerformHttpRequest(reqParams);
 


### PR DESCRIPTION
## Description

As requested in https://github.com/wazuh/wazuh-agent/issues/520, this PR adds the ability to always register an agent as new. This means that regardless of whether the agent was previously registered or not, when running the registration process it will behave as a new agent. This means that:

- A new UUID will be generated.
- A new key must be specified or will be generated in case it is not present.
- A new name must be specified or will be generated in case it is not present.

Also, the `groups` property is removed from the agent registration body as it no longer applies to this request.


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X