### PR TITLE
Avoid the use/creation of real databases in the UTs.

### DIFF
--- a/src/agent/agent_info/CMakeLists.txt
+++ b/src/agent/agent_info/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(AgentInfo src/agent_info.cpp src/agent_info_persistance.cpp)
 target_include_directories(AgentInfo PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(AgentInfo PUBLIC nlohmann_json::nlohmann_json Config PRIVATE Persistence Boost::uuid Logger)
+target_link_libraries(AgentInfo PUBLIC nlohmann_json::nlohmann_json Config Persistence PRIVATE Boost::uuid Logger)
 
 if(MSVC)
     target_link_libraries(AgentInfo PRIVATE bcrypt)

--- a/src/agent/agent_info/CMakeLists.txt
+++ b/src/agent/agent_info/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(nlohmann_json CONFIG REQUIRED)
 add_library(AgentInfo src/agent_info.cpp src/agent_info_persistance.cpp)
 target_include_directories(AgentInfo PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(AgentInfo PUBLIC nlohmann_json::nlohmann_json Config PRIVATE Persistence Boost::uuid Logger)
 
 if(MSVC)

--- a/src/agent/agent_info/CMakeLists.txt
+++ b/src/agent/agent_info/CMakeLists.txt
@@ -11,8 +11,8 @@ find_package(nlohmann_json CONFIG REQUIRED)
 add_library(AgentInfo src/agent_info.cpp src/agent_info_persistance.cpp)
 target_include_directories(AgentInfo PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(AgentInfo PUBLIC nlohmann_json::nlohmann_json Config Persistence PRIVATE Boost::uuid Logger)
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_link_libraries(AgentInfo PUBLIC nlohmann_json::nlohmann_json Config PRIVATE Persistence Boost::uuid Logger)
 
 if(MSVC)
     target_link_libraries(AgentInfo PRIVATE bcrypt)

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <agent_info_persistance.hpp>
 #include <config.h>
 #include <nlohmann/json.hpp>
 
@@ -8,6 +7,8 @@
 #include <memory>
 #include <string>
 #include <vector>
+
+class AgentInfoPersistance;
 
 /// @brief Stores and manages information about an agent.
 ///
@@ -32,7 +33,7 @@ public:
               std::function<nlohmann::json()> getOSInfo = nullptr,
               std::function<nlohmann::json()> getNetworksInfo = nullptr,
               bool agentIsRegistering = false,
-              std::unique_ptr<AgentInfoPersistance> persistence = nullptr);
+              std::shared_ptr<AgentInfoPersistance> persistence = nullptr);
 
     /// @brief Gets the agent's name.
     /// @return The agent's name.
@@ -146,6 +147,6 @@ private:
     /// @brief Specify if the agent is about to register.
     bool m_agentIsRegistering;
 
-    /// @brief Unique pointer to the agent info persistence instance.
-    std::unique_ptr<AgentInfoPersistance> m_persistence;
+    /// @brief Pointer to the agent info persistence instance.
+    std::shared_ptr<AgentInfoPersistance> m_persistence;
 };

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -29,7 +29,7 @@ public:
     /// @param getNetworksInfo Function to retrieve network information in JSON format.
     /// @param agentIsRegistering True if the agent is being registered, false otherwise.
     /// @param persistence Optional pointer to an AgentInfoPersistance object.
-    AgentInfo(std::string dbFolderPath = config::DEFAULT_DATA_PATH,
+    AgentInfo(const std::string& dbFolderPath = config::DEFAULT_DATA_PATH,
               std::function<nlohmann::json()> getOSInfo = nullptr,
               std::function<nlohmann::json()> getNetworksInfo = nullptr,
               bool agentIsRegistering = false,
@@ -116,9 +116,6 @@ private:
     /// @param networksJson JSON object containing network interface information.
     /// @return Vector of strings with the active IP addresses.
     std::vector<std::string> GetActiveIPAddresses(const nlohmann::json& networksJson) const;
-
-    /// @brief The agent's data folder path.
-    std::string m_dataFolderPath;
 
     /// @brief The agent's name.
     std::string m_name;

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <agent_info_persistance.hpp>
 #include <config.h>
 #include <nlohmann/json.hpp>
 
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -25,10 +27,12 @@ public:
     /// @param getOSInfo Function to retrieve OS information in JSON format.
     /// @param getNetworksInfo Function to retrieve network information in JSON format.
     /// @param agentIsRegistering True if the agent is being registered, false otherwise.
+    /// @param persistence Optional pointer to an AgentInfoPersistance object.
     AgentInfo(std::string dbFolderPath = config::DEFAULT_DATA_PATH,
               std::function<nlohmann::json()> getOSInfo = nullptr,
               std::function<nlohmann::json()> getNetworksInfo = nullptr,
-              bool agentIsRegistering = false);
+              bool agentIsRegistering = false,
+              std::unique_ptr<AgentInfoPersistance> persistence = nullptr);
 
     /// @brief Gets the agent's name.
     /// @return The agent's name.
@@ -141,4 +145,7 @@ private:
 
     /// @brief Specify if the agent is about to register.
     bool m_agentIsRegistering;
+
+    /// @brief Unique pointer to the agent info persistence instance.
+    std::unique_ptr<AgentInfoPersistance> m_persistence;
 };

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -17,14 +17,13 @@ namespace
     const std::string PRODUCT_NAME = "WazuhXDR";
 } // namespace
 
-AgentInfo::AgentInfo(std::string dbFolderPath,
+AgentInfo::AgentInfo(const std::string& dbFolderPath,
                      std::function<nlohmann::json()> getOSInfo,
                      std::function<nlohmann::json()> getNetworksInfo,
                      bool agentIsRegistering,
                      std::shared_ptr<AgentInfoPersistance> persistence)
-    : m_dataFolderPath(std::move(dbFolderPath))
-    , m_agentIsRegistering(agentIsRegistering)
-    , m_persistence(persistence ? std::move(persistence) : std::make_shared<AgentInfoPersistance>(m_dataFolderPath))
+    : m_agentIsRegistering(agentIsRegistering)
+    , m_persistence(persistence ? std::move(persistence) : std::make_shared<AgentInfoPersistance>(dbFolderPath))
 {
     if (!m_agentIsRegistering)
     {

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -5,6 +5,7 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <memory>
 #include <random>
 #include <utility>
 
@@ -19,17 +20,18 @@ namespace
 AgentInfo::AgentInfo(std::string dbFolderPath,
                      std::function<nlohmann::json()> getOSInfo,
                      std::function<nlohmann::json()> getNetworksInfo,
-                     bool agentIsRegistering)
+                     bool agentIsRegistering,
+                     std::unique_ptr<AgentInfoPersistance> persistence)
     : m_dataFolderPath(std::move(dbFolderPath))
     , m_agentIsRegistering(agentIsRegistering)
+    , m_persistence(persistence ? std::move(persistence) : std::make_unique<AgentInfoPersistance>(m_dataFolderPath))
 {
     if (!m_agentIsRegistering)
     {
-        AgentInfoPersistance agentInfoPersistance(m_dataFolderPath);
-        m_name = agentInfoPersistance.GetName();
-        m_key = agentInfoPersistance.GetKey();
-        m_uuid = agentInfoPersistance.GetUUID();
-        m_groups = agentInfoPersistance.GetGroups();
+        m_name = m_persistence->GetName();
+        m_key = m_persistence->GetKey();
+        m_uuid = m_persistence->GetUUID();
+        m_groups = m_persistence->GetGroups();
     }
 
     if (m_uuid.empty())
@@ -183,18 +185,16 @@ std::string AgentInfo::GetMetadataInfo() const
 
 void AgentInfo::Save() const
 {
-    AgentInfoPersistance agentInfoPersistance(m_dataFolderPath);
-    agentInfoPersistance.ResetToDefault();
-    agentInfoPersistance.SetName(m_name);
-    agentInfoPersistance.SetKey(m_key);
-    agentInfoPersistance.SetUUID(m_uuid);
-    agentInfoPersistance.SetGroups(m_groups);
+    m_persistence->ResetToDefault();
+    m_persistence->SetName(m_name);
+    m_persistence->SetKey(m_key);
+    m_persistence->SetUUID(m_uuid);
+    m_persistence->SetGroups(m_groups);
 }
 
 bool AgentInfo::SaveGroups() const
 {
-    AgentInfoPersistance agentInfoPersistance(m_dataFolderPath);
-    return agentInfoPersistance.SetGroups(m_groups);
+    return m_persistence->SetGroups(m_groups);
 }
 
 std::vector<std::string> AgentInfo::GetActiveIPAddresses(const nlohmann::json& networksJson) const

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -21,10 +21,10 @@ AgentInfo::AgentInfo(std::string dbFolderPath,
                      std::function<nlohmann::json()> getOSInfo,
                      std::function<nlohmann::json()> getNetworksInfo,
                      bool agentIsRegistering,
-                     std::unique_ptr<AgentInfoPersistance> persistence)
+                     std::shared_ptr<AgentInfoPersistance> persistence)
     : m_dataFolderPath(std::move(dbFolderPath))
     , m_agentIsRegistering(agentIsRegistering)
-    , m_persistence(persistence ? std::move(persistence) : std::make_unique<AgentInfoPersistance>(m_dataFolderPath))
+    , m_persistence(persistence ? std::move(persistence) : std::make_shared<AgentInfoPersistance>(m_dataFolderPath))
 {
     if (!m_agentIsRegistering)
     {

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -3,7 +3,6 @@
 #include <logger.hpp>
 
 #include <column.hpp>
-#include <persistence.hpp>
 #include <persistence_factory.hpp>
 
 using namespace column;

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -133,17 +133,20 @@ void AgentInfoPersistance::InsertDefaultAgentInfo()
     }
 }
 
-void AgentInfoPersistance::SetAgentInfoValue(const std::string& column, const std::string& value)
+bool AgentInfoPersistance::SetAgentInfoValue(const std::string& column, const std::string& value)
 {
     try
     {
         const Row columns = {ColumnValue(column, ColumnType::TEXT, value)};
         m_db->Update(AGENT_INFO_TABLE_NAME, columns);
+        return true;
     }
     catch (const std::exception& e)
     {
         LogError("Error updating {}: {}.", column, e.what());
     }
+
+    return false;
 }
 
 std::string AgentInfoPersistance::GetAgentInfoValue(const std::string& column) const
@@ -208,19 +211,19 @@ std::vector<std::string> AgentInfoPersistance::GetGroups() const
     return groupList;
 }
 
-void AgentInfoPersistance::SetName(const std::string& name)
+bool AgentInfoPersistance::SetName(const std::string& name)
 {
-    SetAgentInfoValue(AGENT_INFO_NAME_COLUMN_NAME, name);
+    return SetAgentInfoValue(AGENT_INFO_NAME_COLUMN_NAME, name);
 }
 
-void AgentInfoPersistance::SetKey(const std::string& key)
+bool AgentInfoPersistance::SetKey(const std::string& key)
 {
-    SetAgentInfoValue(AGENT_INFO_KEY_COLUMN_NAME, key);
+    return SetAgentInfoValue(AGENT_INFO_KEY_COLUMN_NAME, key);
 }
 
-void AgentInfoPersistance::SetUUID(const std::string& uuid)
+bool AgentInfoPersistance::SetUUID(const std::string& uuid)
 {
-    SetAgentInfoValue(AGENT_INFO_UUID_COLUMN_NAME, uuid);
+    return SetAgentInfoValue(AGENT_INFO_UUID_COLUMN_NAME, uuid);
 }
 
 bool AgentInfoPersistance::SetGroups(const std::vector<std::string>& groupList)
@@ -248,7 +251,7 @@ bool AgentInfoPersistance::SetGroups(const std::vector<std::string>& groupList)
     return true;
 }
 
-void AgentInfoPersistance::ResetToDefault()
+bool AgentInfoPersistance::ResetToDefault()
 {
     try
     {
@@ -257,9 +260,11 @@ void AgentInfoPersistance::ResetToDefault()
         CreateAgentInfoTable();
         CreateAgentGroupTable();
         InsertDefaultAgentInfo();
+        return true;
     }
     catch (const std::exception& e)
     {
         LogError("Error resetting to default values: {}.", e.what());
     }
+    return false;
 }

--- a/src/agent/agent_info/src/agent_info_persistance.cpp
+++ b/src/agent/agent_info/src/agent_info_persistance.cpp
@@ -25,13 +25,20 @@ namespace
     const std::string AGENT_GROUP_NAME_COLUMN_NAME = "name";
 } // namespace
 
-AgentInfoPersistance::AgentInfoPersistance(const std::string& dbFolderPath)
+AgentInfoPersistance::AgentInfoPersistance(const std::string& dbFolderPath, std::unique_ptr<Persistence> persistence)
 {
     const auto dbFilePath = dbFolderPath + "/" + AGENT_INFO_DB_NAME;
 
     try
     {
-        m_db = PersistenceFactory::CreatePersistence(PersistenceFactory::PersistenceType::SQLITE3, dbFilePath);
+        if (persistence)
+        {
+            m_db = std::move(persistence);
+        }
+        else
+        {
+            m_db = PersistenceFactory::CreatePersistence(PersistenceFactory::PersistenceType::SQLITE3, dbFilePath);
+        }
 
         if (!m_db->TableExists(AGENT_INFO_TABLE_NAME))
         {

--- a/src/agent/agent_info/src/agent_info_persistance.hpp
+++ b/src/agent/agent_info/src/agent_info_persistance.hpp
@@ -47,15 +47,18 @@ public:
 
     /// @brief Sets the agent's name in the database.
     /// @param name The name to set.
-    void SetName(const std::string& name);
+    /// @return True if the operation was successful, false otherwise.
+    bool SetName(const std::string& name);
 
     /// @brief Sets the agent's key in the database.
     /// @param key The key to set.
-    void SetKey(const std::string& key);
+    /// @return True if the operation was successful, false otherwise.
+    bool SetKey(const std::string& key);
 
     /// @brief Sets the agent's UUID in the database.
     /// @param uuid The UUID to set.
-    void SetUUID(const std::string& uuid);
+    /// @return True if the operation was successful, false otherwise.
+    bool SetUUID(const std::string& uuid);
 
     /// @brief Sets the agent's group list in the database, replacing any existing groups.
     /// @param groupList A vector of strings, each representing a group name.
@@ -63,7 +66,8 @@ public:
     bool SetGroups(const std::vector<std::string>& groupList);
 
     /// @brief Resets the database tables to default values, clearing all data.
-    void ResetToDefault();
+    /// @return True if the reset was successful, false otherwise.
+    bool ResetToDefault();
 
 private:
     /// @brief Checks if the agent info table is empty.
@@ -82,7 +86,8 @@ private:
     /// @brief Sets a specific agent info value in the database.
     /// @param column The name of the column to set.
     /// @param value The value to set in the specified column.
-    void SetAgentInfoValue(const std::string& column, const std::string& value);
+    /// @return True if the operation was successful, false otherwise.
+    bool SetAgentInfoValue(const std::string& column, const std::string& value);
 
     /// @brief Retrieves a specific agent info value from the database.
     /// @param column The name of the column to retrieve.

--- a/src/agent/agent_info/src/agent_info_persistance.hpp
+++ b/src/agent/agent_info/src/agent_info_persistance.hpp
@@ -12,6 +12,7 @@ class AgentInfoPersistance
 public:
     /// @brief Constructs the persistence manager for agent info, initializing the database and tables if necessary.
     /// @param dbFolderPath Path to the database folder.
+    /// @param persistence Optional pointer to an existing persistence object.
     explicit AgentInfoPersistance(const std::string& dbFolderPath, std::unique_ptr<Persistence> persistence = nullptr);
 
     /// @brief Destructor for AgentInfoPersistance.

--- a/src/agent/agent_info/src/agent_info_persistance.hpp
+++ b/src/agent/agent_info/src/agent_info_persistance.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <persistence.hpp>
+
 #include <memory>
 #include <string>
 #include <vector>
-
-class Persistence;
 
 /// @brief Manages persistence of agent information and groups in a database.
 class AgentInfoPersistance
@@ -12,7 +12,7 @@ class AgentInfoPersistance
 public:
     /// @brief Constructs the persistence manager for agent info, initializing the database and tables if necessary.
     /// @param dbFolderPath Path to the database folder.
-    explicit AgentInfoPersistance(const std::string& dbFolderPath);
+    explicit AgentInfoPersistance(const std::string& dbFolderPath, std::unique_ptr<Persistence> persistence = nullptr);
 
     /// @brief Destructor for AgentInfoPersistance.
     ~AgentInfoPersistance();

--- a/src/agent/agent_info/tests/CMakeLists.txt
+++ b/src/agent/agent_info/tests/CMakeLists.txt
@@ -10,6 +10,8 @@ add_test(NAME AgentInfoTest COMMAND agent_info_test)
 
 add_executable(agent_info_persistance_test agent_info_persistance_test.cpp)
 configure_target(agent_info_persistance_test)
-target_include_directories(agent_info_persistance_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-target_link_libraries(agent_info_persistance_test PRIVATE AgentInfo Persistence GTest::gtest)
+target_include_directories(agent_info_persistance_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../persistence/tests/mocks)
+target_link_libraries(agent_info_persistance_test PRIVATE AgentInfo Persistence GTest::gtest GTest::gmock)
 add_test(NAME AgentInfoPersistanceTest COMMAND agent_info_persistance_test)

--- a/src/agent/agent_info/tests/CMakeLists.txt
+++ b/src/agent/agent_info/tests/CMakeLists.txt
@@ -2,8 +2,10 @@ find_package(GTest CONFIG REQUIRED)
 
 add_executable(agent_info_test agent_info_test.cpp)
 configure_target(agent_info_test)
-target_include_directories(agent_info_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-target_link_libraries(agent_info_test PRIVATE AgentInfo Persistence GTest::gtest)
+target_include_directories(agent_info_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../persistence/tests/mocks)
+target_link_libraries(agent_info_test PRIVATE AgentInfo Persistence GTest::gtest GTest::gmock GTest::gmock_main)
 add_test(NAME AgentInfoTest COMMAND agent_info_test)
 
 add_executable(agent_info_persistance_test agent_info_persistance_test.cpp)

--- a/src/agent/agent_info/tests/agent_info_persistance_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_persistance_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <agent_info_persistance.hpp>
+#include <mocks_persistence.hpp>
 
 #include <memory>
 #include <string>
@@ -9,75 +10,397 @@
 class AgentInfoPersistanceTest : public ::testing::Test
 {
 protected:
+    MockPersistence* mockPersistence = nullptr;
+    std::unique_ptr<AgentInfoPersistance> agentInfoPersistance;
+
     void SetUp() override
     {
-        persistance = std::make_unique<AgentInfoPersistance>(".");
-        persistance->ResetToDefault();
-    }
+        auto mockPersistencePtr = std::make_unique<MockPersistence>();
+        mockPersistence = mockPersistencePtr.get();
 
-    std::unique_ptr<AgentInfoPersistance> persistance;
+        EXPECT_CALL(*mockPersistence, TableExists("agent_info")).WillOnce(testing::Return(true));
+        EXPECT_CALL(*mockPersistence, TableExists("agent_group")).WillOnce(testing::Return(true));
+        EXPECT_CALL(*mockPersistence, GetCount("agent_info", testing::_, testing::_))
+            .WillOnce(testing::Return(0))
+            .WillOnce(testing::Return(0));
+        EXPECT_CALL(*mockPersistence, Insert("agent_info", testing::_)).Times(1);
+
+        agentInfoPersistance = std::make_unique<AgentInfoPersistance>("db_path", std::move(mockPersistencePtr));
+    }
 };
 
 TEST_F(AgentInfoPersistanceTest, TestConstruction)
 {
-    EXPECT_NE(persistance, nullptr);
+    EXPECT_NE(agentInfoPersistance, nullptr);
 }
 
-TEST_F(AgentInfoPersistanceTest, TestDefaultValues)
+TEST_F(AgentInfoPersistanceTest, TestGetNameValue)
 {
-    EXPECT_EQ(persistance->GetName(), "");
-    EXPECT_EQ(persistance->GetKey(), "");
-    EXPECT_EQ(persistance->GetUUID(), "");
+    std::vector<column::Row> mockRowName = {{column::ColumnValue("name", column::ColumnType::TEXT, "name_test")}};
+    EXPECT_CALL(*mockPersistence,
+                Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .WillOnce(testing::Return(mockRowName));
+    EXPECT_EQ(agentInfoPersistance->GetName(), "name_test");
+}
+
+TEST_F(AgentInfoPersistanceTest, TestGetNameNotValue)
+{
+    std::vector<column::Row> mockRowName = {};
+    EXPECT_CALL(*mockPersistence,
+                Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .WillOnce(testing::Return(mockRowName));
+    EXPECT_EQ(agentInfoPersistance->GetName(), "");
+}
+
+TEST_F(AgentInfoPersistanceTest, TestGetNameCatch)
+{
+    EXPECT_CALL(*mockPersistence,
+                Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Select")));
+    EXPECT_EQ(agentInfoPersistance->GetName(), "");
+}
+
+TEST_F(AgentInfoPersistanceTest, TestGetKeyValue)
+{
+    std::vector<column::Row> mockRowKey = {{column::ColumnValue("key", column::ColumnType::TEXT, "key_test")}};
+    EXPECT_CALL(*mockPersistence,
+                Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .WillOnce(testing::Return(mockRowKey));
+    EXPECT_EQ(agentInfoPersistance->GetKey(), "key_test");
+}
+
+TEST_F(AgentInfoPersistanceTest, TestGetKeyNotValue)
+{
+    std::vector<column::Row> mockRowKey = {};
+    EXPECT_CALL(*mockPersistence,
+                Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .WillOnce(testing::Return(mockRowKey));
+    EXPECT_EQ(agentInfoPersistance->GetKey(), "");
+}
+
+TEST_F(AgentInfoPersistanceTest, TestGetKeyCatch)
+{
+    EXPECT_CALL(*mockPersistence,
+                Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Select")));
+    EXPECT_EQ(agentInfoPersistance->GetKey(), "");
+}
+
+TEST_F(AgentInfoPersistanceTest, TestGetUUIDValue)
+{
+    std::vector<column::Row> mockRowUUID = {{column::ColumnValue("uuid", column::ColumnType::TEXT, "uuid_test")}};
+    EXPECT_CALL(*mockPersistence,
+                Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .WillOnce(testing::Return(mockRowUUID));
+    EXPECT_EQ(agentInfoPersistance->GetUUID(), "uuid_test");
+}
+
+TEST_F(AgentInfoPersistanceTest, TestGetUUIDNotValue)
+{
+    std::vector<column::Row> mockRowUUID = {};
+    EXPECT_CALL(*mockPersistence,
+                Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .WillOnce(testing::Return(mockRowUUID));
+    EXPECT_EQ(agentInfoPersistance->GetUUID(), "");
+}
+
+TEST_F(AgentInfoPersistanceTest, TestGetUUIDCatch)
+{
+    EXPECT_CALL(*mockPersistence,
+                Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Select")));
+    EXPECT_EQ(agentInfoPersistance->GetUUID(), "");
+}
+
+TEST_F(AgentInfoPersistanceTest, TestGetGroupsValue)
+{
+    std::vector<column::Row> mockRowGroups = {{column::ColumnValue("name", column::ColumnType::TEXT, "group_1")},
+                                              {column::ColumnValue("name", column::ColumnType::TEXT, "group_2")}};
+    EXPECT_CALL(*mockPersistence,
+                Select("agent_group", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .WillOnce(testing::Return(mockRowGroups));
+
+    std::vector<std::string> expectedGroups = {"group_1", "group_2"};
+    EXPECT_EQ(agentInfoPersistance->GetGroups(), expectedGroups);
+}
+
+TEST_F(AgentInfoPersistanceTest, TestGetGroupsNotValue)
+{
+    std::vector<column::Row> mockRowGroups = {};
+    EXPECT_CALL(*mockPersistence,
+                Select("agent_group", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .WillOnce(testing::Return(mockRowGroups));
+
+    std::vector<std::string> expectedGroups = {};
+    EXPECT_EQ(agentInfoPersistance->GetGroups(), expectedGroups);
+}
+
+TEST_F(AgentInfoPersistanceTest, TestGetGroupsCatch)
+{
+    EXPECT_CALL(*mockPersistence,
+                Select("agent_group", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Select")));
+
+    std::vector<std::string> expectedGroups = {};
+    EXPECT_EQ(agentInfoPersistance->GetGroups(), expectedGroups);
 }
 
 TEST_F(AgentInfoPersistanceTest, TestSetName)
 {
-    const std::string newName = "new_name";
-    persistance->SetName(newName);
-    EXPECT_EQ(persistance->GetName(), newName);
+    std::string expectedColumn = "name";
+    std::string newName = "new_name";
+
+    EXPECT_CALL(*mockPersistence,
+                Update(testing::Eq("agent_info"),
+                       testing::AllOf(testing::SizeIs(1),
+                                      testing::Contains(
+                                          testing::AllOf(testing::Field(&column::ColumnValue::Value, newName),
+                                                         testing::Field(&column::ColumnName::Name, expectedColumn)))),
+                       testing::_,
+                       testing::_))
+        .Times(1);
+    EXPECT_TRUE(agentInfoPersistance->SetName(newName));
+}
+
+TEST_F(AgentInfoPersistanceTest, TestSetNameCatch)
+{
+    std::string expectedColumn = "name";
+    std::string newName = "new_name";
+
+    EXPECT_CALL(*mockPersistence,
+                Update(testing::Eq("agent_info"),
+                       testing::AllOf(testing::SizeIs(1),
+                                      testing::Contains(
+                                          testing::AllOf(testing::Field(&column::ColumnValue::Value, newName),
+                                                         testing::Field(&column::ColumnName::Name, expectedColumn)))),
+                       testing::_,
+                       testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Update")));
+    EXPECT_FALSE(agentInfoPersistance->SetName(newName));
 }
 
 TEST_F(AgentInfoPersistanceTest, TestSetKey)
 {
-    const std::string newKey = "new_key";
-    persistance->SetKey(newKey);
-    EXPECT_EQ(persistance->GetKey(), newKey);
+    std::string expectedColumn = "key";
+    std::string newKey = "new_key";
+
+    EXPECT_CALL(*mockPersistence,
+                Update(testing::Eq("agent_info"),
+                       testing::AllOf(testing::SizeIs(1),
+                                      testing::Contains(
+                                          testing::AllOf(testing::Field(&column::ColumnValue::Value, newKey),
+                                                         testing::Field(&column::ColumnName::Name, expectedColumn)))),
+                       testing::_,
+                       testing::_))
+        .Times(1);
+    EXPECT_TRUE(agentInfoPersistance->SetKey(newKey));
+}
+
+TEST_F(AgentInfoPersistanceTest, TestSetKeyCatch)
+{
+    std::string expectedColumn = "key";
+    std::string newKey = "new_key";
+
+    EXPECT_CALL(*mockPersistence,
+                Update(testing::Eq("agent_info"),
+                       testing::AllOf(testing::SizeIs(1),
+                                      testing::Contains(
+                                          testing::AllOf(testing::Field(&column::ColumnValue::Value, newKey),
+                                                         testing::Field(&column::ColumnName::Name, expectedColumn)))),
+                       testing::_,
+                       testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Update")));
+    EXPECT_FALSE(agentInfoPersistance->SetKey(newKey));
 }
 
 TEST_F(AgentInfoPersistanceTest, TestSetUUID)
 {
-    const std::string newUUID = "new_uuid";
-    persistance->SetUUID(newUUID);
-    EXPECT_EQ(persistance->GetUUID(), newUUID);
+    std::string expectedColumn = "uuid";
+    std::string newUUID = "new_uuid";
+
+    EXPECT_CALL(*mockPersistence,
+                Update(testing::Eq("agent_info"),
+                       testing::AllOf(testing::SizeIs(1),
+                                      testing::Contains(
+                                          testing::AllOf(testing::Field(&column::ColumnValue::Value, newUUID),
+                                                         testing::Field(&column::ColumnName::Name, expectedColumn)))),
+                       testing::_,
+                       testing::_))
+        .Times(1);
+    EXPECT_TRUE(agentInfoPersistance->SetUUID(newUUID));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetGroups)
+TEST_F(AgentInfoPersistanceTest, TestSetUUIDCatch)
 {
-    const std::vector<std::string> newGroups = {"group_1", "group_2"};
-    persistance->SetGroups(newGroups);
-    EXPECT_EQ(persistance->GetGroups(), newGroups);
+    std::string expectedColumn = "uuid";
+    std::string newUUID = "new_uuid";
+
+    EXPECT_CALL(*mockPersistence,
+                Update(testing::Eq("agent_info"),
+                       testing::AllOf(testing::SizeIs(1),
+                                      testing::Contains(
+                                          testing::AllOf(testing::Field(&column::ColumnValue::Value, newUUID),
+                                                         testing::Field(&column::ColumnName::Name, expectedColumn)))),
+                       testing::_,
+                       testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Update")));
+    EXPECT_FALSE(agentInfoPersistance->SetUUID(newUUID));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetGroupsDelete)
+TEST_F(AgentInfoPersistanceTest, TestSetGroupsSuccess)
 {
-    const std::vector<std::string> oldGroups = {"group_1", "group_2"};
-    const std::vector<std::string> newGroups = {"group_3", "group_4"};
-    persistance->SetGroups(oldGroups);
-    EXPECT_EQ(persistance->GetGroups(), oldGroups);
-    persistance->SetGroups(newGroups);
-    EXPECT_EQ(persistance->GetGroups(), newGroups);
+    const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
+
+    EXPECT_CALL(*mockPersistence, BeginTransaction()).Times(1);
+    EXPECT_CALL(*mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
+    EXPECT_CALL(*mockPersistence, Insert("agent_group", testing::_)).Times(2);
+    EXPECT_CALL(*mockPersistence, CommitTransaction(testing::_)).Times(1);
+
+    EXPECT_TRUE(agentInfoPersistance->SetGroups(newGroups));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestResetToDefault)
+TEST_F(AgentInfoPersistanceTest, TestSetGroupsBeginTransactionFails)
 {
-    const std::string newName = "new_name";
-    persistance->SetName(newName);
-    EXPECT_EQ(persistance->GetName(), newName);
+    const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
 
-    persistance->ResetToDefault();
-    EXPECT_EQ(persistance->GetName(), "");
-    EXPECT_EQ(persistance->GetKey(), "");
-    EXPECT_EQ(persistance->GetUUID(), "");
+    EXPECT_CALL(*mockPersistence, BeginTransaction())
+        .WillOnce(testing::Throw(std::runtime_error("Error BeginTransaction")));
+
+    EXPECT_FALSE(agentInfoPersistance->SetGroups(newGroups));
+}
+
+TEST_F(AgentInfoPersistanceTest, TestSetGroupsRemoveFails)
+{
+    const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
+
+    EXPECT_CALL(*mockPersistence, BeginTransaction()).Times(1);
+    EXPECT_CALL(*mockPersistence, Remove("agent_group", testing::_, testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Remove")));
+    EXPECT_CALL(*mockPersistence, RollbackTransaction(testing::_)).Times(1);
+
+    EXPECT_FALSE(agentInfoPersistance->SetGroups(newGroups));
+}
+
+TEST_F(AgentInfoPersistanceTest, TestSetGroupsInsertFails1)
+{
+    const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
+
+    EXPECT_CALL(*mockPersistence, BeginTransaction()).Times(1);
+    EXPECT_CALL(*mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
+    EXPECT_CALL(*mockPersistence, Insert("agent_group", testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Insert")));
+    EXPECT_CALL(*mockPersistence, RollbackTransaction(testing::_)).Times(1);
+
+    EXPECT_FALSE(agentInfoPersistance->SetGroups(newGroups));
+}
+
+TEST_F(AgentInfoPersistanceTest, TestSetGroupsInsertFails2)
+{
+    const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
+
+    EXPECT_CALL(*mockPersistence, BeginTransaction()).Times(1);
+    EXPECT_CALL(*mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
+
+    testing::Sequence seq;
+    EXPECT_CALL(*mockPersistence, Insert("agent_group", testing::_))
+        .InSequence(seq)
+        .WillOnce(testing::Return())
+        .WillOnce(testing::Throw(std::runtime_error("Error Insert")));
+    EXPECT_CALL(*mockPersistence, RollbackTransaction(testing::_)).Times(1);
+
+    EXPECT_FALSE(agentInfoPersistance->SetGroups(newGroups));
+}
+
+TEST_F(AgentInfoPersistanceTest, TestSetGroupsCommitFails)
+{
+    const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
+
+    EXPECT_CALL(*mockPersistence, BeginTransaction()).Times(1);
+    EXPECT_CALL(*mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
+    EXPECT_CALL(*mockPersistence, Insert("agent_group", testing::_)).Times(2);
+    EXPECT_CALL(*mockPersistence, CommitTransaction(testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Commit")));
+    EXPECT_CALL(*mockPersistence, RollbackTransaction(testing::_)).Times(1);
+
+    EXPECT_FALSE(agentInfoPersistance->SetGroups(newGroups));
+}
+
+TEST_F(AgentInfoPersistanceTest, TestSetGroupsRollbackFails)
+{
+    const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
+
+    EXPECT_CALL(*mockPersistence, BeginTransaction()).Times(1);
+    EXPECT_CALL(*mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
+    EXPECT_CALL(*mockPersistence, Insert("agent_group", testing::_)).Times(2);
+    EXPECT_CALL(*mockPersistence, CommitTransaction(testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Commit")));
+    EXPECT_CALL(*mockPersistence, RollbackTransaction(testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Rollback")));
+
+    EXPECT_FALSE(agentInfoPersistance->SetGroups(newGroups));
+}
+
+TEST_F(AgentInfoPersistanceTest, TestResetToDefaultSuccess)
+{
+    EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
+    EXPECT_CALL(*mockPersistence, DropTable("agent_group")).Times(1);
+    EXPECT_CALL(*mockPersistence, CreateTable("agent_info", testing::_)).Times(1);
+    EXPECT_CALL(*mockPersistence, CreateTable("agent_group", testing::_)).Times(1);
+    EXPECT_CALL(*mockPersistence, GetCount("agent_info", testing::_, testing::_)).WillOnce(testing::Return(0));
+    EXPECT_CALL(*mockPersistence, Insert(testing::_, testing::_)).Times(1);
+
+    EXPECT_TRUE(agentInfoPersistance->ResetToDefault());
+}
+
+TEST_F(AgentInfoPersistanceTest, TestResetToDefaultDropTableAgentInfoFails)
+{
+    EXPECT_CALL(*mockPersistence, DropTable("agent_info"))
+        .WillOnce(testing::Throw(std::runtime_error("Error DropTable")));
+
+    EXPECT_FALSE(agentInfoPersistance->ResetToDefault());
+}
+
+TEST_F(AgentInfoPersistanceTest, TestResetToDefaultDropTableAgentGroupFails)
+{
+    EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
+    EXPECT_CALL(*mockPersistence, DropTable("agent_group"))
+        .WillOnce(testing::Throw(std::runtime_error("Error DropTable")));
+
+    EXPECT_FALSE(agentInfoPersistance->ResetToDefault());
+}
+
+TEST_F(AgentInfoPersistanceTest, TestResetToDefaultCreateAgentInfoTableFails)
+{
+    EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
+    EXPECT_CALL(*mockPersistence, DropTable("agent_group")).Times(1);
+    EXPECT_CALL(*mockPersistence, CreateTable("agent_info", testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error CreateAgentInfoTable")));
+
+    EXPECT_FALSE(agentInfoPersistance->ResetToDefault());
+}
+
+TEST_F(AgentInfoPersistanceTest, TestResetToDefaultCreateAgentGroupTableFails)
+{
+    EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
+    EXPECT_CALL(*mockPersistence, DropTable("agent_group")).Times(1);
+    EXPECT_CALL(*mockPersistence, CreateTable("agent_info", testing::_)).Times(1);
+    EXPECT_CALL(*mockPersistence, CreateTable("agent_group", testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error CreateAgentGroupTable")));
+
+    EXPECT_FALSE(agentInfoPersistance->ResetToDefault());
+}
+
+TEST_F(AgentInfoPersistanceTest, TestResetToDefaultInsertFails)
+{
+    EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
+    EXPECT_CALL(*mockPersistence, DropTable("agent_group")).Times(1);
+    EXPECT_CALL(*mockPersistence, CreateTable("agent_info", testing::_)).Times(1);
+    EXPECT_CALL(*mockPersistence, CreateTable("agent_group", testing::_)).Times(1);
+    EXPECT_CALL(*mockPersistence, GetCount("agent_info", testing::_, testing::_)).WillOnce(testing::Return(0));
+    EXPECT_CALL(*mockPersistence, Insert("agent_info", testing::_))
+        .WillOnce(testing::Throw(std::runtime_error("Error Insert")));
+
+    EXPECT_FALSE(agentInfoPersistance->ResetToDefault());
 }
 
 int main(int argc, char** argv)

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -12,7 +12,7 @@ class AgentInfoTest : public ::testing::Test
 {
 protected:
     MockPersistence* mockPersistence = nullptr;
-    std::unique_ptr<AgentInfoPersistance> agentPersistence;
+    std::shared_ptr<AgentInfoPersistance> agentPersistence;
     std::unique_ptr<AgentInfo> agentInfo;
 
     void SetUp() override
@@ -34,7 +34,7 @@ protected:
             SetUpAgentInfoInitialization();
         }
 
-        agentPersistence = std::make_unique<AgentInfoPersistance>("db_path", std::move(mockPersistencePtr));
+        agentPersistence = std::make_shared<AgentInfoPersistance>("db_path", std::move(mockPersistencePtr));
 
         agentInfo = std::make_unique<AgentInfo>("db_path",
                                                 osLambda ? osLambda : nullptr,

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -11,9 +11,9 @@
 class AgentInfoTest : public ::testing::Test
 {
 protected:
-    MockPersistence* mockPersistence = nullptr;
-    std::shared_ptr<AgentInfoPersistance> agentPersistence;
-    std::unique_ptr<AgentInfo> agentInfo;
+    MockPersistence* m_mockPersistence = nullptr;
+    std::shared_ptr<AgentInfoPersistance> m_agentPersistence;
+    std::unique_ptr<AgentInfo> m_agentInfo;
 
     void SetUp() override
     {
@@ -25,7 +25,7 @@ protected:
                              bool agentIsRegistering = false)
     {
         auto mockPersistencePtr = std::make_unique<MockPersistence>();
-        mockPersistence = mockPersistencePtr.get();
+        m_mockPersistence = mockPersistencePtr.get();
 
         SetUpPersistenceMock();
 
@@ -34,20 +34,20 @@ protected:
             SetUpAgentInfoInitialization();
         }
 
-        agentPersistence = std::make_shared<AgentInfoPersistance>("db_path", std::move(mockPersistencePtr));
+        m_agentPersistence = std::make_shared<AgentInfoPersistance>("db_path", std::move(mockPersistencePtr));
 
-        agentInfo = std::make_unique<AgentInfo>("db_path",
-                                                osLambda ? osLambda : nullptr,
-                                                networksLambda ? networksLambda : nullptr,
-                                                agentIsRegistering,
-                                                std::move(agentPersistence));
+        m_agentInfo = std::make_unique<AgentInfo>("db_path",
+                                                  osLambda ? osLambda : nullptr,
+                                                  networksLambda ? networksLambda : nullptr,
+                                                  agentIsRegistering,
+                                                  std::move(m_agentPersistence));
     }
 
     void SetUpPersistenceMock()
     {
-        EXPECT_CALL(*mockPersistence, TableExists("agent_info")).WillOnce(testing::Return(true));
-        EXPECT_CALL(*mockPersistence, TableExists("agent_group")).WillOnce(testing::Return(true));
-        EXPECT_CALL(*mockPersistence, GetCount("agent_info", testing::_, testing::_)).WillOnce(testing::Return(1));
+        EXPECT_CALL(*m_mockPersistence, TableExists("agent_info")).WillOnce(testing::Return(true));
+        EXPECT_CALL(*m_mockPersistence, TableExists("agent_group")).WillOnce(testing::Return(true));
+        EXPECT_CALL(*m_mockPersistence, GetCount("agent_info", testing::_, testing::_)).WillOnce(testing::Return(1));
     }
 
     void SetUpAgentInfoInitialization()
@@ -55,16 +55,16 @@ protected:
         std::vector<column::Row> mockRowName = {{column::ColumnValue("name", column::ColumnType::TEXT, "name_test")}};
         std::vector<column::Row> mockRowKey = {{column::ColumnValue("key", column::ColumnType::TEXT, "key_test")}};
         std::vector<column::Row> mockRowUUID = {{column::ColumnValue("uuid", column::ColumnType::TEXT, "uuid_test")}};
-        std::vector<column::Row> mockRowGroup = {{column::ColumnValue("name", column::ColumnType::TEXT, "group_test")}};
+        std::vector<column::Row> mockRowGroup = {{}};
 
         testing::Sequence seq;
-        EXPECT_CALL(*mockPersistence,
+        EXPECT_CALL(*m_mockPersistence,
                     Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
             .InSequence(seq)
             .WillOnce(testing::Return(mockRowName))
             .WillOnce(testing::Return(mockRowKey))
             .WillOnce(testing::Return(mockRowUUID));
-        EXPECT_CALL(*mockPersistence,
+        EXPECT_CALL(*m_mockPersistence,
                     Select("agent_group", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
             .WillOnce(testing::Return(mockRowGroup));
     }
@@ -73,9 +73,9 @@ protected:
 TEST_F(AgentInfoTest, TestDefaultConstructorDefaultValues)
 {
     EXPECT_NO_THROW({
-        EXPECT_EQ(agentInfo->GetName(), "name_test");
-        EXPECT_EQ(agentInfo->GetKey(), "key_test");
-        EXPECT_NE(agentInfo->GetUUID(), "");
+        EXPECT_EQ(m_agentInfo->GetName(), "name_test");
+        EXPECT_EQ(m_agentInfo->GetKey(), "key_test");
+        EXPECT_NE(m_agentInfo->GetUUID(), "");
     });
 }
 
@@ -83,16 +83,16 @@ TEST_F(AgentInfoTest, TestSetName)
 {
     const std::string newName = "new_name";
 
-    agentInfo->SetName(newName);
-    EXPECT_EQ(agentInfo->GetName(), newName);
+    m_agentInfo->SetName(newName);
+    EXPECT_EQ(m_agentInfo->GetName(), newName);
 }
 
 TEST_F(AgentInfoTest, TestSetKey)
 {
     const std::string newKey = "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj";
 
-    agentInfo->SetKey(newKey);
-    EXPECT_EQ(agentInfo->GetKey(), newKey);
+    m_agentInfo->SetKey(newKey);
+    EXPECT_EQ(m_agentInfo->GetKey(), newKey);
 }
 
 TEST_F(AgentInfoTest, TestSetBadKey)
@@ -100,86 +100,85 @@ TEST_F(AgentInfoTest, TestSetBadKey)
     const std::string newKey1 = "4GhT7uFm";
     const std::string newKey2 = "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrN=";
 
-    ASSERT_FALSE(agentInfo->SetKey(newKey1));
-    ASSERT_FALSE(agentInfo->SetKey(newKey2));
+    ASSERT_FALSE(m_agentInfo->SetKey(newKey1));
+    ASSERT_FALSE(m_agentInfo->SetKey(newKey2));
 }
 
 TEST_F(AgentInfoTest, TestSetEmptyKey)
 {
     const std::string newKey;
 
-    agentInfo->SetKey(newKey);
-    EXPECT_NE(agentInfo->GetKey(), newKey);
+    m_agentInfo->SetKey(newKey);
+    EXPECT_NE(m_agentInfo->GetKey(), newKey);
 }
 
 TEST_F(AgentInfoTest, TestSetUUID)
 {
     const std::string newUUID = "new_uuid";
 
-    agentInfo->SetUUID(newUUID);
-    EXPECT_EQ(agentInfo->GetUUID(), newUUID);
+    m_agentInfo->SetUUID(newUUID);
+    EXPECT_EQ(m_agentInfo->GetUUID(), newUUID);
 }
 
 TEST_F(AgentInfoTest, TestSetGroups)
 {
     const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
 
-    agentInfo->SetGroups(newGroups);
-    EXPECT_EQ(agentInfo->GetGroups(), newGroups);
+    m_agentInfo->SetGroups(newGroups);
+    EXPECT_EQ(m_agentInfo->GetGroups(), newGroups);
 }
 
 TEST_F(AgentInfoTest, TestSaveGroups)
 {
     const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
 
-    EXPECT_CALL(*mockPersistence, BeginTransaction()).Times(1);
-    EXPECT_CALL(*mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
-    EXPECT_CALL(*mockPersistence, Insert("agent_group", testing::_)).Times(2);
-    EXPECT_CALL(*mockPersistence, CommitTransaction(testing::_)).Times(1);
+    EXPECT_CALL(*m_mockPersistence, BeginTransaction()).Times(1);
+    EXPECT_CALL(*m_mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
+    EXPECT_CALL(*m_mockPersistence, Insert("agent_group", testing::_)).Times(2);
+    EXPECT_CALL(*m_mockPersistence, CommitTransaction(testing::_)).Times(1);
 
-    agentInfo->SetGroups(newGroups);
-    EXPECT_TRUE(agentInfo->SaveGroups());
-    EXPECT_EQ(agentInfo->GetGroups(), newGroups);
+    m_agentInfo->SetGroups(newGroups);
+    EXPECT_TRUE(m_agentInfo->SaveGroups());
+    EXPECT_EQ(m_agentInfo->GetGroups(), newGroups);
 }
 
 TEST_F(AgentInfoTest, TestSave)
 {
     // Mock for: m_persistence->ResetToDefault();
-    EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
-    EXPECT_CALL(*mockPersistence, DropTable("agent_group")).Times(1);
-    EXPECT_CALL(*mockPersistence, CreateTable(testing::_, testing::_)).Times(2);
-    EXPECT_CALL(*mockPersistence, GetCount("agent_info", testing::_, testing::_)).WillOnce(testing::Return(0));
-    EXPECT_CALL(*mockPersistence, Insert(testing::_, testing::_)).Times(1);
+    EXPECT_CALL(*m_mockPersistence, DropTable("agent_info")).Times(1);
+    EXPECT_CALL(*m_mockPersistence, DropTable("agent_group")).Times(1);
+    EXPECT_CALL(*m_mockPersistence, CreateTable(testing::_, testing::_)).Times(2);
+    EXPECT_CALL(*m_mockPersistence, GetCount("agent_info", testing::_, testing::_)).WillOnce(testing::Return(0));
+    EXPECT_CALL(*m_mockPersistence, Insert(testing::_, testing::_)).Times(1);
 
     // Mock for: m_persistence->SetName(m_name); m_persistence->SetKey(m_key); m_persistence->SetUUID(m_uuid);
-    EXPECT_CALL(*mockPersistence, Update("agent_info", testing::_, testing::_, testing::_)).Times(3);
+    EXPECT_CALL(*m_mockPersistence, Update("agent_info", testing::_, testing::_, testing::_)).Times(3);
 
     // Mock for: m_persistence->SetGroups(m_groups);
-    EXPECT_CALL(*mockPersistence, BeginTransaction()).Times(1);
-    EXPECT_CALL(*mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
-    EXPECT_CALL(*mockPersistence, Insert("agent_group", testing::_)).Times(1);
-    EXPECT_CALL(*mockPersistence, CommitTransaction(testing::_)).Times(1);
-    agentInfo->Save();
+    EXPECT_CALL(*m_mockPersistence, BeginTransaction()).Times(1);
+    EXPECT_CALL(*m_mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
+    EXPECT_CALL(*m_mockPersistence, CommitTransaction(testing::_)).Times(1);
+    m_agentInfo->Save();
 }
 
 TEST_F(AgentInfoTest, TestLoadMetadataInfoNoSysInfo)
 {
     InitializeAgentInfo(nullptr, nullptr, true);
 
-    auto metadataInfo = nlohmann::json::parse(agentInfo->GetMetadataInfo());
+    const auto metadataInfo = nlohmann::json::parse(m_agentInfo->GetMetadataInfo());
 
     EXPECT_TRUE(metadataInfo != nullptr);
 
     // Agent information
-    EXPECT_EQ(metadataInfo["type"], agentInfo->GetType());
-    EXPECT_EQ(metadataInfo["version"], agentInfo->GetVersion());
-    EXPECT_EQ(metadataInfo["id"], agentInfo->GetUUID());
-    EXPECT_EQ(metadataInfo["name"], agentInfo->GetName());
-    EXPECT_EQ(metadataInfo["key"], agentInfo->GetKey());
-    EXPECT_TRUE(metadataInfo["groups"] == nullptr);
+    EXPECT_EQ(metadataInfo["type"], m_agentInfo->GetType());
+    EXPECT_EQ(metadataInfo["version"], m_agentInfo->GetVersion());
+    EXPECT_EQ(metadataInfo["id"], m_agentInfo->GetUUID());
+    EXPECT_EQ(metadataInfo["name"], m_agentInfo->GetName());
+    EXPECT_EQ(metadataInfo["key"], m_agentInfo->GetKey());
+    EXPECT_FALSE(metadataInfo.contains("groups"));
 
     // Endpoint information
-    EXPECT_TRUE(metadataInfo["host"] == nullptr);
+    EXPECT_FALSE(metadataInfo.contains("host"));
 }
 
 TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
@@ -212,28 +211,28 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoRegistration)
 
     InitializeAgentInfo([os]() { return os; }, [networks]() { return networks; }, true);
 
-    auto metadataInfo = nlohmann::json::parse(agentInfo->GetMetadataInfo());
+    const auto metadataInfo = nlohmann::json::parse(m_agentInfo->GetMetadataInfo());
 
     EXPECT_TRUE(metadataInfo != nullptr);
 
     // Agent information
-    EXPECT_EQ(metadataInfo["type"], agentInfo->GetType());
-    EXPECT_EQ(metadataInfo["version"], agentInfo->GetVersion());
-    EXPECT_EQ(metadataInfo["id"], agentInfo->GetUUID());
-    EXPECT_EQ(metadataInfo["name"], agentInfo->GetName());
-    EXPECT_EQ(metadataInfo["key"], agentInfo->GetKey());
-    EXPECT_TRUE(metadataInfo["groups"] == nullptr);
+    EXPECT_EQ(metadataInfo["type"], m_agentInfo->GetType());
+    EXPECT_EQ(metadataInfo["version"], m_agentInfo->GetVersion());
+    EXPECT_EQ(metadataInfo["id"], m_agentInfo->GetUUID());
+    EXPECT_EQ(metadataInfo["name"], m_agentInfo->GetName());
+    EXPECT_EQ(metadataInfo["key"], m_agentInfo->GetKey());
+    EXPECT_FALSE(metadataInfo.contains("groups"));
 
     // Endpoint information
-    EXPECT_TRUE(metadataInfo["host"] != nullptr);
-    EXPECT_TRUE(metadataInfo["host"]["os"] != nullptr);
+    EXPECT_TRUE(metadataInfo.contains("host"));
+    EXPECT_TRUE(metadataInfo["host"].contains("os"));
     EXPECT_EQ(metadataInfo["host"]["os"]["name"], "test_os");
     EXPECT_EQ(metadataInfo["host"]["os"]["type"], "test_type");
     EXPECT_EQ(metadataInfo["host"]["os"]["version"], "1.0.0");
-    EXPECT_TRUE(metadataInfo["host"]["ip"] != nullptr);
+    EXPECT_TRUE(metadataInfo["host"].contains("ip"));
     EXPECT_EQ(metadataInfo["host"]["ip"][0], "127.0.0.1");
     EXPECT_EQ(metadataInfo["host"]["ip"][1], "fe80::0000");
-    EXPECT_TRUE(metadataInfo["host"]["ip"][2] == nullptr);
+    EXPECT_LT(metadataInfo["host"]["ip"].size(), 3);
     EXPECT_EQ(metadataInfo["host"]["architecture"], "test_arch");
     EXPECT_EQ(metadataInfo["host"]["hostname"], "test_name");
 }
@@ -263,25 +262,25 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoConnected)
 
     InitializeAgentInfo([os]() { return os; }, [networks]() { return networks; });
 
-    auto metadataInfo = nlohmann::json::parse(agentInfo->GetMetadataInfo());
+    const auto metadataInfo = nlohmann::json::parse(m_agentInfo->GetMetadataInfo());
 
-    EXPECT_TRUE(metadataInfo["agent"] != nullptr);
+    EXPECT_TRUE(metadataInfo.contains("agent"));
 
     // Agent information
-    EXPECT_EQ(metadataInfo["agent"]["type"], agentInfo->GetType());
-    EXPECT_EQ(metadataInfo["agent"]["version"], agentInfo->GetVersion());
-    EXPECT_EQ(metadataInfo["agent"]["id"], agentInfo->GetUUID());
-    EXPECT_EQ(metadataInfo["agent"]["name"], agentInfo->GetName());
-    EXPECT_TRUE(metadataInfo["agent"]["key"] == nullptr);
-    EXPECT_TRUE(metadataInfo["agent"]["groups"] != nullptr);
+    EXPECT_EQ(metadataInfo["agent"]["type"], m_agentInfo->GetType());
+    EXPECT_EQ(metadataInfo["agent"]["version"], m_agentInfo->GetVersion());
+    EXPECT_EQ(metadataInfo["agent"]["id"], m_agentInfo->GetUUID());
+    EXPECT_EQ(metadataInfo["agent"]["name"], m_agentInfo->GetName());
+    EXPECT_FALSE(metadataInfo["agent"].contains("key"));
+    EXPECT_TRUE(metadataInfo["agent"].contains("groups"));
 
     // Endpoint information
-    EXPECT_TRUE(metadataInfo["agent"]["host"] != nullptr);
-    EXPECT_TRUE(metadataInfo["agent"]["host"]["os"] != nullptr);
+    EXPECT_TRUE(metadataInfo["agent"].contains("host"));
+    EXPECT_TRUE(metadataInfo["agent"]["host"].contains("os"));
     EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["name"], "test_os");
     EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["type"], "test_type");
     EXPECT_EQ(metadataInfo["agent"]["host"]["os"]["version"], "1.0.0");
-    EXPECT_TRUE(metadataInfo["agent"]["host"]["ip"] != nullptr);
+    EXPECT_TRUE(metadataInfo["agent"]["host"].contains("ip"));
     EXPECT_EQ(metadataInfo["agent"]["host"]["ip"][0], "127.0.0.1");
     EXPECT_EQ(metadataInfo["agent"]["host"]["architecture"], "test_arch");
     EXPECT_EQ(metadataInfo["agent"]["host"]["hostname"], "test_name");
@@ -289,10 +288,10 @@ TEST_F(AgentInfoTest, TestLoadMetadataInfoConnected)
 
 TEST_F(AgentInfoTest, TestLoadHeaderInfo)
 {
-    auto headerInfo = agentInfo->GetHeaderInfo();
+    auto headerInfo = m_agentInfo->GetHeaderInfo();
 
     EXPECT_NE(headerInfo, "");
-    EXPECT_TRUE(headerInfo.starts_with("WazuhXDR/" + agentInfo->GetVersion() + " (" + agentInfo->GetType() + "; "));
+    EXPECT_TRUE(headerInfo.starts_with("WazuhXDR/" + m_agentInfo->GetVersion() + " (" + m_agentInfo->GetType() + "; "));
 }
 
 int main(int argc, char** argv)

--- a/src/agent/include/agent.hpp
+++ b/src/agent/include/agent.hpp
@@ -29,11 +29,13 @@ public:
     /// @param configFilePath Path to the configuration file
     /// @param signalHandler Pointer to a custom ISignalHandler implementation
     /// @param httpClient Pointer to an IHttpClient implementation
+    /// @param agentInfo Optional AgentInfo object
     /// @throws std::runtime_error If the Agent is not registered
     /// @throws Any exception propagated from dependencies used within the constructor
     Agent(const std::string& configFilePath,
           std::unique_ptr<ISignalHandler> signalHandler = std::make_unique<SignalHandler>(),
-          std::unique_ptr<http_client::IHttpClient> httpClient = nullptr);
+          std::unique_ptr<http_client::IHttpClient> httpClient = nullptr,
+          std::optional<AgentInfo> agentInfo = std::nullopt);
 
     /// @brief Destructor
     ~Agent();

--- a/src/agent/include/agent_registration.hpp
+++ b/src/agent/include/agent_registration.hpp
@@ -35,6 +35,7 @@ namespace agent_registration
         /// @param name The agent's name.
         /// @param dbFolderPath The path to the database folder.
         /// @param verificationMode The connection verification mode.
+        /// @param agentInfo Optional agent's information object.
         AgentRegistration(std::unique_ptr<http_client::IHttpClient> httpClient,
                           std::string url,
                           std::string user,
@@ -42,7 +43,8 @@ namespace agent_registration
                           const std::string& key,
                           const std::string& name,
                           const std::string& dbFolderPath,
-                          std::string verificationMode);
+                          std::string verificationMode,
+                          std::optional<AgentInfo> agentInfo = std::nullopt);
 
         /// @brief Registers the agent with the manager.
         ///

--- a/src/agent/persistence/tests/mocks/mocks_persistence.hpp
+++ b/src/agent/persistence/tests/mocks/mocks_persistence.hpp
@@ -1,0 +1,50 @@
+#include <gmock/gmock.h>
+
+#include <persistence.hpp>
+
+#include <string>
+#include <vector>
+
+class MockPersistence : public Persistence
+{
+public:
+    MOCK_METHOD(bool, TableExists, (const std::string& tableName), (override));
+    MOCK_METHOD(void, CreateTable, (const std::string& tableName, const column::Keys& cols), (override));
+    MOCK_METHOD(void, Insert, (const std::string& tableName, const column::Row& cols), (override));
+    MOCK_METHOD(void,
+                Update,
+                (const std::string& tableName,
+                 const column::Row& fields,
+                 const column::Criteria& selCriteria,
+                 column::LogicalOperator logOp),
+                (override));
+    MOCK_METHOD(void,
+                Remove,
+                (const std::string& tableName, const column::Criteria& selCriteria, column::LogicalOperator logOp),
+                (override));
+    MOCK_METHOD(void, DropTable, (const std::string& tableName), (override));
+    MOCK_METHOD(std::vector<column::Row>,
+                Select,
+                (const std::string& tableName,
+                 const column::Names& fields,
+                 const column::Criteria& selCriteria,
+                 column::LogicalOperator logOp,
+                 const column::Names& orderBy,
+                 column::OrderType orderType,
+                 int limit),
+                (override));
+    MOCK_METHOD(int,
+                GetCount,
+                (const std::string& tableName, const column::Criteria& selCriteria, column::LogicalOperator logOp),
+                (override));
+    MOCK_METHOD(size_t,
+                GetSize,
+                (const std::string& tableName,
+                 const column::Names& fields,
+                 const column::Criteria& selCriteria,
+                 column::LogicalOperator logOp),
+                (override));
+    MOCK_METHOD(TransactionId, BeginTransaction, (), (override));
+    MOCK_METHOD(void, CommitTransaction, (TransactionId transactionId), (override));
+    MOCK_METHOD(void, RollbackTransaction, (TransactionId transactionId), (override));
+};

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -14,11 +14,16 @@ namespace agent_registration
                                          std::string password,
                                          const std::string& key,
                                          const std::string& name,
-                                         const std::string& dbFolderPath,
-                                         std::string verificationMode)
+                                         [[maybe_unused]] const std::string& dbFolderPath,
+                                         std::string verificationMode,
+                                         std::optional<AgentInfo> agentInfo)
         : m_httpClient(std::move(httpClient))
-        , m_agentInfo(
-              dbFolderPath, [this]() { return m_sysInfo.os(); }, [this]() { return m_sysInfo.networks(); }, true)
+        , m_agentInfo(agentInfo.has_value() ? std::move(*agentInfo)
+                                            : AgentInfo(
+                                                  dbFolderPath,
+                                                  [this]() { return m_sysInfo.os(); },
+                                                  [this]() { return m_sysInfo.networks(); },
+                                                  true))
         , m_serverUrl(std::move(url))
         , m_user(std::move(user))
         , m_password(std::move(password))

--- a/src/agent/src/agent_registration.cpp
+++ b/src/agent/src/agent_registration.cpp
@@ -14,7 +14,7 @@ namespace agent_registration
                                          std::string password,
                                          const std::string& key,
                                          const std::string& name,
-                                         [[maybe_unused]] const std::string& dbFolderPath,
+                                         const std::string& dbFolderPath,
                                          std::string verificationMode,
                                          std::optional<AgentInfo> agentInfo)
         : m_httpClient(std::move(httpClient))

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -2,8 +2,11 @@ find_package(GTest CONFIG REQUIRED)
 
 add_executable(agent_test agent_test.cpp)
 configure_target(agent_test)
-target_include_directories(agent_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-target_link_libraries(agent_test PRIVATE Agent GTest::gtest GTest::gmock)
+target_include_directories(agent_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../agent_info/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../persistence/tests/mocks)
+target_link_libraries(agent_test PRIVATE Agent Persistence GTest::gtest GTest::gmock)
 
 if(NOT WIN32)
     add_test(NAME AgentTest COMMAND agent_test)

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(agent_registration_test agent_registration_test.cpp)
 configure_target(agent_registration_test)
 target_include_directories(agent_registration_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
     ${CMAKE_CURRENT_SOURCE_DIR}/../agent_info/src)
-target_link_libraries(agent_registration_test PRIVATE Agent GTest::gmock GTest::gtest)
+target_link_libraries(agent_registration_test PRIVATE Agent Persistence GTest::gmock GTest::gtest)
 add_test(NAME AgentRegistrationTest COMMAND agent_registration_test)
 
 add_executable(signal_handler_test signal_handler_test.cpp)

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -11,8 +11,10 @@ endif()
 
 add_executable(agent_registration_test agent_registration_test.cpp)
 configure_target(agent_registration_test)
-target_include_directories(agent_registration_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
-    ${CMAKE_CURRENT_SOURCE_DIR}/../agent_info/src)
+target_include_directories(agent_registration_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../agent_info/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../persistence/tests/mocks)
 target_link_libraries(agent_registration_test PRIVATE Agent Persistence GTest::gmock GTest::gtest)
 add_test(NAME AgentRegistrationTest COMMAND agent_registration_test)
 

--- a/src/agent/tests/agent_registration_test.cpp
+++ b/src/agent/tests/agent_registration_test.cpp
@@ -7,6 +7,7 @@
 #include <ihttp_client.hpp>
 
 #include "../http_client/tests/mocks/mock_http_client.hpp"
+#include <mocks_persistence.hpp>
 
 #include <boost/asio.hpp>
 #include <nlohmann/json.hpp>
@@ -20,32 +21,70 @@ class RegisterTest : public ::testing::Test
 protected:
     void SetUp() override
     {
+        auto mockPersistencePtr = std::make_unique<MockPersistence>();
+        mockPersistence = mockPersistencePtr.get();
+
+        SetConstructorPersistenceExpectCalls();
+
         SysInfo sysInfo;
         agent = std::make_unique<AgentInfo>(
             ".",
-            [&sysInfo]() mutable { return sysInfo.os(); },
-            [&sysInfo]() mutable { return sysInfo.networks(); },
-            true);
+            [sysInfo]() mutable { return sysInfo.os(); },
+            [sysInfo]() mutable { return sysInfo.networks(); },
+            true,
+            std::make_shared<AgentInfoPersistance>("db_path", std::move(mockPersistencePtr)));
 
         agent->SetKey("4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj");
         agent->SetName("agent_name");
-        agent->Save();
+    }
+
+    void SetConstructorPersistenceExpectCalls()
+    {
+        EXPECT_CALL(*mockPersistence, TableExists("agent_info")).WillOnce(testing::Return(true));
+        EXPECT_CALL(*mockPersistence, TableExists("agent_group")).WillOnce(testing::Return(true));
+        EXPECT_CALL(*mockPersistence, GetCount("agent_info", testing::_, testing::_))
+            .WillOnce(testing::Return(0))
+            .WillOnce(testing::Return(0));
+        EXPECT_CALL(*mockPersistence, Insert("agent_info", testing::_)).Times(1);
+    }
+
+    void SetAgentInfoSaveExpectCalls()
+    {
+        // Mock for: m_persistence->ResetToDefault();
+        EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
+        EXPECT_CALL(*mockPersistence, DropTable("agent_group")).Times(1);
+        EXPECT_CALL(*mockPersistence, CreateTable(testing::_, testing::_)).Times(2);
+        EXPECT_CALL(*mockPersistence, GetCount("agent_info", testing::_, testing::_)).WillOnce(testing::Return(0));
+        EXPECT_CALL(*mockPersistence, Insert(testing::_, testing::_)).Times(1);
+
+        // Mock for: m_persistence->SetName(m_name); m_persistence->SetKey(m_key); m_persistence->SetUUID(m_uuid);
+        EXPECT_CALL(*mockPersistence, Update("agent_info", testing::_, testing::_, testing::_)).Times(3);
+
+        // Mock for: m_persistence->SetGroups(m_groups);
+        EXPECT_CALL(*mockPersistence, BeginTransaction()).Times(1);
+        EXPECT_CALL(*mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
+        EXPECT_CALL(*mockPersistence, CommitTransaction(testing::_)).Times(1);
     }
 
     std::unique_ptr<AgentInfo> agent;
     std::unique_ptr<agent_registration::AgentRegistration> registration;
+    MockPersistence* mockPersistence = nullptr;
 };
 
 TEST_F(RegisterTest, RegistrationTestSuccess)
 {
-    AgentInfoPersistance agentInfoPersistance(".");
-    agentInfoPersistance.ResetToDefault();
-
     auto mockHttpClient = std::make_unique<MockHttpClient>();
     auto mockHttpClientPtr = mockHttpClient.get();
 
-    registration = std::make_unique<agent_registration::AgentRegistration>(
-        std::move(mockHttpClient), "https://localhost:55000", "user", "password", "", "", ".", "full");
+    registration = std::make_unique<agent_registration::AgentRegistration>(std::move(mockHttpClient),
+                                                                           "https://localhost:55000",
+                                                                           "user",
+                                                                           "password",
+                                                                           "",
+                                                                           "",
+                                                                           ".",
+                                                                           "full",
+                                                                           std::move(*agent));
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     std::tuple<int, std::string> expectedResponse1 {200, R"({"data":{"token":"token"}})"};
@@ -59,15 +98,15 @@ TEST_F(RegisterTest, RegistrationTestSuccess)
         .WillOnce(testing::Return(expectedResponse2));
 
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+
+    SetAgentInfoSaveExpectCalls();
+
     const bool res = registration->Register();
     ASSERT_TRUE(res);
 }
 
 TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
 {
-    AgentInfoPersistance agentInfoPersistance(".");
-    agentInfoPersistance.ResetToDefault();
-
     auto mockHttpClient = std::make_unique<MockHttpClient>();
     auto mockHttpClientPtr = mockHttpClient.get();
 
@@ -78,7 +117,8 @@ TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
                                                                            "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj",
                                                                            "agent_name",
                                                                            ".",
-                                                                           "certificate");
+                                                                           "certificate",
+                                                                           std::move(*agent));
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     std::tuple<int, std::string> expectedResponse {401, ""};
@@ -92,9 +132,6 @@ TEST_F(RegisterTest, RegistrationFailsIfAuthenticationFails)
 
 TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
 {
-    AgentInfoPersistance agentInfoPersistance(".");
-    agentInfoPersistance.ResetToDefault();
-
     auto mockHttpClient = std::make_unique<MockHttpClient>();
     auto mockHttpClientPtr = mockHttpClient.get();
 
@@ -105,7 +142,8 @@ TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
                                                                            "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj",
                                                                            "agent_name",
                                                                            ".",
-                                                                           "none");
+                                                                           "none",
+                                                                           std::move(*agent));
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     std::tuple<int, std::string> expectedResponse1 {200, R"({"data":{"token":"token"}})"};
@@ -125,16 +163,18 @@ TEST_F(RegisterTest, RegistrationFailsIfServerResponseIsNotOk)
 
 TEST_F(RegisterTest, RegisteringWithoutAKeyGeneratesOneAutomatically)
 {
-    AgentInfoPersistance agentInfoPersistance(".");
-    agentInfoPersistance.ResetToDefault();
-
-    EXPECT_TRUE(agentInfoPersistance.GetKey().empty());
-
     auto mockHttpClient = std::make_unique<MockHttpClient>();
     auto mockHttpClientPtr = mockHttpClient.get();
 
-    registration = std::make_unique<agent_registration::AgentRegistration>(
-        std::move(mockHttpClient), "https://localhost:55000", "user", "password", "", "agent_name", ".", "full");
+    registration = std::make_unique<agent_registration::AgentRegistration>(std::move(mockHttpClient),
+                                                                           "https://localhost:55000",
+                                                                           "user",
+                                                                           "password",
+                                                                           "",
+                                                                           "agent_name",
+                                                                           ".",
+                                                                           "full",
+                                                                           std::move(*agent));
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     std::tuple<int, std::string> expectedResponse1 {200, R"({"data":{"token":"token"}})"};
@@ -148,10 +188,53 @@ TEST_F(RegisterTest, RegisteringWithoutAKeyGeneratesOneAutomatically)
         .WillOnce(testing::Return(expectedResponse2));
 
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+
+    // Mock for: m_persistence->ResetToDefault();
+    EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
+    EXPECT_CALL(*mockPersistence, DropTable("agent_group")).Times(1);
+    EXPECT_CALL(*mockPersistence, CreateTable(testing::_, testing::_)).Times(2);
+    EXPECT_CALL(*mockPersistence, GetCount("agent_info", testing::_, testing::_)).WillOnce(testing::Return(0));
+    EXPECT_CALL(*mockPersistence, Insert(testing::_, testing::_)).Times(1);
+
+    // Mock for: m_persistence->SetName(m_name); m_persistence->SetKey(m_key); m_persistence->SetUUID(m_uuid);
+    testing::InSequence seq;
+    EXPECT_CALL(*mockPersistence,
+                Update(testing::Eq("agent_info"),
+                       testing::AllOf(
+                           testing::SizeIs(1),
+                           testing::Contains(testing::AllOf(testing::Field(&column::ColumnValue::Value, "agent_name"),
+                                                            testing::Field(&column::ColumnName::Name, "name")))),
+                       testing::_,
+                       testing::_))
+        .Times(1);
+
+    EXPECT_CALL(*mockPersistence,
+                Update(testing::Eq("agent_info"),
+                       testing::AllOf(testing::SizeIs(1),
+                                      testing::Contains(testing::AllOf(
+                                          testing::Field(&column::ColumnValue::Value, testing::Not(testing::Eq(""))),
+                                          testing::Field(&column::ColumnName::Name, "key")))),
+                       testing::_,
+                       testing::_))
+        .Times(1);
+
+    EXPECT_CALL(*mockPersistence,
+                Update(testing::Eq("agent_info"),
+                       testing::AllOf(testing::SizeIs(1),
+                                      testing::Contains(testing::AllOf(
+                                          testing::Field(&column::ColumnValue::Value, testing::Not(testing::Eq(""))),
+                                          testing::Field(&column::ColumnName::Name, "uuid")))),
+                       testing::_,
+                       testing::_))
+        .Times(1);
+
+    // Mock for: m_persistence->SetGroups(m_groups);
+    EXPECT_CALL(*mockPersistence, BeginTransaction()).Times(1);
+    EXPECT_CALL(*mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
+    EXPECT_CALL(*mockPersistence, CommitTransaction(testing::_)).Times(1);
+
     const bool res = registration->Register();
     ASSERT_TRUE(res);
-
-    EXPECT_FALSE(agentInfoPersistance.GetKey().empty());
 }
 
 TEST_F(RegisterTest, RegistrationTestFailWithBadKey)
@@ -165,15 +248,17 @@ TEST_F(RegisterTest, RegistrationTestFailWithBadKey)
                                                        "badKey",
                                                        "agent_name",
                                                        ".",
-                                                       "full"),
+                                                       "full",
+                                                       std::move(*agent)),
                  std::invalid_argument);
 }
 
 TEST_F(RegisterTest, RegistrationTestFailWithHttpClientError)
 {
-    ASSERT_THROW(agent_registration::AgentRegistration(
-                     nullptr, "https://localhost:55000", "user", "password", "", "agent_name", ".", "full"),
-                 std::runtime_error);
+    ASSERT_THROW(
+        agent_registration::AgentRegistration(
+            nullptr, "https://localhost:55000", "user", "password", "", "agent_name", ".", "full", std::move(*agent)),
+        std::runtime_error);
 }
 
 TEST_F(RegisterTest, AuthenticateWithUserPassword_Success)
@@ -181,8 +266,15 @@ TEST_F(RegisterTest, AuthenticateWithUserPassword_Success)
     auto mockHttpClient = std::make_unique<MockHttpClient>();
     auto mockHttpClientPtr = mockHttpClient.get();
 
-    registration = std::make_unique<agent_registration::AgentRegistration>(
-        std::move(mockHttpClient), "https://localhost:55000", "user", "password", "", "", ".", "full");
+    registration = std::make_unique<agent_registration::AgentRegistration>(std::move(mockHttpClient),
+                                                                           "https://localhost:55000",
+                                                                           "user",
+                                                                           "password",
+                                                                           "",
+                                                                           "",
+                                                                           ".",
+                                                                           "full",
+                                                                           std::move(*agent));
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     std::tuple<int, std::string> expectedResponse {200, R"({"data":{"token":"valid_token"}})"};
@@ -202,8 +294,15 @@ TEST_F(RegisterTest, AuthenticateWithUserPassword_Failure)
     auto mockHttpClient = std::make_unique<MockHttpClient>();
     auto mockHttpClientPtr = mockHttpClient.get();
 
-    registration = std::make_unique<agent_registration::AgentRegistration>(
-        std::move(mockHttpClient), "https://localhost:55000", "user", "password", "", "", ".", "full");
+    registration = std::make_unique<agent_registration::AgentRegistration>(std::move(mockHttpClient),
+                                                                           "https://localhost:55000",
+                                                                           "user",
+                                                                           "password",
+                                                                           "",
+                                                                           "",
+                                                                           ".",
+                                                                           "full",
+                                                                           std::move(*agent));
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     std::tuple<int, std::string> expectedResponse {401, ""};

--- a/src/agent/tests/agent_test.cpp
+++ b/src/agent/tests/agent_test.cpp
@@ -19,8 +19,8 @@ class AgentTests : public ::testing::Test
 protected:
     std::string AGENT_CONFIG_PATH;
     std::string AGENT_PATH;
-    std::unique_ptr<AgentInfo> agentInfo;
-    MockPersistence* mockPersistence = nullptr;
+    std::unique_ptr<AgentInfo> m_agentInfo;
+    MockPersistence* m_mockPersistence = nullptr;
 
     void SetUp() override
     {
@@ -40,20 +40,20 @@ protected:
         CreateTempConfigFile();
 
         auto mockPersistencePtr = std::make_unique<MockPersistence>();
-        mockPersistence = mockPersistencePtr.get();
+        m_mockPersistence = mockPersistencePtr.get();
 
         SetConstructorPersistenceExpectCalls();
 
         SysInfo sysInfo;
-        agentInfo = std::make_unique<AgentInfo>(
+        m_agentInfo = std::make_unique<AgentInfo>(
             AGENT_PATH,
             [sysInfo]() mutable { return sysInfo.os(); },
             [sysInfo]() mutable { return sysInfo.networks(); },
             false,
             std::make_shared<AgentInfoPersistance>("db_path", std::move(mockPersistencePtr)));
 
-        agentInfo->SetKey("4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj");
-        agentInfo->SetName("agent_name");
+        m_agentInfo->SetKey("4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj");
+        m_agentInfo->SetName("agent_name");
     }
 
     void TearDown() override
@@ -107,21 +107,21 @@ logcollector:
         std::vector<column::Row> mockRowUUID = {{}};
         std::vector<column::Row> mockRowGroup = {{}};
 
-        EXPECT_CALL(*mockPersistence, TableExists("agent_info")).WillOnce(testing::Return(true));
-        EXPECT_CALL(*mockPersistence, TableExists("agent_group")).WillOnce(testing::Return(true));
-        EXPECT_CALL(*mockPersistence, GetCount("agent_info", testing::_, testing::_))
+        EXPECT_CALL(*m_mockPersistence, TableExists("agent_info")).WillOnce(testing::Return(true));
+        EXPECT_CALL(*m_mockPersistence, TableExists("agent_group")).WillOnce(testing::Return(true));
+        EXPECT_CALL(*m_mockPersistence, GetCount("agent_info", testing::_, testing::_))
             .WillOnce(testing::Return(0))
             .WillOnce(testing::Return(0));
-        EXPECT_CALL(*mockPersistence, Insert("agent_info", testing::_)).Times(1);
+        EXPECT_CALL(*m_mockPersistence, Insert("agent_info", testing::_)).Times(1);
 
         testing::Sequence seq;
-        EXPECT_CALL(*mockPersistence,
+        EXPECT_CALL(*m_mockPersistence,
                     Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
             .InSequence(seq)
             .WillOnce(testing::Return(mockRowName))
             .WillOnce(testing::Return(mockRowKey))
             .WillOnce(testing::Return(mockRowUUID));
-        EXPECT_CALL(*mockPersistence,
+        EXPECT_CALL(*m_mockPersistence,
                     Select("agent_group", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
             .WillOnce(testing::Return(mockRowGroup));
     }
@@ -145,7 +145,7 @@ TEST_F(AgentTests, AgentStopsWhenSignalReceived)
     EXPECT_CALL(*mockHttpClient, PerformHttpRequest(testing::_))
         .WillRepeatedly(testing::Invoke([&expectedResponse]() -> intStringTuple { return expectedResponse; }));
 
-    Agent agent(AGENT_CONFIG_PATH, std::move(mockSignalHandler), std::move(mockHttpClient), std::move(*agentInfo));
+    Agent agent(AGENT_CONFIG_PATH, std::move(mockSignalHandler), std::move(mockHttpClient), std::move(*m_agentInfo));
 
     EXPECT_NO_THROW(agent.Run());
     EXPECT_TRUE(WaitForSignalCalled);


### PR DESCRIPTION
## Description

This PR adds the necessary changes to avoid the use and/or creation of the `agent_info.db` database in the UTs.

## Proposed Changes

The [Persistence](https://github.com/wazuh/wazuh-agent/blob/main/src/agent/persistence/include/persistence.hpp) interface is used to declare a mock class(MockPersistence) that implements this interface in order to mock the methods used by AgentInfoPersistance

The changes include:

- Creation of class MockPersistence
- Changes in the constructor of AgentInfoPersistance to be able to inject the object of the MockPersistence class.
- Creating UTs for AgentInfoPersistance
- Changes in the constructor of AgentInfo, AgentRegistration and Agent to be able to inject an object of the AgentInfoPersistance class created with the MockPersistence object injection.
- Correction of AgentInfo, AgentRegistration and Agent UTs


<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

#### Running of the Agent:

Agent Registration:

```bash
ls /var/lib/wazuh-agent/

./wazuh-agent --register-agent --password wazuh --user wazuh --url https://192.168.0.177:55000
Starting wazuh-agent registration
wazuh-agent registered

ls /var/lib/wazuh-agent/
agent_info.db

sqlite3 /var/lib/wazuh-agent/agent_info.db "select * from agent_info;"
nico-VirtualBox|MA9quV4YbKVe6t02BpNald22hXZy7E6z|43ed9670-06ac-41d5-b1d2-72273b6fb3e8
```

Agent Run:

```bash
./wazuh-agent 
[2025-02-11 11:59:00.222] [wazuh-agent] [info] [INFO] [process_options_unix.cpp:24] [StartAgent] Starting wazuh-agent
[2025-02-11 11:59:00.722] [wazuh-agent] [info] [INFO] [communicator.cpp:113] [SendAuthenticationRequest] Successfully authenticated with the manager.
[2025-02-11 11:59:00.769] [wazuh-agent] [info] [INFO] [inventory.cpp:19] [Start] Inventory module started.
[2025-02-11 11:59:00.777] [wazuh-agent] [info] [INFO] [logcollector.cpp:28] [Start] Logcollector module is disabled.
[2025-02-11 11:59:00.808] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:991] [SyncLoop] Module started.
[2025-02-11 12:01:01.316] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:974] [Scan] Starting evaluation.
[2025-02-11 12:01:36.321] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:986] [Scan] Evaluation finished.
```

AgentInfoPersistance Test:

```bash
ls
agent_info_persistance_test  agent_info_test  CMakeFiles  cmake_install.cmake  CTestTestfile.cmake  Makefile
nico@nico-VirtualBox:~/wazuh-agent/build/agent/agent_info/tests$ ./agent_info_persistance_test 
[==========] Running 32 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 32 tests from AgentInfoPersistanceTest
[ RUN      ] AgentInfoPersistanceTest.TestConstruction
[       OK ] AgentInfoPersistanceTest.TestConstruction (3 ms)
[ RUN      ] AgentInfoPersistanceTest.TestGetNameValue
[       OK ] AgentInfoPersistanceTest.TestGetNameValue (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestGetNameNotValue
[       OK ] AgentInfoPersistanceTest.TestGetNameNotValue (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestGetNameCatch
[2025-02-11 12:08:23.524] [error] [ERROR] [agent_info_persistance.cpp:168] [GetAgentInfoValue] Error fetching name: Error Select.
[       OK ] AgentInfoPersistanceTest.TestGetNameCatch (435 ms)
[ RUN      ] AgentInfoPersistanceTest.TestGetKeyValue
[       OK ] AgentInfoPersistanceTest.TestGetKeyValue (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestGetKeyNotValue
[       OK ] AgentInfoPersistanceTest.TestGetKeyNotValue (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestGetKeyCatch
[2025-02-11 12:08:23.527] [error] [ERROR] [agent_info_persistance.cpp:168] [GetAgentInfoValue] Error fetching key: Error Select.
[       OK ] AgentInfoPersistanceTest.TestGetKeyCatch (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestGetUUIDValue
[       OK ] AgentInfoPersistanceTest.TestGetUUIDValue (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestGetUUIDNotValue
[       OK ] AgentInfoPersistanceTest.TestGetUUIDNotValue (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestGetUUIDCatch
[2025-02-11 12:08:23.527] [error] [ERROR] [agent_info_persistance.cpp:168] [GetAgentInfoValue] Error fetching uuid: Error Select.
[       OK ] AgentInfoPersistanceTest.TestGetUUIDCatch (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestGetGroupsValue
[       OK ] AgentInfoPersistanceTest.TestGetGroupsValue (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestGetGroupsNotValue
[       OK ] AgentInfoPersistanceTest.TestGetGroupsNotValue (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestGetGroupsCatch
[2025-02-11 12:08:23.527] [error] [ERROR] [agent_info_persistance.cpp:208] [GetGroups] Error getting agent group list: Error Select.
[       OK ] AgentInfoPersistanceTest.TestGetGroupsCatch (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetName
[       OK ] AgentInfoPersistanceTest.TestSetName (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetNameCatch
[2025-02-11 12:08:23.527] [error] [ERROR] [agent_info_persistance.cpp:146] [SetAgentInfoValue] Error updating name: Error Update.
[       OK ] AgentInfoPersistanceTest.TestSetNameCatch (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetKey
[       OK ] AgentInfoPersistanceTest.TestSetKey (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetKeyCatch
[2025-02-11 12:08:23.527] [error] [ERROR] [agent_info_persistance.cpp:146] [SetAgentInfoValue] Error updating key: Error Update.
[       OK ] AgentInfoPersistanceTest.TestSetKeyCatch (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetUUID
[       OK ] AgentInfoPersistanceTest.TestSetUUID (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetUUIDCatch
[2025-02-11 12:08:23.527] [error] [ERROR] [agent_info_persistance.cpp:146] [SetAgentInfoValue] Error updating uuid: Error Update.
[       OK ] AgentInfoPersistanceTest.TestSetUUIDCatch (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetGroupsSuccess
[       OK ] AgentInfoPersistanceTest.TestSetGroupsSuccess (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetGroupsBeginTransactionFails
[2025-02-11 12:08:23.541] [error] [ERROR] [agent_info_persistance.cpp:240] [SetGroups] Failed to begin transaction: Error BeginTransaction.
[       OK ] AgentInfoPersistanceTest.TestSetGroupsBeginTransactionFails (19 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetGroupsRemoveFails
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:258] [SetGroups] Error inserting group: Error Remove.
[       OK ] AgentInfoPersistanceTest.TestSetGroupsRemoveFails (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetGroupsInsertFails1
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:258] [SetGroups] Error inserting group: Error Insert.
[       OK ] AgentInfoPersistanceTest.TestSetGroupsInsertFails1 (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetGroupsInsertFails2
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:258] [SetGroups] Error inserting group: Error Insert.
[       OK ] AgentInfoPersistanceTest.TestSetGroupsInsertFails2 (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetGroupsCommitFails
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:258] [SetGroups] Error inserting group: Error Commit.
[       OK ] AgentInfoPersistanceTest.TestSetGroupsCommitFails (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestSetGroupsRollbackFails
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:258] [SetGroups] Error inserting group: Error Commit.
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:266] [SetGroups] Rollback failed: Error Rollback.
[       OK ] AgentInfoPersistanceTest.TestSetGroupsRollbackFails (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestResetToDefaultSuccess
[       OK ] AgentInfoPersistanceTest.TestResetToDefaultSuccess (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestResetToDefaultDropTableAgentInfoFails
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:287] [ResetToDefault] Error resetting to default values: Error DropTable.
[       OK ] AgentInfoPersistanceTest.TestResetToDefaultDropTableAgentInfoFails (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestResetToDefaultDropTableAgentGroupFails
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:287] [ResetToDefault] Error resetting to default values: Error DropTable.
[       OK ] AgentInfoPersistanceTest.TestResetToDefaultDropTableAgentGroupFails (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestResetToDefaultCreateAgentInfoTableFails
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:92] [CreateAgentInfoTable] Error creating table: Error CreateAgentInfoTable.
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:287] [ResetToDefault] Error resetting to default values: Error CreateAgentInfoTable.
[       OK ] AgentInfoPersistanceTest.TestResetToDefaultCreateAgentInfoTableFails (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestResetToDefaultCreateAgentGroupTableFails
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:109] [CreateAgentGroupTable] Error creating table: Error CreateAgentGroupTable.
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:287] [ResetToDefault] Error resetting to default values: Error CreateAgentGroupTable.
[       OK ] AgentInfoPersistanceTest.TestResetToDefaultCreateAgentGroupTableFails (0 ms)
[ RUN      ] AgentInfoPersistanceTest.TestResetToDefaultInsertFails
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:131] [InsertDefaultAgentInfo] Error inserting default agent info: Error Insert.
[2025-02-11 12:08:23.547] [error] [ERROR] [agent_info_persistance.cpp:287] [ResetToDefault] Error resetting to default values: Error Insert.
[       OK ] AgentInfoPersistanceTest.TestResetToDefaultInsertFails (0 ms)
[----------] 32 tests from AgentInfoPersistanceTest (463 ms total)

[----------] Global test environment tear-down
[==========] 32 tests from 1 test suite ran. (465 ms total)
[  PASSED  ] 32 tests.
nico@nico-VirtualBox:~/wazuh-agent/build/agent/agent_info/tests$ ls
agent_info_persistance_test  agent_info_test  CMakeFiles  cmake_install.cmake  CTestTestfile.cmake  Makefile
```

AgentInfo Test:

```bash
ls
agent_info_persistance_test  agent_info_test  CMakeFiles  cmake_install.cmake  CTestTestfile.cmake  Makefile
nico@nico-VirtualBox:~/wazuh-agent/build/agent/agent_info/tests$ ./agent_info_test 
[==========] Running 13 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 13 tests from AgentInfoTest
[ RUN      ] AgentInfoTest.TestDefaultConstructorDefaultValues
[       OK ] AgentInfoTest.TestDefaultConstructorDefaultValues (62 ms)
[ RUN      ] AgentInfoTest.TestSetName
[       OK ] AgentInfoTest.TestSetName (0 ms)
[ RUN      ] AgentInfoTest.TestSetKey
[       OK ] AgentInfoTest.TestSetKey (0 ms)
[ RUN      ] AgentInfoTest.TestSetBadKey
[       OK ] AgentInfoTest.TestSetBadKey (0 ms)
[ RUN      ] AgentInfoTest.TestSetEmptyKey
[       OK ] AgentInfoTest.TestSetEmptyKey (0 ms)
[ RUN      ] AgentInfoTest.TestSetUUID
[       OK ] AgentInfoTest.TestSetUUID (7 ms)
[ RUN      ] AgentInfoTest.TestSetGroups
[       OK ] AgentInfoTest.TestSetGroups (0 ms)
[ RUN      ] AgentInfoTest.TestSaveGroups
[       OK ] AgentInfoTest.TestSaveGroups (52 ms)
[ RUN      ] AgentInfoTest.TestSave
[       OK ] AgentInfoTest.TestSave (1 ms)
[ RUN      ] AgentInfoTest.TestLoadMetadataInfoNoSysInfo
[       OK ] AgentInfoTest.TestLoadMetadataInfoNoSysInfo (0 ms)
[ RUN      ] AgentInfoTest.TestLoadMetadataInfoRegistration
[       OK ] AgentInfoTest.TestLoadMetadataInfoRegistration (0 ms)
[ RUN      ] AgentInfoTest.TestLoadMetadataInfoConnected
[       OK ] AgentInfoTest.TestLoadMetadataInfoConnected (4 ms)
[ RUN      ] AgentInfoTest.TestLoadHeaderInfo
[       OK ] AgentInfoTest.TestLoadHeaderInfo (0 ms)
[----------] 13 tests from AgentInfoTest (152 ms total)

[----------] Global test environment tear-down
[==========] 13 tests from 1 test suite ran. (152 ms total)
[  PASSED  ] 13 tests.
nico@nico-VirtualBox:~/wazuh-agent/build/agent/agent_info/tests$ ls
agent_info_persistance_test  agent_info_test  CMakeFiles  cmake_install.cmake  CTestTestfile.cmake  Makefile
```

AgentRegistration Test:

```bash
ls
agent_registration_test  agent_test  CMakeFiles  cmake_install.cmake  CTestTestfile.cmake  instance_handler_test  Makefile  message_queue_utils_test  signal_handler_test
nico@nico-VirtualBox:~/wazuh-agent/build/agent/tests$ ./agent_registration_test 
[==========] Running 8 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 8 tests from RegisterTest
[ RUN      ] RegisterTest.RegistrationTestSuccess
[       OK ] RegisterTest.RegistrationTestSuccess (163 ms)
[ RUN      ] RegisterTest.RegistrationFailsIfAuthenticationFails
Error authenticating: 401.
Failed to authenticate with the manager
[       OK ] RegisterTest.RegistrationFailsIfAuthenticationFails (12 ms)
[ RUN      ] RegisterTest.RegistrationFailsIfServerResponseIsNotOk
Registration error: 400.
[       OK ] RegisterTest.RegistrationFailsIfServerResponseIsNotOk (34 ms)
[ RUN      ] RegisterTest.RegisteringWithoutAKeyGeneratesOneAutomatically
[       OK ] RegisterTest.RegisteringWithoutAKeyGeneratesOneAutomatically (27 ms)
[ RUN      ] RegisterTest.RegistrationTestFailWithBadKey
[       OK ] RegisterTest.RegistrationTestFailWithBadKey (179 ms)
[ RUN      ] RegisterTest.RegistrationTestFailWithHttpClientError
[       OK ] RegisterTest.RegistrationTestFailWithHttpClientError (0 ms)
[ RUN      ] RegisterTest.AuthenticateWithUserPassword_Success
[       OK ] RegisterTest.AuthenticateWithUserPassword_Success (14 ms)
[ RUN      ] RegisterTest.AuthenticateWithUserPassword_Failure
Error authenticating: 401.
[       OK ] RegisterTest.AuthenticateWithUserPassword_Failure (3 ms)
[----------] 8 tests from RegisterTest (448 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (463 ms total)
[  PASSED  ] 8 tests.
nico@nico-VirtualBox:~/wazuh-agent/build/agent/tests$ ls
agent_registration_test  agent_test  CMakeFiles  cmake_install.cmake  CTestTestfile.cmake  instance_handler_test  Makefile  message_queue_utils_test  signal_handler_test
```

Agent Test:

```bash
ls
agent_registration_test  agent_test  CMakeFiles  cmake_install.cmake  CTestTestfile.cmake  instance_handler_test  Makefile  message_queue_utils_test  signal_handler_test
nico@nico-VirtualBox:~/wazuh-agent/build/agent/tests$ ./agent_test 
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from AgentTests
[ RUN      ] AgentTests.AgentStopsWhenSignalReceived
[2025-02-11 12:13:25.481] [warning] [WARN] [communicator.cpp:183] [AuthenticateWithUuidAndKey] Error: 401.
[2025-02-11 12:13:25.481] [warning] [WARN] [communicator.cpp:117] [SendAuthenticationRequest] Failed to authenticate with the manager. Retrying in 30 seconds.
[2025-02-11 12:13:25.481] [warning] [WARN] [communicator.cpp:183] [AuthenticateWithUuidAndKey] Error: 401.
[2025-02-11 12:13:25.481] [warning] [WARN] [communicator.cpp:117] [SendAuthenticationRequest] Failed to authenticate with the manager. Retrying in 30 seconds.
[2025-02-11 12:13:25.640] [info] [INFO] [inventory.cpp:14] [Start] Inventory module is disabled.
[2025-02-11 12:13:25.643] [info] [INFO] [logcollector.cpp:28] [Start] Logcollector module is disabled.
[2025-02-11 12:13:25.665] [info] [INFO] [inventory.cpp:78] [Stop] Inventory module stopping...
[2025-02-11 12:13:25.671] [info] [INFO] [logcollector.cpp:100] [Stop] Logcollector module stopped.
[       OK ] AgentTests.AgentStopsWhenSignalReceived (4117 ms)
[----------] 1 test from AgentTests (4168 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (4196 ms total)
[  PASSED  ] 1 test.
nico@nico-VirtualBox:~/wazuh-agent/build/agent/tests$ ls
agent_registration_test  agent_test  CMakeFiles  cmake_install.cmake  CTestTestfile.cmake  instance_handler_test  Makefile  message_queue_utils_test  signal_handler_test
nico@nico-VirtualBox:~/wazuh-agent/build/agent/tests$ ls /tmp/
1e150c02-4c15-455d-aad5-7a608e036ad4       systemd-private-4d485f928d634310b93957c146f05974-ModemManager.service-IggciV
{256080BF-6BD4-420A-9F9F-C1D17F5713D5}     systemd-private-4d485f928d634310b93957c146f05974-systemd-logind.service-75z9fh
code-52fa87d6-21d7-4b18-871f-ab9a70dbe55d  systemd-private-4d485f928d634310b93957c146f05974-systemd-oomd.service-oqFjEI
command_store.db                           systemd-private-4d485f928d634310b93957c146f05974-systemd-resolved.service-k3aCqp
local.db                                   systemd-private-4d485f928d634310b93957c146f05974-upower.service-V080S4
local.db-journal                           unleash-backup-codeium-extension.json
queue.db                                   unleash-repo-schema-v1-codeium-language-server.json
snap-private-tmp                           VMwareDnD
```

As you can see, the agent_info.db database has not been created. The use of the other dbs in the UTs will be corrected in another issue.

### Artifacts Affected

Executable files, all platforms.
<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

None
<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Documentation Updates

None
<!--
If applicable, list the sections of documentation that have been updated as part of this pull request.
-->

### Tests Introduced

Added: 

- AgentInfoPersistanceTest

Fixed:

- AgentInfoTests
- RegisterTest
- AgentTests

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
