### PR TITLE
Check access and validation of centralized configuration files

### DIFF
--- a/src/agent/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/agent/centralized_configuration/src/centralized_configuration.cpp
@@ -2,7 +2,27 @@
 #include <config.h>
 #include <logger.hpp>
 
+#include <chrono>
 #include <filesystem>
+#include <random>
+
+namespace
+{
+    std::string CreateTmpFilename()
+    {
+        constexpr int MIN_VALUE = 1000;
+        constexpr int MAX_VALUE = 9999;
+        std::random_device rd;
+        std::mt19937 generator(rd());
+        std::uniform_int_distribution<int> distribution(MIN_VALUE, MAX_VALUE);
+        int random = distribution(generator);
+
+        auto now = std::chrono::high_resolution_clock::now();
+        auto timestamp = now.time_since_epoch().count();
+
+        return std::to_string(timestamp) + "_" + std::to_string(random);
+    }
+} // namespace
 
 namespace centralized_configuration
 {
@@ -90,7 +110,8 @@ namespace centralized_configuration
             for (const auto& groupId : groupIds)
             {
                 const std::filesystem::path tmpGroupFile =
-                    m_fileSystemWrapper->temp_directory_path() / (groupId + config::DEFAULT_SHARED_FILE_EXTENSION);
+                    m_fileSystemWrapper->temp_directory_path() /
+                    (groupId + "_" + CreateTmpFilename() + config::DEFAULT_SHARED_FILE_EXTENSION);
 
                 const auto dlResult = co_await m_downloadGroupFilesFunction(groupId, tmpGroupFile.string());
 


### PR DESCRIPTION
## Description

Closes #514 

This PR aims to prevent collisions when downloading and validating the configuration for the same group simultaneously.

## Proposed Changes

A function is added to generate a random name for the configuration file. The file is validated using this random name, and if the validation is successful, it is renamed to its final name.

### Results and Evidence

```
[2025-01-29 08:11:20.965] [wazuh-agent] [debug] [DEBUG] [command_handler.cpp:72] [CommandsProcessingTask] Processing command: set-group({"groups":["validYaml","invalidYaml"]})
[2025-01-29 08:11:20.966] [wazuh-agent] [info] [INFO] [command_handler_utils.cpp:80] [DispatchCommand] Dispatching command set-group(CentralizedConfiguration)
[2025-01-29 08:11:20.968] [wazuh-agent] [trace] [TRACE] [centralized_configuration.cpp:120] [ExecuteCommand] Temporary group file path: /tmp/validYaml_1738134680968435153_2768.yml
[2025-01-29 08:11:20.975] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:232] [Co_PerformHttpRequest] Request /api/v1/files?file_name=validYaml.yml: Status 200
[2025-01-29 08:11:21.975] [wazuh-agent] [trace] [TRACE] [centralized_configuration.cpp:167] [ExecuteCommand] Final group file path: /etc/wazuh-agent/shared/validYaml.yml
[2025-01-29 08:11:21.975] [wazuh-agent] [trace] [TRACE] [centralized_configuration.cpp:120] [ExecuteCommand] Temporary group file path: /tmp/invalidYaml_1738134681975623359_1226.yml
[2025-01-29 08:11:21.981] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:232] [Co_PerformHttpRequest] Request /api/v1/files?file_name=invalidYaml.yml: Status 200
[2025-01-29 08:11:22.982] [wazuh-agent] [warning] [WARN] [centralized_configuration.cpp:133] [ExecuteCommand] Failed to validate the file for group 'invalidYaml', invalid group file received: /tmp/invalidYaml_1738134681975623359_1226.yml
[2025-01-29 08:11:22.991] [wazuh-agent] [info] [INFO] [command_handler.cpp:106] [CommandsProcessingTask] Done processing command: set-group(CentralizedConfiguration)
```
Trace messages were added for development purposes only.

### Artifacts Affected

Changes should be transparent to artifacts.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality - not apply
- [x] Configuration changes documented - not apply
- [x] Developer documentation reflects the changes - not apply
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues - not apply

<!--
Include any additional information relevant to the review process.
-->
