### PR TITLE
Improve command execution in modules

### DIFF
--- a/src/agent/src/command_handler_utils.cpp
+++ b/src/agent/src/command_handler_utils.cpp
@@ -36,7 +36,7 @@ namespace
     {
         try
         {
-            constexpr auto timeout = std::chrono::minutes {60};
+            constexpr auto timeout = std::chrono::minutes {10};
             auto timer = std::make_shared<boost::asio::steady_timer>(co_await boost::asio::this_coro::executor);
             timer->expires_after(timeout);
             co_await timer->async_wait(boost::asio::use_awaitable);

--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -32,7 +32,7 @@ public:
     void Start();
     void Setup(std::shared_ptr<const configuration::ConfigurationParser> configurationParser);
     void Stop();
-    Co_CommandExecutionResult ExecuteCommand(const std::string command, const nlohmann::json parameters);
+    Co_CommandExecutionResult ExecuteCommand(const std::string command, const nlohmann::json parameters) const;
 
     const std::string& Name() const
     {

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -80,10 +80,20 @@ void Inventory::Stop()
 }
 
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
-Co_CommandExecutionResult Inventory::ExecuteCommand(const std::string command, const nlohmann::json)
+Co_CommandExecutionResult Inventory::ExecuteCommand(const std::string command, const nlohmann::json) const
 {
+    if (!m_enabled)
+    {
+        LogInfo("Inventory module is disabled.");
+        co_return module_command::CommandExecutionResult {module_command::Status::FAILURE, "Module is disabled"};
+    }
+    else if (m_stopping)
+    {
+        LogInfo("Inventory module is stopped.");
+        co_return module_command::CommandExecutionResult {module_command::Status::FAILURE, "Module is stopped"};
+    }
     LogInfo("Command: {}", command);
-    co_return module_command::CommandExecutionResult {module_command::Status::SUCCESS, "OK"};
+    co_return module_command::CommandExecutionResult {module_command::Status::SUCCESS, "Command not implemented yet"};
 }
 
 void Inventory::SetPushMessageFunction(const std::function<int(Message)>& pushMessage)

--- a/src/modules/logcollector/src/logcollector.cpp
+++ b/src/modules/logcollector/src/logcollector.cpp
@@ -104,8 +104,18 @@ void Logcollector::Stop()
 Co_CommandExecutionResult Logcollector::ExecuteCommand(const std::string command,
                                                        [[maybe_unused]] const nlohmann::json parameters)
 {
+    if (!m_enabled)
+    {
+        LogInfo("Logcollector module is disabled.");
+        co_return module_command::CommandExecutionResult {module_command::Status::FAILURE, "Module is disabled"};
+    }
+    else if (m_ioContext.stopped())
+    {
+        LogInfo("Logcollector module is stopped.");
+        co_return module_command::CommandExecutionResult {module_command::Status::FAILURE, "Module is stopped"};
+    }
     LogInfo("Logcollector command: ", command);
-    co_return module_command::CommandExecutionResult {module_command::Status::SUCCESS, "OK"};
+    co_return module_command::CommandExecutionResult {module_command::Status::SUCCESS, "Command not implemented yet"};
 }
 
 // NOLINTEND(performance-unnecessary-value-param)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/515|

## Description

This PR introduces changes to prevent the execution of commands in the Inventory and Logcollector modules when they are not ready, either because they are disabled or stopped due to a configuration reload.