### PR TITLE
Add unit tests for self restart

### DIFF
--- a/src/agent/restart_handler/CMakeLists.txt
+++ b/src/agent/restart_handler/CMakeLists.txt
@@ -14,8 +14,15 @@ else()
 endif()
 
 add_library(RestartHandler ${SOURCES})
-target_include_directories(RestartHandler PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(RestartHandler
+                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
+                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(RestartHandler PUBLIC Boost::asio CommandEntry PRIVATE Logger)
 
 include(../../cmake/ConfigureTarget.cmake)
 configure_target(RestartHandler)
+
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/src/agent/restart_handler/include/restart_handler.hpp
+++ b/src/agent/restart_handler/include/restart_handler.hpp
@@ -15,6 +15,9 @@ namespace restart_handler
         /// @brief A list of command line arguments used to restart the agent process.
         static std::vector<char*> startupCmdLineArgs;
 
+        /// @brief Timeout for the restart operation until force a hard restart.
+        static const int timeoutInSecs = 30;
+
         /// @brief RestartHandler class.
         explicit RestartHandler();
 

--- a/src/agent/restart_handler/src/restart_handler_unix.cpp
+++ b/src/agent/restart_handler/src/restart_handler_unix.cpp
@@ -1,6 +1,5 @@
-#include "restart_handler_unix.hpp"
-#include <fstream>
 #include <logger.hpp>
+#include <restart_handler_unix.hpp>
 
 #include <chrono>
 #include <thread>
@@ -31,12 +30,9 @@ namespace restart_handler
         }
     }
 
-    void StopAgent()
+    void StopAgent(const pid_t pid, const int timeoutInSecs)
     {
-        const int timeoutInSecs = 30;
         const time_t startTime = time(nullptr);
-
-        pid_t pid = getppid();
 
         // Shutdown Gracefully
         kill(pid, SIGTERM);
@@ -45,7 +41,7 @@ namespace restart_handler
         {
             if (kill(pid, 0) != 0)
             {
-                LogInfo("Agent gracefully stopped.");
+                LogInfo("Agent stopped.");
                 break;
             }
 
@@ -70,7 +66,7 @@ namespace restart_handler
         else if (pid == 0)
         {
             // Child process
-            StopAgent();
+            StopAgent(getppid(), RestartHandler::timeoutInSecs);
 
             LogInfo("Starting wazuh agent in a new process.");
 

--- a/src/agent/restart_handler/src/restart_handler_unix.hpp
+++ b/src/agent/restart_handler/src/restart_handler_unix.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <boost/asio/awaitable.hpp>
-#include <command_entry.hpp>
 #include <restart_handler.hpp>
 #include <vector>
 
@@ -13,11 +12,15 @@ namespace restart_handler
     /// @return true if systemctl is available and running as a systemd service, otherwise returns false.
     bool UsingSystemctl();
 
-    /// @brief Stops the agent by terminating the child process.
+    /// @brief Stops the agent by terminating its process.
     ///
-    /// This function sends a SIGTERM signal to the agent process to stop it. If the agent process
-    /// does not stop within a specified timeout period (30 seconds), it forces termination with a SIGKILL signal.
-    void StopAgent();
+    /// This function sends a SIGTERM signal to the agent process to request its termination. If the agent
+    /// process does not stop within the specified timeout period (30 seconds), a SIGKILL signal is sent to force
+    /// termination.
+    ///
+    /// @param pid The process ID of the agent to be stopped.
+    /// @param timeout The maximum time (in seconds) to wait for the agent to stop before forcing termination.
+    void StopAgent(const pid_t pid, const int timeout);
 
     /// @brief Restarts the module by forking a new process.
     ///

--- a/src/agent/restart_handler/tests/CMakeLists.txt
+++ b/src/agent/restart_handler/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+find_package(GTest CONFIG REQUIRED)
+
+if(UNIX)
+    add_executable(restart_handler_test restart_handler_tests.cpp)
+    configure_target(restart_handler_test)
+    target_include_directories(restart_handler_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+    target_link_libraries(restart_handler_test PRIVATE RestartHandler GTest::gtest GTest::gmock GTest::gmock_main)
+    add_test(NAME RestartHandler COMMAND restart_handler_test)
+endif()

--- a/src/agent/restart_handler/tests/restart_handler_tests.cpp
+++ b/src/agent/restart_handler/tests/restart_handler_tests.cpp
@@ -1,0 +1,165 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <restart_handler_unix.hpp>
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <chrono>
+#include <csignal>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace testing;
+
+namespace
+{
+    // NOLINTBEGIN(cppcoreguidelines-avoid-reference-signal-handler-definitions)
+    void SigchldHandler(int status)
+    {
+        while (waitpid(-1, &status, WNOHANG) > 0)
+        {
+            // The child process has terminated, no action needed here
+        }
+    }
+
+    // NOLINTEND(cppcoreguidelines-avoid-reference-signal-handler-definitions)
+
+    void SigtermHandler([[maybe_unused]] int signum)
+    {
+        exit(0);
+    }
+} // namespace
+
+TEST(TestUsingSystemctl, ReturnsTrueWhenSystemctlIsAvailable)
+{
+    setenv("INVOCATION_ID", "testing", 1);
+    if (0 == std::system("which systemctl > /dev/null 2>&1"))
+    {
+        EXPECT_TRUE(restart_handler::UsingSystemctl());
+    }
+    else
+    {
+        EXPECT_FALSE(restart_handler::UsingSystemctl());
+    }
+}
+
+TEST(TestUsingSystemctl, ReturnsFalseWhenSystemctlIsNotAvailable)
+{
+    unsetenv("INVOCATION_ID");
+    EXPECT_FALSE(restart_handler::UsingSystemctl());
+}
+
+TEST(StopAgentTest, GratefullyStop)
+{
+    testing::internal::CaptureStdout();
+    signal(SIGCHLD, SigchldHandler);
+
+    pid_t pid = fork();
+
+    if (pid < 0)
+    {
+        FAIL() << "Fork failed!";
+    }
+    if (pid == 0)
+    {
+        // Child process (Simulate agent running)
+        const int timeout = 60;
+        std::this_thread::sleep_for(std::chrono::seconds(timeout));
+    }
+
+    // Parent process
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    const int timeout = 10;
+    restart_handler::StopAgent(pid, timeout);
+
+    std::string stdout_logs = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(stdout_logs.find("Timeout reached! Forcing agent process termination."), std::string::npos);
+    EXPECT_NE(stdout_logs.find("Agent stopped"), std::string::npos);
+}
+
+TEST(StopAgentTest, ForceStop)
+{
+    testing::internal::CaptureStdout();
+    signal(SIGCHLD, SigchldHandler);
+    signal(SIGTERM, SIG_IGN); // Ignore SIGTERM
+
+    pid_t pid = fork();
+
+    if (pid < 0)
+    {
+        FAIL() << "Fork failed!";
+    }
+    if (pid == 0)
+    {
+        // Child process (Simulate agent running)
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        std::this_thread::sleep_for(std::chrono::seconds(60));
+    }
+
+    // Parent process
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    restart_handler::StopAgent(pid, 2);
+
+    std::string stdout_logs = testing::internal::GetCapturedStdout();
+    EXPECT_NE(stdout_logs.find("Timeout reached! Forcing agent process termination."), std::string::npos);
+    EXPECT_NE(stdout_logs.find("Agent stopped"), std::string::npos);
+}
+
+TEST(RestartWithForkTest, ShouldRestartUsingFork)
+{
+
+    testing::internal::CaptureStdout();
+    pid_t pid = fork();
+
+    if (pid < 0)
+    {
+        FAIL() << "Fork failed!";
+    }
+    if (pid == 0)
+    {
+        // Child process (Simulate agent running)
+        setsid();
+        signal(SIGTERM, SigtermHandler);
+
+        boost::asio::io_context io_context;
+
+        boost::asio::co_spawn(
+            io_context,
+            []() -> boost::asio::awaitable<void>
+            {
+                const char* args[] = {"/usr/bin/sleep", "3"};
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                restart_handler::RestartHandler::SetCommandLineArguments(2, const_cast<char**>(args));
+
+                const auto result = co_await restart_handler::RestartWithFork();
+            }(),
+            boost::asio::detached);
+
+        io_context.run();
+    }
+
+    // Parent process
+    int status {};
+    waitpid(pid, &status, 0);
+
+    std::string stdout_logs = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(stdout_logs.find("Agent stopped"), std::string::npos);
+    EXPECT_EQ(stdout_logs.find("Starting wazuh agent in a new process"), std::string::npos);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/438|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR introduces tests for the restart handler.


## Tests

```bash
cd build/agent/restart_handler/tests/ && ctest -VV
UpdateCTestConfiguration  from :/root/wazuh-agent/build/agent/restart_handler/tests/DartConfiguration.tcl
UpdateCTestConfiguration  from :/root/wazuh-agent/build/agent/restart_handler/tests/DartConfiguration.tcl
Test project /root/wazuh-agent/build/agent/restart_handler/tests
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: RestartHandler

1: Test command: /root/wazuh-agent/build/agent/restart_handler/tests/restart_handler_test
1: Working Directory: /root/wazuh-agent/build/agent/restart_handler/tests
1: Test timeout computed to be: 10000000
1: [==========] Running 5 tests from 3 test suites.
1: [----------] Global test environment set-up.
1: [----------] 2 tests from TestUsingSystemctl
1: [ RUN      ] TestUsingSystemctl.ReturnsTrueWhenSystemctlIsAvailable
1: [       OK ] TestUsingSystemctl.ReturnsTrueWhenSystemctlIsAvailable (1 ms)
1: [ RUN      ] TestUsingSystemctl.ReturnsFalseWhenSystemctlIsNotAvailable
1: [       OK ] TestUsingSystemctl.ReturnsFalseWhenSystemctlIsNotAvailable (0 ms)
1: [----------] 2 tests from TestUsingSystemctl (1 ms total)
1: 
1: [----------] 2 tests from StopAgentTest
1: [ RUN      ] StopAgentTest.GratefullyStop
1: [       OK ] StopAgentTest.GratefullyStop (2000 ms)
1: [ RUN      ] StopAgentTest.ForceStop
1: [       OK ] StopAgentTest.ForceStop (5000 ms)
1: [----------] 2 tests from StopAgentTest (7001 ms total)
1: 
1: [----------] 1 test from RestartWithForkTest
1: [ RUN      ] RestartWithForkTest.ShouldRestartUsingFork
1: [       OK ] RestartWithForkTest.ShouldRestartUsingFork (0 ms)
1: [----------] 1 test from RestartWithForkTest (0 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 5 tests from 3 test suites ran. (7003 ms total)
1: [  PASSED  ] 5 tests.
1/1 Test #1: RestartHandler ...................   Passed   11.01 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =  11.01 sec
```