### PR TITLE
Adapt Package Data Provider to Avoid Negative Size Values

### DIFF
--- a/docs/ref/modules/inventory/README.md
+++ b/docs/ref/modules/inventory/README.md
@@ -119,7 +119,7 @@ CREATE TABLE packages (
     location TEXT,
     architecture TEXT,
     description TEXT,
-    size INTEGER,
+    size BIGINT,
     format TEXT,
     PRIMARY KEY (name, version, architecture, format, location)
 ) WITHOUT ROWID;
@@ -135,7 +135,7 @@ This table stores information about installed software packages.
 |     ✔️     | `location`     | TEXT    | Installation location.                  |         |
 |     ✔️     | `architecture` | TEXT    | Architecture of the package.            |         |
 |           | `description`  | TEXT    | Description of the package.             |         |
-|           | `size`         | INTEGER | Size of the package in bytes.           |         |
+|           | `size`         | BIGINT  | Size of the package in bytes.           |         |
 |     ✔️     | `format`       | TEXT    | Format of the package (e.g., RPM, DEB). |         |
 
 ### Processes Table

--- a/src/common/data_provider/src/packages/packageLinuxParserHelper.h
+++ b/src/common/data_provider/src/packages/packageLinuxParserHelper.h
@@ -78,7 +78,7 @@ namespace PackageLinuxHelper
             nlohmann::json version = EMPTY_VALUE;
             nlohmann::json vendor = UNKNOWN_VALUE;
             nlohmann::json description = UNKNOWN_VALUE;
-            int size                 { 0 };
+            int64_t size { 0 };
 
             auto it{info.find("Priority")};
 
@@ -98,7 +98,7 @@ namespace PackageLinuxHelper
 
             if (it != info.end())
             {
-                size = stol(it->second) * 1024;
+                size = stoll(it->second) * 1024;
             }
 
             it = info.find("Multi-Arch");
@@ -169,7 +169,7 @@ namespace PackageLinuxHelper
         nlohmann::json vendor = UNKNOWN_VALUE;
         nlohmann::json install_time = UNKNOWN_VALUE;
         nlohmann::json description = UNKNOWN_VALUE;
-        int         size         { 0 };
+        int64_t     size         { 0 };
         bool        hasName      { false };
         bool        hasVersion   { false };
 
@@ -230,7 +230,7 @@ namespace PackageLinuxHelper
 
             if (data.is_number())
             {
-                size = data.get<int>();
+                size = data.get<int64_t>();
             }
             else if (data.is_string())
             {
@@ -240,7 +240,7 @@ namespace PackageLinuxHelper
                 {
                     try
                     {
-                        size = std::stoi( stringData );
+                        size = std::stoll( stringData );
                     }
                     catch (const std::exception& e)
                     {

--- a/src/common/data_provider/src/packages/packageLinuxRpmParserHelperLegacy.h
+++ b/src/common/data_provider/src/packages/packageLinuxRpmParserHelperLegacy.h
@@ -63,7 +63,7 @@ namespace PackageLinuxHelper
                 }
 
                 ret["name"]         = name;
-                ret["size"]         = size.empty() || size.compare(DEFAULT_VALUE) == 0 ? 0 : stoi(size);
+                ret["size"]         = size.empty() || size.compare(DEFAULT_VALUE) == 0 ? 0 : stoll(size);
                 ret["install_time"] = install_time.empty() || install_time.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : nlohmann::json(install_time);
                 ret["location"]     = EMPTY_VALUE;
                 ret["groups"]       = groups.empty() || groups.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : nlohmann::json(groups);

--- a/src/common/data_provider/src/packages/pkgWrapper.h
+++ b/src/common/data_provider/src/packages/pkgWrapper.h
@@ -373,7 +373,7 @@ class PKGWrapper final : public IPackageWrapper
         std::string m_location;
         std::string m_multiarch;
         std::string m_priority;
-        int m_size;
+        int64_t m_size;
         std::string m_vendor;
         std::string m_installTime;
 };

--- a/src/common/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
+++ b/src/common/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
@@ -26,13 +26,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformation)
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t3\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t3\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("3:1.5-24.el5", jsPackageInfo["version"]);
@@ -46,7 +46,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationLibRpm)
 {
     RpmPackageManager::Package input;
     input.name = "mktemp";
-    input.size = 15432;
+    input.size = 4111222333;
     input.installTime = "1425472738";
     input.group = "System Environment/Base";
     input.version = "1.5";
@@ -58,7 +58,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationLibRpm)
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(input) };
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("3:1.5-24.el5", jsPackageInfo["version"]);
@@ -113,13 +113,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpoch)
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("1.5-24.el5", jsPackageInfo["version"]);
@@ -133,7 +133,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmNoEpochNoReleaseLibRpm)
 {
     RpmPackageManager::Package input;
     input.name = "mktemp";
-    input.size = 15432;
+    input.size = 4111222333;
     input.installTime = "1425472738";
     input.group = "System Environment/Base";
     input.version = "4.16";
@@ -143,7 +143,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmNoEpochNoReleaseLibRpm)
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(input) };
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("4.16", jsPackageInfo["version"]);
@@ -157,7 +157,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmNoEpochLibRpm)
 {
     RpmPackageManager::Package input;
     input.name = "mktemp";
-    input.size = 15432;
+    input.size = 4111222333;
     input.installTime = "1425472738";
     input.group = "System Environment/Base";
     input.version = "4.16";
@@ -168,7 +168,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmNoEpochLibRpm)
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(input) };
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("1:4.16", jsPackageInfo["version"]);
@@ -182,13 +182,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpochNonRelease)
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t\t\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t\t\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("1.5", jsPackageInfo["version"]);
@@ -202,13 +202,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonRelease)
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t3\t\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t3\t\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("3:1.5", jsPackageInfo["version"]);
@@ -222,13 +222,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpochWithNone)
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t(none)\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t(none)\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("1.5-24.el5", jsPackageInfo["version"]);
@@ -242,13 +242,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonReleaseWithNone)
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t3\t(none)\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t3\t(none)\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("3:1.5", jsPackageInfo["version"]);
@@ -262,13 +262,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpochNonReleaseWith
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t(none)\t(none)\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t(none)\t(none)\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("1.5", jsPackageInfo["version"]);
@@ -284,7 +284,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseDpkgInformation)
     constexpr auto STATUS_INFO      {"Status: install ok installed"};
     constexpr auto PRIORITY_INFO    {"Priority: optional"};
     constexpr auto SECTION_INFO     {"Section: libdevel"};
-    constexpr auto SIZE_INFO        {"Installed-Size: 591"};
+    constexpr auto SIZE_INFO        {"Installed-Size: 4014865"};
     constexpr auto VENDOR_INFO      {"Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>"};
     constexpr auto ARCH_INFO        {"Architecture: amd64"};
     constexpr auto MULTIARCH_INFO   {"Multi-Arch: same"};
@@ -313,7 +313,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseDpkgInformation)
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("zlib1g-dev", jsPackageInfo["name"]);
     EXPECT_EQ("optional", jsPackageInfo["priority"]);
-    EXPECT_EQ(605184, jsPackageInfo["size"]);
+    EXPECT_EQ(4111221760, jsPackageInfo["size"]);
     EXPECT_EQ("libdevel", jsPackageInfo["groups"]);
     EXPECT_EQ("same", jsPackageInfo["multiarch"]);
     EXPECT_EQ("1:1.2.11.dfsg-2ubuntu1.2", jsPackageInfo["version"]);
@@ -333,7 +333,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseSnapCorrectMapping)
             "summary": "Shared GNOME 3.38 Ubuntu stack",
             "description": "This snap includes a GNOME 3.38 stack (the base libraries and desktop \nintegration components) and shares it through the content interface. \n",
             "icon": "/v2/icons/gnome-3-38-2004/icon",
-            "installed-size": 363151360,
+            "installed-size": 4111222333,
             "name": "gnome-3-38-2004",
             "publisher": {
                 "id": "canonical",
@@ -368,7 +368,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseSnapCorrectMapping)
 
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("gnome-3-38-2004", jsPackageInfo["name"]);
-    EXPECT_EQ(363151360, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("2022/11/23 20:33:59", jsPackageInfo["install_time"]);
     EXPECT_TRUE(jsPackageInfo["groups"].is_null());
     EXPECT_EQ("0+git.6f39565", jsPackageInfo["version"]);
@@ -475,7 +475,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseSnapValidSizeAsString)
             "summary": "Shared GNOME 3.38 Ubuntu stack",
             "description": "This snap includes a GNOME 3.38 stack (the base libraries and desktop \nintegration components) and shares it through the content interface. \n",
             "icon": "/v2/icons/gnome-3-38-2004/icon",
-            "installed-size": "363151360",
+            "installed-size": "4111222333",
             "name": "gnome-3-38-2004",
             "publisher": {
                 "id": "canonical",
@@ -509,7 +509,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseSnapValidSizeAsString)
         )"_json) };
 
     EXPECT_FALSE(jsPackageInfo.empty());
-    EXPECT_EQ(363151360, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
 }
 
 TEST_F(SysInfoPackagesLinuxHelperTest, parseSnapEmptyJSON)

--- a/src/modules/inventory/src/inventoryImp.cpp
+++ b/src/modules/inventory/src/inventoryImp.cpp
@@ -62,7 +62,7 @@ constexpr auto PACKAGES_SQL_STATEMENT {
     location TEXT,
     architecture TEXT,
     description TEXT,
-    size INTEGER,
+    size BIGINT,
     format TEXT,
     PRIMARY KEY (name,version,architecture,format,location)) WITHOUT ROWID;)"};
 

--- a/src/modules/inventory/tests/inventoryImp/inventoryImp_test.cpp
+++ b/src/modules/inventory/tests/inventoryImp/inventoryImp_test.cpp
@@ -75,7 +75,7 @@ TEST_F(InventoryImpTest, defaultCtor)
     EXPECT_CALL(*spInfoWrapper, packages(testing::_))
         .Times(::testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
-            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
 
     EXPECT_CALL(*spInfoWrapper, processes(testing::_))
         .Times(testing::AtLeast(1))
@@ -104,7 +104,7 @@ TEST_F(InventoryImpTest, defaultCtor)
     const auto expectedResult2 {
         R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":null,"kernel":"7601","name":"Microsoft Windows 7","platform":null,"type":null,"version":"6.1.7601"}}},"metadata":{"collector":"system","module":"inventory","operation":"create"}})"};
     const auto expectedResult3 {
-        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
+        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":4111222333,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
     const auto expectedResult4 {
         R"({"data":{"process":{"args":null,"command_line":null,"group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"metadata":{"collector":"processes","module":"inventory","operation":"create"}})"};
     const auto expectedResult5 {
@@ -155,7 +155,7 @@ TEST_F(InventoryImpTest, intervalSeconds)
     EXPECT_CALL(*spInfoWrapper, packages(testing::_))
         .Times(::testing::AtLeast(2))
         .WillRepeatedly(::testing::InvokeArgument<0>(
-            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
     EXPECT_CALL(*spInfoWrapper, processes(testing::_))
         .Times(testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
@@ -257,7 +257,7 @@ TEST_F(InventoryImpTest, noHardware)
     EXPECT_CALL(*spInfoWrapper, packages(testing::_))
         .Times(::testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
-            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
     EXPECT_CALL(*spInfoWrapper, processes(testing::_))
         .Times(testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
@@ -283,7 +283,7 @@ TEST_F(InventoryImpTest, noHardware)
     const auto expectedResult2 {
         R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":null,"kernel":"7601","name":"Microsoft Windows 7","platform":null,"type":null,"version":"6.1.7601"}}},"metadata":{"collector":"system","module":"inventory","operation":"create"}})"};
     const auto expectedResult3 {
-        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
+        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":4111222333,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
     const auto expectedResult4 {
         R"({"data":{"process":{"args":null,"command_line":null,"group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"metadata":{"collector":"processes","module":"inventory","operation":"create"}})"};
     const auto expectedResult5 {
@@ -345,7 +345,7 @@ TEST_F(InventoryImpTest, noOs)
     EXPECT_CALL(*spInfoWrapper, packages(testing::_))
         .Times(::testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
-            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
     EXPECT_CALL(*spInfoWrapper, processes(testing::_))
         .Times(testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
@@ -371,7 +371,7 @@ TEST_F(InventoryImpTest, noOs)
     const auto expectedResult1 {
         R"({"data":{"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":2904},"memory":{"free":2257872,"total":4972208,"used":{"percentage":54}}},"observer":{"serial_number":"Intel Corporation"}},"metadata":{"collector":"hardware","module":"inventory","operation":"create"}})"};
     const auto expectedResult2 {
-        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
+        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":4111222333,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
     const auto expectedResult3 {
         R"({"data":{"process":{"args":null,"command_line":null,"group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"metadata":{"collector":"processes","module":"inventory","operation":"create"}})"};
     const auto expectedResult4 {
@@ -436,7 +436,7 @@ TEST_F(InventoryImpTest, noNetwork)
     EXPECT_CALL(*spInfoWrapper, packages(testing::_))
         .Times(::testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
-            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
     EXPECT_CALL(*spInfoWrapper, processes(testing::_))
         .Times(testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
@@ -461,7 +461,7 @@ TEST_F(InventoryImpTest, noNetwork)
     const auto expectedResult2 {
         R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":null,"kernel":"7601","name":"Microsoft Windows 7","platform":null,"type":null,"version":"6.1.7601"}}},"metadata":{"collector":"system","module":"inventory","operation":"create"}})"};
     const auto expectedResult3 {
-        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
+        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":4111222333,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
     const auto expectedResult4 {
         R"({"data":{"process":{"args":null,"command_line":null,"group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"metadata":{"collector":"processes","module":"inventory","operation":"create"}})"};
     const auto expectedResult5 {
@@ -608,7 +608,7 @@ TEST_F(InventoryImpTest, noPorts)
     EXPECT_CALL(*spInfoWrapper, packages(testing::_))
         .Times(::testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
-            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
     EXPECT_CALL(*spInfoWrapper, processes(testing::_))
         .Times(testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
@@ -636,7 +636,7 @@ TEST_F(InventoryImpTest, noPorts)
     const auto expectedResult2 {
         R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":null,"kernel":"7601","name":"Microsoft Windows 7","platform":null,"type":null,"version":"6.1.7601"}}},"metadata":{"collector":"system","module":"inventory","operation":"create"}})"};
     const auto expectedResult3 {
-        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
+        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":4111222333,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
     const auto expectedResult4 {
         R"({"data":{"process":{"args":null,"command_line":null,"group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"metadata":{"collector":"processes","module":"inventory","operation":"create"}})"};
     const auto expectedResult5 {
@@ -699,7 +699,7 @@ TEST_F(InventoryImpTest, noPortsAll)
     EXPECT_CALL(*spInfoWrapper, packages(testing::_))
         .Times(::testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
-            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
     EXPECT_CALL(*spInfoWrapper, processes(testing::_))
         .Times(testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
@@ -726,7 +726,7 @@ TEST_F(InventoryImpTest, noPortsAll)
     const auto expectedResult2 {
         R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":null,"kernel":"7601","name":"Microsoft Windows 7","platform":null,"type":null,"version":"6.1.7601"}}},"metadata":{"collector":"system","module":"inventory","operation":"create"}})"};
     const auto expectedResult3 {
-        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
+        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":4111222333,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
     const auto expectedResult4 {
         R"({"data":{"process":{"args":null,"command_line":null,"group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"metadata":{"collector":"processes","module":"inventory","operation":"create"}})"};
     const auto expectedResult5 {
@@ -796,7 +796,7 @@ TEST_F(InventoryImpTest, noProcesses)
     EXPECT_CALL(*spInfoWrapper, packages(testing::_))
         .Times(::testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
-            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
     EXPECT_CALL(*spInfoWrapper, hotfixes())
         .WillRepeatedly(Return(nlohmann::json::parse(R"([{"hotfix":"KB12345678"}])")));
     EXPECT_CALL(*spInfoWrapper, networks())
@@ -820,7 +820,7 @@ TEST_F(InventoryImpTest, noProcesses)
     const auto expectedResult2 {
         R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":null,"kernel":"7601","name":"Microsoft Windows 7","platform":null,"type":null,"version":"6.1.7601"}}},"metadata":{"collector":"system","module":"inventory","operation":"create"}})"};
     const auto expectedResult3 {
-        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
+        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":4111222333,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
     const auto expectedResult4 {
         R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"metadata":{"collector":"hotfixes","module":"inventory","operation":"create"}})"};
     const auto expectedResult5 {
@@ -883,7 +883,7 @@ TEST_F(InventoryImpTest, noHotfixes)
     EXPECT_CALL(*spInfoWrapper, packages(testing::_))
         .Times(::testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
-            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+            R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
     EXPECT_CALL(*spInfoWrapper, processes(testing::_))
         .Times(testing::AtLeast(1))
         .WillOnce(::testing::InvokeArgument<0>(
@@ -909,7 +909,7 @@ TEST_F(InventoryImpTest, noHotfixes)
     const auto expectedResult2 {
         R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":null,"kernel":"7601","name":"Microsoft Windows 7","platform":null,"type":null,"version":"6.1.7601"}}},"metadata":{"collector":"system","module":"inventory","operation":"create"}})"};
     const auto expectedResult3 {
-        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
+        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":4111222333,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
     const auto expectedResult4 {
         R"({"data":{"process":{"args":null,"command_line":null,"group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"metadata":{"collector":"processes","module":"inventory","operation":"create"}})"};
     const auto expectedResult5 {
@@ -1277,9 +1277,9 @@ TEST_F(InventoryImpTest, PackagesDuplicated)
         .Times(::testing::AtLeast(1))
         .WillOnce(::testing::DoAll(
             ::testing::InvokeArgument<0>(
-                R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json),
+                R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json),
             ::testing::InvokeArgument<0>(
-                R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json)));
+                R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json)));
 
     CallbackMock wrapper;
     std::function<void(const std::string&)> callbackData {[&wrapper](const std::string& data)
@@ -1292,7 +1292,7 @@ TEST_F(InventoryImpTest, PackagesDuplicated)
                                                           }};
 
     const auto expectedResult1 {
-        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":411,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
+        R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":4111222333,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
 
     EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);
 


### PR DESCRIPTION
Closes #575

## Description

This PR fixes an overflow that occurs in the field size of packages, when the size of the package installed in the agent exceeds the limit for an int variable (32bits). This causes the field to have a wrong negative value.

## Proposed Changes

- Update data provider package 'size' variable from `int` (32 bits) to `int64_t` (64 bits).
- Update field type in inventory 'packages' table from `INTEGER` to `BIGINT`. 

## Results and Evidence

As can be seen, prior to the changes introduced in this PR, the size of the _kf6-core22_ package is stored in _local.db_ with a negative value:

```console
sqlite> select name, version, description, size from packages where size<0;
name        version  description       size       
----------  -------  ----------------  -----------
kf6-core22  6.6.0    KDE Frameworks 6  -2103541760
```

Being its size 2191425536 bytes:

```console
vagrant@noble:~/wazuh-agent/build$ curl --unix-socket /run/snapd.socket http://localhost/v2/snaps | jq '.result[] | select(.name == "kf6-core22")'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5269    0  5269    0     0  2614k      0 --:--:-- --:--:-- --:--:-- 5145k
{
  "id": "DlAIkaMJ1XMsnQRKcn0EjE2nc1S37X4r",
  "title": "kf6-core22",
  "summary": "KDE Frameworks 6",
  "description": "KDE Frameworks are addons and useful extensions to Qt",
  "installed-size": 2191425536,
  "install-date": "2025-02-06T18:56:09.418597901Z",
  "name": "kf6-core22",
  "publisher": {
    "id": "2rsYZu6kqYVFsSejExu4YENdXQEO40Xb",
    "username": "kde",
    "display-name": "KDE",
    "validation": "verified"
  },
  "developer": "kde",
  "status": "active",
  "type": "app",
  "base": "core22",
  "version": "6.6.0",
  "channel": "stable",
  "tracking-channel": "latest/stable",
  "ignore-validation": false,
  "revision": "40",
  "confinement": "strict",
  "private": false,
  "devmode": false,
  "jailmode": false,
  "mounted-from": "/var/lib/snapd/snaps/kf6-core22_40.snap",
  "links": null,
  "contact": ""
}
```

### Testing after increasing the variable size to 64 bits

```console
sqlite> select name, version, description, size from packages where size>2147483648;
name        version  description       size      
----------  -------  ----------------  ----------
kf6-core22  6.6.0    KDE Frameworks 6  2191425536
```

#### Inventory first scan

Stateful event:

```json
{"collector":"packages","id":"6f877afd88db2f6d6b9dc01f54f8ec1eb9252d81","module":"inventory","operation":"create"}
{"@timestamp":"2025-02-06T20:28:06.014Z","package":{"architecture":null,"description":"KDE Frameworks 6","installed":"2025/02/06 18:56:09","name":"kf6-core22","path":"/snap/kf6-core22","size":2191425536,"type":"snap","version":"6.6.0"}}
```

#### Uninstalling package

```console
root@noble:/home/vagrant# snap remove kf6-core22
kf6-core22 removed
```

Stateful event:

```json
{"collector":"packages","id":"6f877afd88db2f6d6b9dc01f54f8ec1eb9252d81","module":"inventory","operation":"delete"}
```

Stateless event:

```json
{"collector":"packages","module":"inventory"}
{"event":{"action":"package-removed","category":["package"],"created":"2025-02-06T20:37:08.042Z","reason":"Package kf6-core22 (version 6.6.0) was removed","type":["deletion"]},"package":{"architecture":null,"description":"KDE Frameworks 6","installed":"2025/02/06 18:56:09","name":"kf6-core22","path":"/snap/kf6-core22","size":2191425536,"type":"snap","version":"6.6.0"}}
```

#### Reinstalling package

```console
root@noble:/home/vagrant# snap install kf6-core22
kf6-core22 6.6.0 from KDE✓ installed
```

Stateful event:

```json
{"collector":"packages","id":"6f877afd88db2f6d6b9dc01f54f8ec1eb9252d81","module":"inventory","operation":"create"}
{"@timestamp":"2025-02-06T20:40:08.283Z","package":{"architecture":null,"description":"KDE Frameworks 6","installed":"2025/02/06 20:39:58","name":"kf6-core22","path":"/snap/kf6-core22","size":2191425536,"type":"snap","version":"6.6.0"}}
```

Stateless event:

```json
{"collector":"packages","module":"inventory"}
{"event":{"action":"package-installed","category":["package"],"created":"2025-02-06T20:40:08.283Z","reason":"Package kf6-core22 (version 6.6.0) was installed","type":["installation"]},"package":{"architecture":null,"description":"KDE Frameworks 6","installed":"2025/02/06 20:39:58","name":"kf6-core22","path":"/snap/kf6-core22","size":2191425536,"type":"snap","version":"6.6.0"}}
```

**In all generated events the values of the packet 'size' are right.**

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
