### PR TITLE
Reduce High Volume of Inventory Events Generated by Agent

### DIFF
--- a/docs/ref/modules/inventory/README.md
+++ b/docs/ref/modules/inventory/README.md
@@ -16,8 +16,8 @@ The **Inventory** module is responsible for collecting and storing detailed info
 |           | `networks`      | Enables the network scan                           | true    |
 |           | `packages`      | Enables the package scan                           | true    |
 |           | `ports`         | Enables the port scan                              | true    |
-|           | `ports_all`     | Enables the all ports scan or only listening ports | true    |
-|           | `processes`     | Enables the process scan                           | true    |
+|           | `ports_all`     | Enables the all ports scan or only listening ports | false   |
+|           | `processes`     | Enables the process scan                           | false   |
 |           | `hotfixes`      | Enables the hotfix scan                            | true    |
 
 
@@ -31,8 +31,8 @@ inventory:
   networks: true
   packages: true
   ports: true
-  ports_all: true
-  processes: true
+  ports_all: false
+  processes: false
   hotfixes: true
 ```
 ---

--- a/etc/config/wazuh-agent.yml
+++ b/etc/config/wazuh-agent.yml
@@ -15,8 +15,8 @@ inventory:
   networks: true
   packages: true
   ports: true
-  ports_all: true
-  processes: true
+  ports_all: false
+  processes: false
   hotfixes: true
 logcollector:
   enabled: true

--- a/src/cmake/config.cmake
+++ b/src/cmake/config.cmake
@@ -52,9 +52,9 @@ set(DEFAULT_PACKAGES true CACHE BOOL "Default inventory packages")
 
 set(DEFAULT_PORTS true CACHE BOOL "Default inventory ports")
 
-set(DEFAULT_PORTS_ALL true CACHE BOOL "Default inventory ports all")
+set(DEFAULT_PORTS_ALL false CACHE BOOL "Default inventory ports all")
 
-set(DEFAULT_PROCESSES true CACHE BOOL "Default inventory processes")
+set(DEFAULT_PROCESSES false CACHE BOOL "Default inventory processes")
 
 set(DEFAULT_HOTFIXES true CACHE BOOL "Default inventory hotfixes")
 

--- a/src/modules/inventory/tests/inventoryImp/inventoryImp_test.cpp
+++ b/src/modules/inventory/tests/inventoryImp/inventoryImp_test.cpp
@@ -77,11 +77,6 @@ TEST_F(InventoryImpTest, defaultCtor)
         .WillOnce(::testing::InvokeArgument<0>(
             R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
 
-    EXPECT_CALL(*spInfoWrapper, processes(testing::_))
-        .Times(testing::AtLeast(1))
-        .WillOnce(::testing::InvokeArgument<0>(
-            R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
-
     EXPECT_CALL(*spInfoWrapper, hotfixes())
         .WillRepeatedly(Return(nlohmann::json::parse(R"([{"hotfix":"KB12345678"}])")));
 
@@ -105,8 +100,6 @@ TEST_F(InventoryImpTest, defaultCtor)
         R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":null,"kernel":"7601","name":"Microsoft Windows 7","platform":null,"type":null,"version":"6.1.7601"}}},"metadata":{"collector":"system","module":"inventory","operation":"create"}})"};
     const auto expectedResult3 {
         R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":4111222333,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
-    const auto expectedResult4 {
-        R"({"data":{"process":{"args":null,"command_line":null,"group":{"id":"root"},"name":"kworker/u256:2-","parent":{"pid":2},"pid":"431625","real_group":{"id":"root"},"real_user":{"id":"root"},"saved_group":{"id":"root"},"saved_user":{"id":"root"},"start":9302261,"thread":{"id":431625},"tty":{"char_device":{"major":0}},"user":{"id":"root"}}},"metadata":{"collector":"processes","module":"inventory","operation":"create"}})"};
     const auto expectedResult5 {
         R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"metadata":{"collector":"hotfixes","module":"inventory","operation":"create"}})"};
     const auto expectedResult6 {
@@ -117,7 +110,6 @@ TEST_F(InventoryImpTest, defaultCtor)
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(testing::AtLeast(1));
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(testing::AtLeast(1));
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(testing::AtLeast(1));
-    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(testing::AtLeast(1));
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult5)).Times(testing::AtLeast(1));
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult6)).Times(testing::AtLeast(1));
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult7)).Times(testing::AtLeast(1));


### PR DESCRIPTION
## Description

Closes #407 

The Wazuh agent performs regular system inventory synchronization. By default, it is configured to inventory all supported data, including:
- Active processes
- Open ports
- Ports in use

Both active processes and ports in use tend to change frequently, resulting in a significant volume of stateful synchronization messages (`create/delete` events). While this behavior is expected given the current configuration, it can lead to an overload of events and potentially impact system performance.

## Proposal
To reduce the volume of inventory synchronization messages, we propose disabling the following inventory options:
- **Processes inventory**: Disable inventory of active processes.
- **Ports in use inventory**: Disable inventory of ports in use.

These options can be adjusted in the agent configuration as follows:

```yaml
processes: false
ports_all: false
```

This adjustment is expected to significantly reduce the number of inventory-related events without affecting other critical functionalities.

### Configuration Changes

```yaml
inventory:
  enabled: true
  interval: 60s
  scan_on_start: true
  hardware: true
  system: true
  networks: true
  packages: true
  ports: true
  ports_all: false
  processes: false    
  hotfixes: true

```

### Documentation Updates

* Updated inventory default values,

### Tests Introduced

* fixed defaultCtor in inventory fixture.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->

