### PR TITLE
Change command name update group to fetch config

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -23,6 +23,8 @@
   - [Packages](ref/getting-started/packages.md)
   - [Installation](ref/getting-started/installation.md)
 - [Configuration](ref/configuration.md)
+- [Messages](ref/messages.md)
+- [Commands](ref/commands.md)
 - [Modules](ref/modules/README.md)
   - [File Integrity monitoring](ref/modules/fim/README.md)
     - [Architecture](ref/modules/fim/architecture.md)

--- a/docs/ref/commands.md
+++ b/docs/ref/commands.md
@@ -38,9 +38,9 @@ The execution of this command triggers the download of the configuration files f
 }
 ```
 
-### **`update-group`**
+### **`fetch-config`**
 
-This centralized configuration command is responsible for updating the groups to which the agent belongs. This command does not require any arguments.
+This centralized configuration command is responsible for fetching the configuration of the groups to which the agent belongs. This command does not require any arguments.
 
 Executing this command triggers a reload of the configuration and modules to ensure the new settings are applied.
 
@@ -50,7 +50,7 @@ Executing this command triggers a reload of the configuration and modules to ens
     {
         "args":
         {},
-        "name": "update-group",
+        "name": "fetch-config",
         "version": "5.0.0"
     },
     "source": "Users/Services",

--- a/src/agent/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/agent/centralized_configuration/src/centralized_configuration.cpp
@@ -76,7 +76,7 @@ namespace centralized_configuration
                         "CentralizedConfiguration group set failed, error while cleaning the shared directory"};
                 }
             }
-            else if (command == module_command::UPDATE_GROUP_COMMAND)
+            else if (command == module_command::FETCH_CONFIG_COMMAND)
             {
                 groupIds = m_getGroupIdFunction();
             }

--- a/src/agent/centralized_configuration/tests/centralized_configuration_tests.cpp
+++ b/src/agent/centralized_configuration/tests/centralized_configuration_tests.cpp
@@ -223,10 +223,10 @@ TEST(CentralizedConfiguration, ExecuteCommandHandlesRecognizedCommands)
                                         "CentralizedConfiguration set-group done.");
 
             co_await TestExecuteCommand(centralizedConfiguration,
-                                        "update-group",
+                                        "fetch-config",
                                         {},
                                         module_command::Status::SUCCESS,
-                                        "CentralizedConfiguration update-group done.");
+                                        "CentralizedConfiguration fetch-config done.");
 
             co_await TestExecuteCommand(centralizedConfiguration,
                                         "unknown-command",
@@ -342,10 +342,10 @@ TEST(CentralizedConfiguration, SetFunctionsAreCalledAndReturnsCorrectResultsForU
             EXPECT_FALSE(wasDownloadGroupFilesFunctionCalled);
 
             co_await TestExecuteCommand(centralizedConfiguration,
-                                        "update-group",
+                                        "fetch-config",
                                         {},
                                         module_command::Status::SUCCESS,
-                                        "CentralizedConfiguration update-group done.");
+                                        "CentralizedConfiguration fetch-config done.");
 
             EXPECT_TRUE(wasGetGroupIdFunctionCalled);
             EXPECT_TRUE(wasDownloadGroupFilesFunctionCalled);

--- a/src/agent/command_handler/include/command_entry/command_entry.hpp
+++ b/src/agent/command_handler/include/command_entry/command_entry.hpp
@@ -9,7 +9,7 @@ namespace module_command
 {
     /// @brief Commands
     const std::string SET_GROUP_COMMAND = "set-group";
-    const std::string UPDATE_GROUP_COMMAND = "update-group";
+    const std::string FETCH_CONFIG_COMMAND = "fetch-config";
 
     /// @brief Commands arguments
     const std::string GROUPS_ARG = "groups";

--- a/src/agent/command_handler/src/command_handler.cpp
+++ b/src/agent/command_handler/src/command_handler.cpp
@@ -15,7 +15,7 @@ namespace
          CommandDetails {module_command::CENTRALIZED_CONFIGURATION_MODULE,
                          module_command::CommandExecutionMode::SYNC,
                          {{module_command::GROUPS_ARG, nlohmann::json::value_t::array}}}},
-        {module_command::UPDATE_GROUP_COMMAND,
+        {module_command::FETCH_CONFIG_COMMAND,
          CommandDetails {
              module_command::CENTRALIZED_CONFIGURATION_MODULE, module_command::CommandExecutionMode::SYNC, {}}}};
 } // namespace

--- a/src/tests/mock-server/config/commands.groovy
+++ b/src/tests/mock-server/config/commands.groovy
@@ -19,8 +19,8 @@ def actions = [
     ["name": "set-group", "version": "v5.0.0"],
     ["name": "set-group", "version": "v5.0.0", "args": ["other": "noNeedArgs"]],
     ["name": "set-group", "version": "v5.0.0", "args": ["groups": ["validYaml"],"other": "noNeedArgs"]],
-    ["name": "update-group", "version": "v5.0.0", "args": ["groups": ["noNeedArgs"]]],
-    ["name": "update-group", "version": "v5.0.0", "args": ""]
+    ["name": "fetch-config", "version": "v5.0.0", "args": ["groups": ["noNeedArgs"]]],
+    ["name": "fetch-config", "version": "v5.0.0", "args": ""]
 ]
 
 def numCommands = new Random().nextInt(3)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/540|

In this PR, the command name update-group is renamed to fetch-config.

