### PR TITLE
Adapt command arguments to parse a JSON object based on the command name

### DIFF
--- a/docs/ref/commands.md
+++ b/docs/ref/commands.md
@@ -1,0 +1,65 @@
+# Commands
+
+This section describes the defined commands that the agent can execute and the structure they must follow.
+
+## Centralized Configuration
+
+### **`set-group`**
+
+This centralized configuration command is responsible for assigning the groups to which the agent belongs. Each command received must include the complete list of groups in its parameters, including any previously assigned groups, if any, as well as the new groups. If this list of groups is empty, all previously assigned groups will be removed.
+
+The execution of this command triggers the download of the configuration files for each group and subsequently initiates a reload of the configuration and modules to apply the new settings.
+
+```json
+{
+    "action":
+    {
+        "args":
+        {
+            "groups":
+            [
+                "group_1",
+                "group_2",
+                "...",
+                "group_N"
+            ],
+        },
+        "name": "set-group",
+        "version": "5.0.0"
+    },
+    "source": "Users/Services",
+    "document_id": "A8-62pMBBmC6Jrvqj9kW",
+    "user": "Management API",
+    "target":
+    {
+        "id": "d5b250c4-dfa1-4d94-827f-9f99210dbe6c",
+        "type": "agent"
+    }
+}
+```
+
+### **`update-group`**
+
+This centralized configuration command is responsible for updating the groups to which the agent belongs. This command does not require any arguments.
+
+Executing this command triggers a reload of the configuration and modules to ensure the new settings are applied.
+
+```json
+{
+    "action":
+    {
+        "args":
+        {},
+        "name": "update-group",
+        "version": "5.0.0"
+    },
+    "source": "Users/Services",
+    "document_id": "A8-62pMBBmC6Jrvqj9kW",
+    "user": "Management API",
+    "target":
+    {
+        "id": "d5b250c4-dfa1-4d94-827f-9f99210dbe6c",
+        "type": "agent"
+    }
+}
+```

--- a/src/agent/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/agent/centralized_configuration/src/centralized_configuration.cpp
@@ -19,7 +19,15 @@ namespace centralized_configuration
                 if (m_setGroupIdFunction && m_downloadGroupFilesFunction && m_validateFileFunction &&
                     m_reloadModulesFunction)
                 {
-                    groupIds = parameters.get<std::vector<std::string>>();
+                    groupIds = parameters.at("groups").get<std::vector<std::string>>();
+                    if (!std::all_of(
+                            groupIds.begin(), groupIds.end(), [](const std::string& id) { return !id.empty(); }))
+                    {
+                        LogWarn("Group name can not be an empty string.");
+                        co_return module_command::CommandExecutionResult {
+                            module_command::Status::FAILURE,
+                            "CentralizedConfiguration group set failed, a group name can not be an empty string."};
+                    }
 
                     if (!m_setGroupIdFunction(groupIds))
                     {

--- a/src/agent/command_handler/include/command_handler.hpp
+++ b/src/agent/command_handler/include/command_handler.hpp
@@ -61,6 +61,8 @@ namespace command_handler
                     continue;
                 }
 
+                LogDebug("Processing command: {}({})", cmd.value().Command, cmd.value().Parameters.dump());
+
                 if (!CheckCommand(cmd.value()))
                 {
                     cmd.value().ExecutionResult.ErrorCode = module_command::Status::FAILURE;

--- a/src/agent/src/message_queue_utils.cpp
+++ b/src/agent/src/message_queue_utils.cpp
@@ -63,7 +63,7 @@ std::optional<module_command::CommandEntry> GetCommandFromQueue(std::shared_ptr<
 
     std::string id;
     std::string command;
-    nlohmann::json parameters = nlohmann::json::array();
+    nlohmann::json parameters = nlohmann::json::object();
 
     if (jsonData.contains("document_id") && jsonData["document_id"].is_string())
     {
@@ -76,12 +76,9 @@ std::optional<module_command::CommandEntry> GetCommandFromQueue(std::shared_ptr<
         {
             command = jsonData["action"]["name"].get<std::string>();
         }
-        if (jsonData["action"].contains("args") && jsonData["action"]["args"].is_array())
+        if (jsonData["action"].contains("args") && jsonData["action"]["args"].is_object())
         {
-            for (const auto& arg : jsonData["action"]["args"])
-            {
-                parameters.push_back(arg);
-            }
+            parameters = jsonData["action"]["args"];
         }
     }
 

--- a/src/agent/tests/message_queue_utils_test.cpp
+++ b/src/agent/tests/message_queue_utils_test.cpp
@@ -9,7 +9,7 @@
 #include <nlohmann/json.hpp>
 
 const nlohmann::json BASE_DATA_CONTENT =
-    R"({"document_id":"112233", "action":{"name":"command_test","args":["parameters_test"]}})"_json;
+    R"({"document_id":"112233", "action":{"name":"command_test","args":{"parameters":["parameters_test"]}}})"_json;
 
 const auto FUNC = []<typename T>([[maybe_unused]] const std::string&,
                                  [[maybe_unused]] const std::string&) -> std::optional<T>
@@ -206,8 +206,8 @@ TEST_F(MessageQueueUtilsTest, GetCommandFromQueueTest)
 
     ASSERT_EQ(cmd.has_value() ? cmd.value().Id : "", "112233");
     ASSERT_EQ(cmd.has_value() ? cmd.value().Command : "", "command_test");
-    ASSERT_EQ(cmd.has_value() ? cmd.value().Parameters : nlohmann::json::array({""}),
-              nlohmann::json::array({"parameters_test"}));
+    ASSERT_EQ(cmd.has_value() ? cmd.value().Parameters : nlohmann::json::object({"{}"}),
+              R"({"parameters":["parameters_test"]})"_json);
     ASSERT_EQ(cmd.has_value() ? cmd.value().ExecutionResult.ErrorCode : module_command::Status::UNKNOWN,
               module_command::Status::IN_PROGRESS);
 }

--- a/src/tests/mock-server/config/commands.groovy
+++ b/src/tests/mock-server/config/commands.groovy
@@ -11,13 +11,15 @@ def generateUUIDv7() {
 }
 
 def actions = [
-    ["name": "set-group", "version": "v5.0.0", "args": ["validYaml", "invalidYaml"]],
-    ["name": "set-group", "version": "v5.0.0", "args": []],
-    ["name": "set-group", "version": "v5.0.0", "args": [""]],
-    ["name": "set-group", "version": "v5.0.0", "args": ["validYaml", 8]],
-    ["name": "set-group", "version": "v5.0.0", "args": ["validYaml"]],
-    ["name": "update-group", "version": "v5.0.0", "args": ["noNeedArgs"]],
-    ["name": "update-group", "version": "v5.0.0"],
+    ["name": "set-group", "version": "v5.0.0", "args": ["groups": ["validYaml", "invalidYaml"]]],
+    ["name": "set-group", "version": "v5.0.0", "args": ["groups": []]],
+    ["name": "set-group", "version": "v5.0.0", "args": ["groups": [""]]],
+    ["name": "set-group", "version": "v5.0.0", "args": ["groups": ["validYaml", 8]]],
+    ["name": "set-group", "version": "v5.0.0", "args": ["groups": ["validYaml"]]],
+    ["name": "set-group", "version": "v5.0.0"],
+    ["name": "set-group", "version": "v5.0.0", "args": ["other": "noNeedArgs"]],
+    ["name": "set-group", "version": "v5.0.0", "args": ["groups": ["validYaml"],"other": "noNeedArgs"]],
+    ["name": "update-group", "version": "v5.0.0", "args": ["groups": ["noNeedArgs"]]],
     ["name": "update-group", "version": "v5.0.0", "args": ""]
 ]
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/486|

This PR introduces the necessary changes to parse a command with its arguments in JSON object format instead of an array, as previously used. To achieve this, the method of extracting commands from the queue has been modified, along with the function that validates commands. Additionally, a more detailed structure for each command's requirements has been defined, based on its name.