### PR TITLE
Rename file_wait setting to read_interval

### DIFF
--- a/docs/ref/configuration.md
+++ b/docs/ref/configuration.md
@@ -6,8 +6,7 @@
 logcollector:
   enabled: true
   reload_interval: 1m
-  file_wait: 500ms
-  channel_refresh: 5s
+  read_interval: 500ms
   localfiles:
     - location: /var/log/*.log
   journald:
@@ -26,6 +25,6 @@ logcollector:
 
 ### Reference
 
-|Mandatory|Option|Description|Default|
-|:-:|--|--|--|
-||`enabled`|Sets the module as enabled|yes|
+| Mandatory | Option    | Description                | Default |
+| :-------: | --------- | -------------------------- | ------- |
+|           | `enabled` | Sets the module as enabled | yes     |

--- a/docs/ref/modules/logcollector/README.md
+++ b/docs/ref/modules/logcollector/README.md
@@ -8,9 +8,9 @@ system API.
 
 ### Reference
 
-|Mandatory|Option|Description|Default|
-|:-:|--|--|--|
-||`enabled`|Sets the module as enabled|yes|
+| Mandatory | Option    | Description                | Default |
+| :-------: | --------- | -------------------------- | ------- |
+|           | `enabled` | Sets the module as enabled | yes     |
 
 #### File Collector
 
@@ -18,25 +18,25 @@ system API.
 logcollector:
   enabled: true
   reload_interval: 1m
-  file_wait: 500ms
+  read_interval: 500ms
   localfiles:
     - /var/log/auth.log
 ```
 
 The File collector handles plain-text log files. It needs a file path to work.
 
-|Mandatory|Option|Description|Default|
-|:-:|--|--|--|
-|| reload_interval | Time in milliseconds to recheck for new files to monitor | 60000 |
-|| file_wait | Time in milliseconds to recheck for available logs | 500 |
-|✔️| localfiles | Vector of file paths to monitor |  |
+| Mandatory | Option          | Description                                              | Default |
+| :-------: | --------------- | -------------------------------------------------------- | ------- |
+|           | reload_interval | Time in milliseconds to recheck for new files to monitor | 60000   |
+|           | read_interval   | Time in milliseconds to recheck for available logs       | 500     |
+|     ✔️     | localfiles      | Vector of file paths to monitor                          |         |
 
 #### Journald Collector
 
 ```yaml
 logcollector:
   enabled: true
-  file_wait: 500ms
+  read_interval: 500ms
   journald:
     - field: "_SYSTEMD_UNIT"
       value: "cron.service"
@@ -68,22 +68,22 @@ This collector gets logs from Journald on Linux. It needs a field and a value to
 {"event":{"created":"2025-01-17T17:58:32.110Z","module":"logcollector","original":"Stopping Regular background program processing daemon...","provider":"syslog"},"log":{"file":{"path":"init.scope"}},"tags":["mvp"]}
 ```
 
-|Mandatory|Option|Description|Default|
-|:-:|--|--|--|
-|| file_wait | Time in milliseconds to recheck for available logs | 500 |
-|✔️| journald | Vector of journald fields to monitor |  |
-|✔️| journald.field | Journald field to be monitored |  |
-|✔️| journald.value | Value of the Journald field to be filtered by |  |
-|| journald.exact_match | Boolean that allows the value setting to be a substring instead of the exact filtering value | true |
-|| journald.ignore_if_missing | Boolean to ignore the filtering condition for logs without the specified field | false |
-|| journald.conditions | Vector of journald fields to filter to be applied simultaneously |  |
+| Mandatory | Option                     | Description                                                                                  | Default |
+| :-------: | -------------------------- | -------------------------------------------------------------------------------------------- | ------- |
+|           | read_interval              | Time in milliseconds to recheck for available logs                                           | 500     |
+|     ✔️     | journald                   | Vector of journald fields to monitor                                                         |         |
+|     ✔️     | journald.field             | Journald field to be monitored                                                               |         |
+|     ✔️     | journald.value             | Value of the Journald field to be filtered by                                                |         |
+|           | journald.exact_match       | Boolean that allows the value setting to be a substring instead of the exact filtering value | true    |
+|           | journald.ignore_if_missing | Boolean to ignore the filtering condition for logs without the specified field               | false   |
+|           | journald.conditions        | Vector of journald fields to filter to be applied simultaneously                             |         |
 
 #### Windows Collector
 
 ```yaml
 logcollector:
   enabled: true
-  channel_refresh: 5s
+  reload_interval: 1m
   windows:
     - channel: System
       query: Event[System/EventID = 37]
@@ -97,19 +97,19 @@ This collector gets logs from the Windows Event Viewer. It needs a channel and a
 {"event":{"created":"2025-01-07T21:41:27.712Z","module":"logcollector","original":"<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Time-Service' Guid='{06edcfeb-0fd0-4e53-acca-a6f8bbf81bcb}'/><EventID>37</EventID><Version>0</Version><Level>4</Level><Task>0</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2025-01-07T21:41:26.8876581Z'/><EventRecordID>13597</EventRecordID><Correlation/><Execution ProcessID='12848' ThreadID='14956'/><Channel>System</Channel><Computer>HOSTNAME</Computer><Security UserID='S-1-5-19'/></System><EventData Name='TMP_EVENT_TIME_SOURCE_REACHABLE'><Data Name='TimeSource'>time.windows.com,0x8 (ntp.m|0x8|0.0.0.0:123-&gt;40.444.4.444:444)</Data></EventData></Event>","provider":"syslog"},"log":{"file":{"path":"System"}},"tags":["mvp"]}
 ```
 
-|Mandatory|Option|Description|Default|
-|:-:|--|--|--|
-|| channel_refresh | Time in milliseconds to recheck for available logs | 5000 |
-|✔️| windows | Vector of readers to subscribe |  |
-|✔️| windows.channel | Channel name to be used for subscription |  |
-|✔️| windows.query | Query to apply to the channel |  |
+| Mandatory | Option          | Description                                       | Default |
+| :-------: | --------------- | ------------------------------------------------- | ------- |
+|           | reload_interval | Time in milliseconds to recheck for subscriptions | 60000   |
+|     ✔️     | windows         | Vector of readers to subscribe                    |         |
+|     ✔️     | windows.channel | Channel name to be used for subscription          |         |
+|     ✔️     | windows.query   | Query to apply to the channel                     |         |
 
 #### macOS (ULS) Collector
 
 ```yaml
 logcollector:
   enabled: true
-  file_wait: 500ms
+  read_interval: 500ms
   macos:
     - query: process == "sshd" OR message CONTAINS "invalid"
       level: info
@@ -119,6 +119,7 @@ logcollector:
 This collector gets logs from macOS through the Unified Logging System. It needs a query, a level, and a type to work.
 
 ```json
+{"agent":{"groups":[],"host":{"architecture":"x86_64","hostname":"HOSTNAME","ip":["LOCALIP","4444:4444:4444:4444:4444:44444:4444:4444","127.0.0.1","::1"],"os":{"name":"macOS","type":"Unknown","version":"15"}},"id":"4444-4444-4444-4444-ae5a7d59936c","name":"","type":"Endpoint","version":"5.0.0"}}
 {"module":"logcollector","type":"macos"}
 {"event":{"created":"2025-01-17T20:40:56.072Z","module":"logcollector","original":"2025-01-17 20:40:55 +0000 Setting mfgr data:<private> len:9 id:4C","provider":"syslog"},"log":{"file":{"path":"macos"}},"tags":["mvp"]}
 {"module":"logcollector","type":"macos"}
@@ -129,13 +130,13 @@ This collector gets logs from macOS through the Unified Logging System. It needs
 {"event":{"created":"2025-01-17T20:40:56.073Z","module":"logcollector","original":"2025-01-17 20:40:55 +0000 Device found changed: CBDevice 555E3FA6-AE3A-412A-6C97-2E7E2A069AD3, BDA 60:06:E3:8F:14:AF, Nm 'Bluetooth Device', DsFl 0x40 < NearbyInfo >, RSSI -44, Ch 37, AdTsMC <28588540497>, AMfD <4c 00 10 05 2c 98 bc 13 ff>, nbIAT <bc 13 ff>, nbIF 0xCA < Ranging AUE AT Duet >, CF 0x200000000 < RSSI >","provider":"syslog"},"log":{"file":{"path":"macos"}},"tags":["mvp"]}
 ```
 
-|Mandatory|Option|Description|Default|
-|:-:|--|--|--|
-|| file_wait | Time in milliseconds to recheck for available logs | 500 |
-|✔️| macos | Vector of queries to filter macOS logs |  |
-|✔️| macos.query | Predicate to filter logs |  |
-|✔️| macos.level | Log verbosity level: debug, info, notice, error or fault |  |
-|✔️| macos.type | Limits the log type; possible values (combinable): activity, log, trace |  |
+| Mandatory | Option        | Description                                                             | Default |
+| :-------: | ------------- | ----------------------------------------------------------------------- | ------- |
+|           | read_interval | Time in milliseconds to recheck for available logs                      | 500     |
+|     ✔️     | macos         | Vector of queries to filter macOS logs                                  |         |
+|     ✔️     | macos.query   | Predicate to filter logs                                                |         |
+|     ✔️     | macos.level   | Log verbosity level: debug, info, notice, error or fault                |         |
+|     ✔️     | macos.type    | Limits the log type; possible values (combinable): activity, log, trace |         |
 
 ## Class Diagram
 

--- a/etc/config/wazuh-agent.yml
+++ b/etc/config/wazuh-agent.yml
@@ -23,4 +23,4 @@ logcollector:
   localfiles:
     - /var/log/auth.log
   reload_interval: 1m
-  file_wait: 500ms
+  read_interval: 500ms

--- a/src/agent/configuration_parser/tests/configuration_parser_test.cpp
+++ b/src/agent/configuration_parser/tests/configuration_parser_test.cpp
@@ -35,7 +35,7 @@ protected:
                 localfiles:
                 - /var/log/other.log
                 reload_interval: 120
-                file_wait: 1000
+                read_interval: 1000
         )";
         outFile.close();
     }
@@ -56,7 +56,7 @@ protected:
         m_tempConfigFilePath = "temp_wazuh-agent.yml";
 
         std::ofstream outFile(m_tempConfigFilePath);
-        // This string does not respect the yaml format in the line of the file_wait field, the field is misaligned.
+        // This string does not respect the yaml format in the line of the read_interval field, the field is misaligned.
         // With this case we want it to fail when parsing the file.
         outFile << R"(
             agent:
@@ -70,7 +70,7 @@ protected:
                 localfiles:
                 - /var/log/other.log
                 reload_interval: 120
-                  file_wait: 1000
+                  read_interval: 1000
         )";
         outFile.close();
     }
@@ -336,13 +336,13 @@ TEST(ConfigurationParser, GetConfigMultiNode)
           - /var/log/auth.log
           - /var/log/other.log
           reload_interval: 60
-          file_wait: 500
+          read_interval: 500
     )";
     const auto parserStr = std::make_unique<configuration::ConfigurationParser>(strConfig);
     const auto ret = parserStr->GetConfig<std::vector<std::string>>("agent_array", "array_manager_ip")
                          .value_or(std::vector<std::string> {});
     const auto retEnabled = parserStr->GetConfig<bool>("logcollector", "enabled").value_or(false);
-    const auto retFileWait = parserStr->GetConfig<int>("logcollector", "file_wait").value_or(0);
+    const auto retFileWait = parserStr->GetConfig<int>("logcollector", "read_interval").value_or(0);
     const auto retLocalFiles = parserStr->GetConfig<std::vector<std::string>>("logcollector", "localfiles")
                                    .value_or(std::vector<std::string> {});
     ASSERT_EQ(ret[0], "192.168.0.0");
@@ -373,7 +373,7 @@ TEST_F(ConfigurationParserFileTest, ValidConfigFileLoadsCorrectly)
         EXPECT_FALSE(parser->GetConfig<bool>("inventory", "enabled").value_or(true));
         EXPECT_EQ(parser->GetConfig<int>("inventory", "interval").value_or(0), 7200);
         EXPECT_FALSE(parser->GetConfig<bool>("logcollector", "enabled").value_or(true));
-        EXPECT_EQ(parser->GetConfig<int>("logcollector", "file_wait").value_or(0), 1000);
+        EXPECT_EQ(parser->GetConfig<int>("logcollector", "read_interval").value_or(0), 1000);
     }
     catch (const std::exception& e)
     {
@@ -394,7 +394,7 @@ TEST_F(ConfigurationParserInvalidYamlFileTest, InvalidConfigFileLoadsDefault)
         EXPECT_TRUE(parser->GetConfig<bool>("inventory", "enabled").value_or(true));
         EXPECT_EQ(parser->GetConfig<int>("inventory", "interval").value_or(3600), 3600);
         EXPECT_TRUE(parser->GetConfig<bool>("logcollector", "enabled").value_or(true));
-        EXPECT_EQ(parser->GetConfig<int>("logcollector", "file_wait").value_or(500), 500);
+        EXPECT_EQ(parser->GetConfig<int>("logcollector", "read_interval").value_or(500), 500);
     }
     catch (const std::exception& e)
     {

--- a/src/agent/tests/agent_test.cpp
+++ b/src/agent/tests/agent_test.cpp
@@ -81,7 +81,7 @@ logcollector:
   localfiles:
     - /var/log/auth.log
   reload_interval: 1m
-  file_wait: 500ms
+  read_interval: 500ms
 )";
         configFilePath.close();
     }

--- a/src/modules/logcollector/src/logcollector.cpp
+++ b/src/modules/logcollector/src/logcollector.cpp
@@ -78,7 +78,7 @@ void Logcollector::Setup(std::shared_ptr<const configuration::ConfigurationParse
 
 void Logcollector::SetupFileReader(const std::shared_ptr<const configuration::ConfigurationParser> configurationParser)
 {
-    auto fileWait = configurationParser->GetConfig<std::time_t>("logcollector", "file_wait")
+    auto fileWait = configurationParser->GetConfig<std::time_t>("logcollector", "read_interval")
                         .value_or(config::logcollector::DEFAULT_FILE_WAIT);
 
     auto reloadInterval = configurationParser->GetConfig<std::time_t>("logcollector", "reload_interval")

--- a/src/modules/logcollector/src/logcollector_osx.cpp
+++ b/src/modules/logcollector/src/logcollector_osx.cpp
@@ -42,7 +42,7 @@ namespace logcollector
     void Logcollector::AddPlatformSpecificReader(
         const std::shared_ptr<const configuration::ConfigurationParser> configurationParser)
     {
-        const auto fileWait = configurationParser->GetConfig<time_t>("logcollector", "file_wait")
+        const auto fileWait = configurationParser->GetConfig<time_t>("logcollector", "read_interval")
                                   .value_or(config::logcollector::DEFAULT_FILE_WAIT);
 
         auto macosConfig =

--- a/src/modules/logcollector/src/logcollector_unix.cpp
+++ b/src/modules/logcollector/src/logcollector_unix.cpp
@@ -12,7 +12,7 @@ namespace logcollector
         auto journaldConfigs = configurationParser->GetConfig<YAML::Node>("logcollector", "journald")
                                    .value_or(YAML::Node(YAML::NodeType::Sequence));
 
-        auto fileWait = configurationParser->GetConfig<std::time_t>("logcollector", "file_wait")
+        auto fileWait = configurationParser->GetConfig<std::time_t>("logcollector", "read_interval")
                             .value_or(config::logcollector::DEFAULT_FILE_WAIT);
 
         for (const auto& config : journaldConfigs)

--- a/src/modules/logcollector/src/logcollector_win.cpp
+++ b/src/modules/logcollector/src/logcollector_win.cpp
@@ -14,7 +14,7 @@ namespace logcollector
     void Logcollector::AddPlatformSpecificReader(
         std::shared_ptr<const configuration::ConfigurationParser> configurationParser)
     {
-        const auto refreshInterval = configurationParser->GetConfig<time_t>("logcollector", "channel_refresh")
+        const auto refreshInterval = configurationParser->GetConfig<time_t>("logcollector", "reload_interval")
                                          .value_or(config::logcollector::DEFAULT_CHANNEL_REFRESH_INTERVAL);
 
         auto windowsConfig =

--- a/src/modules/logcollector/tests/unit/logcollector_test.cpp
+++ b/src/modules/logcollector/tests/unit/logcollector_test.cpp
@@ -34,7 +34,7 @@ TEST(Logcollector, SetupFileReader)
         - /var/log/auth.log
         - /var/log/syslog
       reload_interval: 60
-      file_wait: 500
+      read_interval: 500
     )";
 
     std::shared_ptr<IReader> capturedReader1;

--- a/src/modules/logcollector/tests/unit/macos_reader/logcollector_osx_test.cpp
+++ b/src/modules/logcollector/tests/unit/macos_reader/logcollector_osx_test.cpp
@@ -43,7 +43,7 @@ INSTANTIATE_TEST_SUITE_P(Configurations,
         logcollector:
           enabled: true
           reload_interval: 60
-          file_wait: 500
+          read_interval: 500
           macos:
             - query: process == "sshd" OR message CONTAINS "invalid"
               level: info


### PR DESCRIPTION
## Description

This PR includes 2 modifications in logcollector settings:
- Setting `file_wait` is renamed to `read_interval`.
- Setting `channel_refresh` is replaced by `reload_interval`.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X