### PR TITLE
Change default SSL verification mode to `none`

### DIFF
--- a/docs/ref/security.md
+++ b/docs/ref/security.md
@@ -8,9 +8,9 @@ The agent now includes functionality to validate whether the server's certificat
 
 The agent supports three validation modes:
 
-- `full`: Verifies both that the certificate is signed by a trusted CA and that the SAN/CN belongs to the host being connected to (default)
+- `full`: Verifies both that the certificate is signed by a trusted CA and that the SAN/CN belongs to the host being connected to
 - `certificate`: Verifies only that the certificate is signed by a trusted CA
-- `none`: Skips all certificate validation
+- `none`: Skips all certificate validation (default)
 
 ### Usage
 

--- a/etc/config/wazuh-agent.yml
+++ b/etc/config/wazuh-agent.yml
@@ -2,7 +2,7 @@ agent:
   thread_count: 4
   server_url: https://localhost:27000
   retry_interval: 30s
-  verification_mode: none # TODO: change this setting to full
+  verification_mode: none
 events:
   batch_interval: 10s
   batch_size: 1MB

--- a/src/agent/src/main.cpp
+++ b/src/agent/src/main.cpp
@@ -1,5 +1,6 @@
 #include "process_options.hpp"
 
+#include <config.h>
 #include <logger.hpp>
 
 #include <boost/program_options.hpp>
@@ -60,14 +61,15 @@ int main(int argc, char* argv[])
 
         if (validOptions.count(OPT_REGISTER_AGENT) > 0)
         {
-            RegisterAgent(
-                validOptions.count(OPT_URL) ? validOptions[OPT_URL].as<std::string>() : "",
-                validOptions.count(OPT_USER) ? validOptions[OPT_USER].as<std::string>() : "",
-                validOptions.count(OPT_PASS) ? validOptions[OPT_PASS].as<std::string>() : "",
-                validOptions.count(OPT_KEY) ? validOptions[OPT_KEY].as<std::string>() : "",
-                validOptions.count(OPT_NAME) ? validOptions[OPT_NAME].as<std::string>() : "",
-                validOptions.count(OPT_CONFIG_FILE) ? validOptions[OPT_CONFIG_FILE].as<std::string>() : "",
-                validOptions.count(OPT_VERIFICATION_MODE) ? validOptions[OPT_VERIFICATION_MODE].as<std::string>() : "");
+            RegisterAgent(validOptions.count(OPT_URL) ? validOptions[OPT_URL].as<std::string>() : "",
+                          validOptions.count(OPT_USER) ? validOptions[OPT_USER].as<std::string>() : "",
+                          validOptions.count(OPT_PASS) ? validOptions[OPT_PASS].as<std::string>() : "",
+                          validOptions.count(OPT_KEY) ? validOptions[OPT_KEY].as<std::string>() : "",
+                          validOptions.count(OPT_NAME) ? validOptions[OPT_NAME].as<std::string>() : "",
+                          validOptions.count(OPT_CONFIG_FILE) ? validOptions[OPT_CONFIG_FILE].as<std::string>() : "",
+                          validOptions.count(OPT_VERIFICATION_MODE)
+                              ? validOptions[OPT_VERIFICATION_MODE].as<std::string>()
+                              : config::agent::DEFAULT_VERIFICATION_MODE);
         }
         else if (validOptions.count(OPT_STATUS) > 0)
         {

--- a/src/cmake/config.cmake
+++ b/src/cmake/config.cmake
@@ -24,7 +24,7 @@ set(DEFAULT_BATCH_INTERVAL 10000 CACHE STRING "Default Agent batch interval (10s
 
 set(DEFAULT_BATCH_SIZE 1000000ULL CACHE STRING "Default Agent batch size limit (1MB)")
 
-set(DEFAULT_VERIFICATION_MODE "full" CACHE STRING "Default Agent verification mode")
+set(DEFAULT_VERIFICATION_MODE "none" CACHE STRING "Default Agent verification mode")
 
 set(DEFAULT_LOGCOLLECTOR_ENABLED true CACHE BOOL "Default Logcollector enabled")
 


### PR DESCRIPTION
## Description  

This PR closes issue #560. According to the proposed changes, we have modified the default behavior of the agent when the server certificate verification option is not specified.  

## Proposed Changes  

- The agent no longer verifies the server certificate during registration unless explicitly set using the `--verification-mode` option.  
- The agent does not verify the certificate during authentication and data transmission unless the `verification_mode` option is explicitly set.  

### Results and Evidence  

After removing the `verification_mode` option from _wazuh-agent.yml_:  

#### Registration  

```sh
./wazuh-agent --config-file wazuh-agent.yml --register-agent --url https://localhost:55000 --user wazuh --password topsecret --name dummy
```  

- **Before:**  
   ```  
   [2025-01-30 13:33:48.367] [wazuh-agent] [warning] [WARN] [https_socket.hpp:57] [SetVerificationMode] Verification mode unknown, full mode is used.  
   [2025-01-30 13:33:48.367] [wazuh-agent] [error] [ERROR] [http_client.cpp:301] [PerformHttpRequest] Error: Error connecting to host: certificate verify failed (SSL routines)  
   [2025-01-30 13:33:48.367] [wazuh-agent] [warning] [WARN] [http_client.cpp:397] [AuthenticateWithUserPassword] Error: 500.  
   Failed to authenticate with the manager  
   wazuh-agent registration failed  
   ```  
- **Now:**  
   ```  
   wazuh-agent registered  
   ```  

#### Connection  

```sh
./wazuh-agent --config-file wazuh-agent.yml
```  

- **Before:**  
   ```  
   [2025-01-30 13:57:29.626] [wazuh-agent] [error] [ERROR] [http_client.cpp:301] [PerformHttpRequest] Error: Error connecting to host: certificate verify failed (SSL routines)  
   [2025-01-30 13:57:29.626] [wazuh-agent] [warning] [WARN] [http_client.cpp:353] [AuthenticateWithUuidAndKey] Error: 500.  
   [2025-01-30 13:57:29.626] [wazuh-agent] [warning] [WARN] [communicator.cpp:100] [SendAuthenticationRequest] Failed to authenticate with the manager. Retrying in 30 seconds.  
   ```  
- **Now:**  
   ```  
   [2025-01-30 13:58:04.129] [wazuh-agent] [info] [INFO] [process_options_unix.cpp:24] [StartAgent] Starting wazuh-agent  
   [2025-01-30 13:58:04.205] [wazuh-agent] [info] [INFO] [communicator.cpp:95] [SendAuthenticationRequest] Successfully authenticated with the manager.  
   ```  

### Artifacts Affected  

- _wazuh-agent_ on all supported platforms.  

### Configuration Changes  

- The configuration file remains unchanged, as the default value was already `none`.  
- If the `verification_mode` option is not explicitly defined, verification is now disabled (`none`).  

### Documentation Updates  

- The security guide has been updated to indicate that the default verification mode is now `none`.  
## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
