### PR TITLE
Add metadata to stateless inventory message

### DIFF
--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -114,8 +114,12 @@ void Inventory::SendDeltaEvent(const std::string& data)
     if (jsonData.contains("stateless") && !jsonData["stateless"].empty())
     {
 
+        auto metadataAux = jsonData["metadata"];
+        metadataAux.erase("id");
+        metadataAux.erase("operation");
+
         const Message statelessMessage {
-            MessageType::STATELESS, jsonData["stateless"], Name(), jsonData["metadata"]["type"], ""};
+            MessageType::STATELESS, jsonData["stateless"], Name(), jsonData["metadata"]["type"], metadataAux.dump()};
 
         if (!m_pushMessage(statelessMessage))
         {

--- a/src/modules/inventory/tests/inventoryImp/inventoryImp_test.cpp
+++ b/src/modules/inventory/tests/inventoryImp/inventoryImp_test.cpp
@@ -1395,13 +1395,14 @@ TEST_F(InventoryImpTest, statelessMessage)
                                                                {
                                                                    auto delta = nlohmann::json::parse(data);
                                                                    delta.erase("data");
-                                                                   delta.erase("metadata");
+                                                                   delta["metadata"].erase("id");
+                                                                   delta["metadata"].erase("operation");
                                                                    delta["stateless"]["event"].erase("created");
                                                                    wrapperDelta.callbackMock(delta.dump());
                                                                }};
 
     const auto expectedResult1 {
-        R"({"stateless":{"event":{"action":"system-detected","category":["host"],"reason":"System UBUNTU is running OS version 6.1.7601","type":["info"]},"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":null,"kernel":"7601","name":"Microsoft Windows 7","platform":null,"type":null,"version":"6.1.7601"}}}})"};
+        R"({"metadata":{"module":"inventory","type":"system"},"stateless":{"event":{"action":"system-detected","category":["host"],"reason":"System UBUNTU is running OS version 6.1.7601","type":["info"]},"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":null,"kernel":"7601","name":"Microsoft Windows 7","platform":null,"type":null,"version":"6.1.7601"}}}})"};
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
 


### PR DESCRIPTION
|Related issue|
|---|
|Close #523|
## Description

This pull request addresses the issue of enhancing the stateless message structure of the Inventory module by including a metadata message. The metadata message is sent prior to the composite event message and includes the following fields:

- `module`: Specifies the module sending the message.
- `type`: Indicates the type of message.
- `operation`: Describes the operation performed.