### PR TITLE
Add configurable timeout for commands request

### DIFF
--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -135,5 +135,8 @@ namespace communicator
 
         /// @brief The verification mode
         std::string m_verificationMode;
+
+        /// @brief Timeout for command requests to manager in secconds.
+        std::time_t m_timeoutCommands;
     };
 } // namespace communicator

--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -137,6 +137,6 @@ namespace communicator
         std::string m_verificationMode;
 
         /// @brief Timeout for command requests to manager in millisecconds.
-        std::time_t m_timeoutCommandsInMilliSeconds;
+        std::time_t m_timeoutCommands;
     };
 } // namespace communicator

--- a/src/agent/communicator/include/communicator.hpp
+++ b/src/agent/communicator/include/communicator.hpp
@@ -136,7 +136,7 @@ namespace communicator
         /// @brief The verification mode
         std::string m_verificationMode;
 
-        /// @brief Timeout for command requests to manager in secconds.
-        std::time_t m_timeoutCommands;
+        /// @brief Timeout for command requests to manager in millisecconds.
+        std::time_t m_timeoutCommandsInMilliSeconds;
     };
 } // namespace communicator

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -89,6 +89,15 @@ namespace communicator
                     config::agent::DEFAULT_VERIFICATION_MODE);
             m_verificationMode = config::agent::DEFAULT_VERIFICATION_MODE;
         }
+
+        m_timeoutCommands = configurationParser->GetConfig<std::time_t>("agent", "commands_request_timeout")
+                                .value_or(config::agent::DEFAULT_COMMANDS_REQUEST_TIMEOUT);
+        if (m_timeoutCommands <= 0)
+        {
+            LogWarn("Incorrect value for 'commands_request_timeout', should be above 0.",
+                    config::agent::DEFAULT_COMMANDS_REQUEST_TIMEOUT);
+            m_timeoutCommands = config::agent::DEFAULT_COMMANDS_REQUEST_TIMEOUT;
+        }
     }
 
     bool Communicator::SendAuthenticationRequest()
@@ -252,7 +261,11 @@ namespace communicator
                                                               m_serverUrl,
                                                               "/api/v1/commands",
                                                               m_getHeaderInfo ? m_getHeaderInfo() : "",
-                                                              m_verificationMode);
+                                                              m_verificationMode,
+                                                              "",
+                                                              "",
+                                                              "",
+                                                              m_timeoutCommands);
         co_await ExecuteRequestLoop(reqParams, {}, onSuccess);
     }
 

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -42,6 +42,10 @@ namespace communicator
 {
     constexpr int TOKEN_PRE_EXPIRY_SECS = 2;
     constexpr int A_SECOND_IN_MILLIS = 1000;
+    // 10 seconds minimum command request timeout
+    constexpr time_t COMMANDS_REQUEST_TIMEOUT_MAX = static_cast<time_t>(10) * A_SECOND_IN_MILLIS;
+    // 15 minutes maximum command request timeout
+    constexpr time_t COMMANDS_REQUEST_TIMEOUT_MIN = static_cast<time_t>(15) * 60 * A_SECOND_IN_MILLIS;
 
     Communicator::Communicator(std::unique_ptr<http_client::IHttpClient> httpClient,
                                std::shared_ptr<configuration::ConfigurationParser> configurationParser,
@@ -90,10 +94,10 @@ namespace communicator
             m_verificationMode = config::agent::DEFAULT_VERIFICATION_MODE;
         }
 
-        m_timeoutCommandsInMilliSeconds =
+        m_timeoutCommands =
             configurationParser->GetTimeConfigInRangeOrDefault(config::agent::DEFAULT_COMMANDS_REQUEST_TIMEOUT,
-                                                               0,
-                                                               std::numeric_limits<time_t>::max(),
+                                                               COMMANDS_REQUEST_TIMEOUT_MIN,
+                                                               COMMANDS_REQUEST_TIMEOUT_MAX,
                                                                "agent",
                                                                "commands_request_timeout");
     }
@@ -263,7 +267,7 @@ namespace communicator
                                                               "",
                                                               "",
                                                               "",
-                                                              m_timeoutCommandsInMilliSeconds);
+                                                              m_timeoutCommands);
         co_await ExecuteRequestLoop(reqParams, {}, onSuccess);
     }
 

--- a/src/agent/communicator/src/communicator.cpp
+++ b/src/agent/communicator/src/communicator.cpp
@@ -90,14 +90,12 @@ namespace communicator
             m_verificationMode = config::agent::DEFAULT_VERIFICATION_MODE;
         }
 
-        m_timeoutCommands = configurationParser->GetConfig<std::time_t>("agent", "commands_request_timeout")
-                                .value_or(config::agent::DEFAULT_COMMANDS_REQUEST_TIMEOUT);
-        if (m_timeoutCommands <= 0)
-        {
-            LogWarn("Incorrect value for 'commands_request_timeout', should be above 0.",
-                    config::agent::DEFAULT_COMMANDS_REQUEST_TIMEOUT);
-            m_timeoutCommands = config::agent::DEFAULT_COMMANDS_REQUEST_TIMEOUT;
-        }
+        m_timeoutCommandsInMilliSeconds =
+            configurationParser->GetTimeConfigInRangeOrDefault(config::agent::DEFAULT_COMMANDS_REQUEST_TIMEOUT,
+                                                               0,
+                                                               std::numeric_limits<time_t>::max(),
+                                                               "agent",
+                                                               "commands_request_timeout");
     }
 
     bool Communicator::SendAuthenticationRequest()
@@ -265,7 +263,7 @@ namespace communicator
                                                               "",
                                                               "",
                                                               "",
-                                                              m_timeoutCommands);
+                                                              m_timeoutCommandsInMilliSeconds);
         co_await ExecuteRequestLoop(reqParams, {}, onSuccess);
     }
 

--- a/src/agent/communicator/tests/communicator_test.cpp
+++ b/src/agent/communicator/tests/communicator_test.cpp
@@ -214,7 +214,7 @@ TEST(CommunicatorTest, GetCommandsFromManager_CallsWithValidToken)
         .WillOnce(Invoke([communicatorPtr, &expectedResponse1]() -> intStringTuple { return expectedResponse1; }));
 
     const auto reqParams = http_client::HttpRequestParams(
-        http_client::MethodType::GET, "https://localhost:27000", "/api/v1/commands", "", "none");
+        http_client::MethodType::GET, "https://localhost:27000", "/api/v1/commands", "", "none", "", "", "", 60000);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     intStringTuple expectedResponse2 {200, "Dummy response"};
@@ -266,7 +266,7 @@ TEST(CommunicatorTest, GetCommandsFromManager_Failure)
         .WillOnce(Invoke([communicatorPtr, &expectedResponse1]() -> intStringTuple { return expectedResponse1; }));
 
     const auto reqParams = http_client::HttpRequestParams(
-        http_client::MethodType::GET, "https://localhost:27000", "/api/v1/commands", "", "none");
+        http_client::MethodType::GET, "https://localhost:27000", "/api/v1/commands", "", "none", "", "", "", 60000);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     intStringTuple expectedResponse2 {401, "Dummy response"};

--- a/src/agent/communicator/tests/communicator_test.cpp
+++ b/src/agent/communicator/tests/communicator_test.cpp
@@ -213,8 +213,9 @@ TEST(CommunicatorTest, GetCommandsFromManager_CallsWithValidToken)
     EXPECT_CALL(*mockHttpClientPtr, PerformHttpRequest(testing::_))
         .WillOnce(Invoke([communicatorPtr, &expectedResponse1]() -> intStringTuple { return expectedResponse1; }));
 
+    const auto timeout = static_cast<time_t>(11) * 60 * 1000;
     const auto reqParams = http_client::HttpRequestParams(
-        http_client::MethodType::GET, "https://localhost:27000", "/api/v1/commands", "", "none", "", "", "", 60000);
+        http_client::MethodType::GET, "https://localhost:27000", "/api/v1/commands", "", "none", "", "", "", timeout);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     intStringTuple expectedResponse2 {200, "Dummy response"};
@@ -265,8 +266,9 @@ TEST(CommunicatorTest, GetCommandsFromManager_Failure)
     EXPECT_CALL(*mockHttpClientPtr, PerformHttpRequest(testing::_))
         .WillOnce(Invoke([communicatorPtr, &expectedResponse1]() -> intStringTuple { return expectedResponse1; }));
 
+    const auto timeout = static_cast<time_t>(11) * 60 * 1000;
     const auto reqParams = http_client::HttpRequestParams(
-        http_client::MethodType::GET, "https://localhost:27000", "/api/v1/commands", "", "none", "", "", "", 60000);
+        http_client::MethodType::GET, "https://localhost:27000", "/api/v1/commands", "", "none", "", "", "", timeout);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     intStringTuple expectedResponse2 {401, "Dummy response"};

--- a/src/agent/http_client/include/http_request_params.hpp
+++ b/src/agent/http_client/include/http_request_params.hpp
@@ -37,7 +37,7 @@ namespace http_client
         std::string User_pass;
         std::string Body;
         bool Use_Https;
-        time_t RequestTimeout;
+        time_t RequestTimeoutInMilliSeconds;
 
         /// @brief Constructs HttpRequestParams with specified parameters
         /// @param method The HTTP method to use
@@ -48,7 +48,7 @@ namespace http_client
         /// @param token Optional token for authorization
         /// @param userPass Optional user credentials for basic authentication
         /// @param body Optional body for the request
-        /// @param RequestTimeout Optional request timeout
+        /// @param RequestTimeoutInMilliSeconds Optional request timeout in milliseconds
         HttpRequestParams(MethodType method,
                           const std::string& serverUrl,
                           std::string endpoint,
@@ -57,7 +57,7 @@ namespace http_client
                           std::string token = "",
                           std::string userPass = "",
                           std::string body = "",
-                          const time_t RequestTimeout = 0);
+                          const time_t RequestTimeoutInMilliSeconds = 0);
 
         /// @brief Equality operator for comparing two HttpRequestParams objects
         /// @param other The other HttpRequestParams object to compare with

--- a/src/agent/http_client/include/http_request_params.hpp
+++ b/src/agent/http_client/include/http_request_params.hpp
@@ -37,7 +37,7 @@ namespace http_client
         std::string User_pass;
         std::string Body;
         bool Use_Https;
-        time_t RequestTimeoutInMilliSeconds;
+        time_t RequestTimeout;
 
         /// @brief Constructs HttpRequestParams with specified parameters
         /// @param method The HTTP method to use

--- a/src/agent/http_client/include/http_request_params.hpp
+++ b/src/agent/http_client/include/http_request_params.hpp
@@ -37,6 +37,7 @@ namespace http_client
         std::string User_pass;
         std::string Body;
         bool Use_Https;
+        time_t RequestTimeout;
 
         /// @brief Constructs HttpRequestParams with specified parameters
         /// @param method The HTTP method to use
@@ -47,6 +48,7 @@ namespace http_client
         /// @param token Optional token for authorization
         /// @param userPass Optional user credentials for basic authentication
         /// @param body Optional body for the request
+        /// @param RequestTimeout Optional request timeout
         HttpRequestParams(MethodType method,
                           const std::string& serverUrl,
                           std::string endpoint,
@@ -54,7 +56,8 @@ namespace http_client
                           std::string verificationMode = "none",
                           std::string token = "",
                           std::string userPass = "",
-                          std::string body = "");
+                          std::string body = "",
+                          const time_t RequestTimeout = 0);
 
         /// @brief Equality operator for comparing two HttpRequestParams objects
         /// @param other The other HttpRequestParams object to compare with

--- a/src/agent/http_client/include/http_request_params.hpp
+++ b/src/agent/http_client/include/http_request_params.hpp
@@ -48,7 +48,7 @@ namespace http_client
         /// @param token Optional token for authorization
         /// @param userPass Optional user credentials for basic authentication
         /// @param body Optional body for the request
-        /// @param RequestTimeoutInMilliSeconds Optional request timeout in milliseconds
+        /// @param requestTimeoutInMilliSeconds Optional request timeout in milliseconds
         HttpRequestParams(MethodType method,
                           const std::string& serverUrl,
                           std::string endpoint,
@@ -57,7 +57,7 @@ namespace http_client
                           std::string token = "",
                           std::string userPass = "",
                           std::string body = "",
-                          const time_t RequestTimeoutInMilliSeconds = 0);
+                          const time_t requestTimeoutInMilliSeconds = 0);
 
         /// @brief Equality operator for comparing two HttpRequestParams objects
         /// @param other The other HttpRequestParams object to compare with

--- a/src/agent/http_client/src/http_client.cpp
+++ b/src/agent/http_client/src/http_client.cpp
@@ -147,7 +147,14 @@ namespace http_client
                 throw std::runtime_error("Error writing request: " + ec.message());
             }
 
-            co_await socket->AsyncRead(res, ec);
+            if (params.RequestTimeout)
+            {
+                co_await socket->AsyncRead(res, ec, params.RequestTimeout);
+            }
+            else
+            {
+                co_await socket->AsyncRead(res, ec);
+            }
 
             if (ec)
             {

--- a/src/agent/http_client/src/http_client.cpp
+++ b/src/agent/http_client/src/http_client.cpp
@@ -147,9 +147,9 @@ namespace http_client
                 throw std::runtime_error("Error writing request: " + ec.message());
             }
 
-            if (params.RequestTimeout)
+            if (params.RequestTimeoutInMilliSeconds)
             {
-                co_await socket->AsyncRead(res, ec, params.RequestTimeout);
+                co_await socket->AsyncRead(res, ec, params.RequestTimeoutInMilliSeconds);
             }
             else
             {

--- a/src/agent/http_client/src/http_client.cpp
+++ b/src/agent/http_client/src/http_client.cpp
@@ -129,6 +129,11 @@ namespace http_client
                 socket->SetVerificationMode(params.Host, params.Verification_Mode);
             }
 
+            if (params.RequestTimeoutInMilliSeconds)
+            {
+                socket->SetTimeout(params.RequestTimeoutInMilliSeconds);
+            }
+
             boost::system::error_code ec;
 
             co_await socket->AsyncConnect(results, ec);
@@ -147,14 +152,7 @@ namespace http_client
                 throw std::runtime_error("Error writing request: " + ec.message());
             }
 
-            if (params.RequestTimeoutInMilliSeconds)
-            {
-                co_await socket->AsyncRead(res, ec, params.RequestTimeoutInMilliSeconds);
-            }
-            else
-            {
-                co_await socket->AsyncRead(res, ec);
-            }
+            co_await socket->AsyncRead(res, ec);
 
             if (ec)
             {

--- a/src/agent/http_client/src/http_client.cpp
+++ b/src/agent/http_client/src/http_client.cpp
@@ -129,9 +129,9 @@ namespace http_client
                 socket->SetVerificationMode(params.Host, params.Verification_Mode);
             }
 
-            if (params.RequestTimeoutInMilliSeconds)
+            if (params.RequestTimeout)
             {
-                socket->SetTimeout(params.RequestTimeoutInMilliSeconds);
+                socket->SetTimeout(std::chrono::milliseconds(params.RequestTimeout));
             }
 
             boost::system::error_code ec;

--- a/src/agent/http_client/src/http_request_params.cpp
+++ b/src/agent/http_client/src/http_request_params.cpp
@@ -22,7 +22,7 @@ namespace http_client
         , Token(std::move(token))
         , User_pass(std::move(userPass))
         , Body(std::move(body))
-        , RequestTimeout(requestTimeout)
+        , RequestTimeoutInMilliSeconds(requestTimeout)
     {
         const auto result = boost::urls::parse_uri(serverUrl);
 
@@ -56,6 +56,6 @@ namespace http_client
         return Method == other.Method && Host == other.Host && Port == other.Port && Endpoint == other.Endpoint &&
                User_agent == other.User_agent && Verification_Mode == other.Verification_Mode && Token == other.Token &&
                User_pass == other.User_pass && Body == other.Body && Use_Https == other.Use_Https &&
-               RequestTimeout == other.RequestTimeout;
+               RequestTimeoutInMilliSeconds == other.RequestTimeoutInMilliSeconds;
     }
 } // namespace http_client

--- a/src/agent/http_client/src/http_request_params.cpp
+++ b/src/agent/http_client/src/http_request_params.cpp
@@ -13,7 +13,8 @@ namespace http_client
                                          std::string verificationMode,
                                          std::string token,
                                          std::string userPass,
-                                         std::string body)
+                                         std::string body,
+                                         const time_t requestTimeout)
         : Method(method)
         , Endpoint(std::move(endpoint))
         , User_agent(std::move(userAgent))
@@ -21,6 +22,7 @@ namespace http_client
         , Token(std::move(token))
         , User_pass(std::move(userPass))
         , Body(std::move(body))
+        , RequestTimeout(requestTimeout)
     {
         const auto result = boost::urls::parse_uri(serverUrl);
 
@@ -53,6 +55,7 @@ namespace http_client
     {
         return Method == other.Method && Host == other.Host && Port == other.Port && Endpoint == other.Endpoint &&
                User_agent == other.User_agent && Verification_Mode == other.Verification_Mode && Token == other.Token &&
-               User_pass == other.User_pass && Body == other.Body && Use_Https == other.Use_Https;
+               User_pass == other.User_pass && Body == other.Body && Use_Https == other.Use_Https &&
+               RequestTimeout == other.RequestTimeout;
     }
 } // namespace http_client

--- a/src/agent/http_client/src/http_request_params.cpp
+++ b/src/agent/http_client/src/http_request_params.cpp
@@ -14,7 +14,7 @@ namespace http_client
                                          std::string token,
                                          std::string userPass,
                                          std::string body,
-                                         const time_t requestTimeout)
+                                         const time_t requestTimeoutInMilliSeconds)
         : Method(method)
         , Endpoint(std::move(endpoint))
         , User_agent(std::move(userAgent))
@@ -22,7 +22,7 @@ namespace http_client
         , Token(std::move(token))
         , User_pass(std::move(userPass))
         , Body(std::move(body))
-        , RequestTimeoutInMilliSeconds(requestTimeout)
+        , RequestTimeoutInMilliSeconds(requestTimeoutInMilliSeconds)
     {
         const auto result = boost::urls::parse_uri(serverUrl);
 

--- a/src/agent/http_client/src/http_request_params.cpp
+++ b/src/agent/http_client/src/http_request_params.cpp
@@ -22,7 +22,7 @@ namespace http_client
         , Token(std::move(token))
         , User_pass(std::move(userPass))
         , Body(std::move(body))
-        , RequestTimeoutInMilliSeconds(requestTimeoutInMilliSeconds)
+        , RequestTimeout(requestTimeoutInMilliSeconds)
     {
         const auto result = boost::urls::parse_uri(serverUrl);
 
@@ -56,6 +56,6 @@ namespace http_client
         return Method == other.Method && Host == other.Host && Port == other.Port && Endpoint == other.Endpoint &&
                User_agent == other.User_agent && Verification_Mode == other.Verification_Mode && Token == other.Token &&
                User_pass == other.User_pass && Body == other.Body && Use_Https == other.Use_Https &&
-               RequestTimeoutInMilliSeconds == other.RequestTimeoutInMilliSeconds;
+               RequestTimeout == other.RequestTimeout;
     }
 } // namespace http_client

--- a/src/agent/http_client/src/http_socket.cpp
+++ b/src/agent/http_client/src/http_socket.cpp
@@ -19,9 +19,9 @@ namespace http_client
         // No functionality for HTTP sockets
     }
 
-    void HttpSocket::SetTimeout(const time_t timeout)
+    void HttpSocket::SetTimeout(const std::chrono::milliseconds timeout)
     {
-        m_timeoutInMilliseconds = timeout;
+        m_timeout = timeout;
     }
 
     void HttpSocket::Connect(const boost::asio::ip::tcp::resolver::results_type& endpoints,
@@ -29,7 +29,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
+            m_socket->expires_after(m_timeout);
             m_socket->connect(endpoints, ec);
         }
         catch (const std::exception& e)
@@ -44,7 +44,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
+            m_socket->expires_after(m_timeout);
             co_await m_socket->async_connect(endpoints, ec);
         }
         catch (const std::exception& e)
@@ -59,7 +59,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
+            m_socket->expires_after(m_timeout);
             m_socket->write(req, ec);
         }
         catch (const std::exception& e)
@@ -74,7 +74,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
+            m_socket->expires_after(m_timeout);
             co_await m_socket->async_write(req, ec);
         }
         catch (const std::exception& e)
@@ -89,7 +89,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
+            m_socket->expires_after(m_timeout);
             boost::beast::flat_buffer buffer;
             m_socket->read(buffer, res, ec);
         }
@@ -105,7 +105,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
+            m_socket->expires_after(m_timeout);
             boost::beast::flat_buffer buffer;
             co_await m_socket->async_read(buffer, res, ec);
         }

--- a/src/agent/http_client/src/http_socket.cpp
+++ b/src/agent/http_client/src/http_socket.cpp
@@ -24,7 +24,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS));
+            m_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
             m_socket->connect(endpoints, ec);
         }
         catch (const std::exception& e)
@@ -39,7 +39,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS));
+            m_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
             co_await m_socket->async_connect(endpoints, ec);
         }
         catch (const std::exception& e)
@@ -54,7 +54,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS));
+            m_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
             m_socket->write(req, ec);
         }
         catch (const std::exception& e)
@@ -69,7 +69,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS));
+            m_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
             co_await m_socket->async_write(req, ec);
         }
         catch (const std::exception& e)
@@ -84,7 +84,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS));
+            m_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
             boost::beast::flat_buffer buffer;
             m_socket->read(buffer, res, ec);
         }

--- a/src/agent/http_client/src/http_socket.cpp
+++ b/src/agent/http_client/src/http_socket.cpp
@@ -19,12 +19,17 @@ namespace http_client
         // No functionality for HTTP sockets
     }
 
+    void HttpSocket::SetTimeout(const time_t timeout)
+    {
+        m_timeoutInMilliseconds = timeout;
+    }
+
     void HttpSocket::Connect(const boost::asio::ip::tcp::resolver::results_type& endpoints,
                              boost::system::error_code& ec)
     {
         try
         {
-            m_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
+            m_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
             m_socket->connect(endpoints, ec);
         }
         catch (const std::exception& e)
@@ -39,7 +44,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
+            m_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
             co_await m_socket->async_connect(endpoints, ec);
         }
         catch (const std::exception& e)
@@ -54,7 +59,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
+            m_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
             m_socket->write(req, ec);
         }
         catch (const std::exception& e)
@@ -69,7 +74,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
+            m_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
             co_await m_socket->async_write(req, ec);
         }
         catch (const std::exception& e)
@@ -84,7 +89,7 @@ namespace http_client
     {
         try
         {
-            m_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
+            m_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
             boost::beast::flat_buffer buffer;
             m_socket->read(buffer, res, ec);
         }
@@ -96,12 +101,11 @@ namespace http_client
 
     boost::asio::awaitable<void>
     HttpSocket::AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
-                          boost::system::error_code& ec,
-                          const std::time_t socketTimeout)
+                          boost::system::error_code& ec)
     {
         try
         {
-            m_socket->expires_after(std::chrono::milliseconds(socketTimeout));
+            m_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
             boost::beast::flat_buffer buffer;
             co_await m_socket->async_read(buffer, res, ec);
         }

--- a/src/agent/http_client/src/http_socket.cpp
+++ b/src/agent/http_client/src/http_socket.cpp
@@ -96,11 +96,12 @@ namespace http_client
 
     boost::asio::awaitable<void>
     HttpSocket::AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
-                          boost::system::error_code& ec)
+                          boost::system::error_code& ec,
+                          const std::time_t socketTimeout)
     {
         try
         {
-            m_socket->expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS));
+            m_socket->expires_after(std::chrono::milliseconds(socketTimeout));
             boost::beast::flat_buffer buffer;
             co_await m_socket->async_read(buffer, res, ec);
         }

--- a/src/agent/http_client/src/http_socket.hpp
+++ b/src/agent/http_client/src/http_socket.hpp
@@ -60,8 +60,10 @@ namespace http_client
         /// @brief Asynchronous version of Read
         /// @param res The response to read
         /// @param ec The error code, if any occurred
+        /// @param socketTimeout Timeout for reading in millisenconds
         boost::asio::awaitable<void> AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
-                                               boost::system::error_code& ec) override;
+                                               boost::system::error_code& ec,
+                                               const time_t socketTimeout = http_client::SOCKET_TIMEOUT_MSECS) override;
 
         /// @brief Closes the socket
         void Close() override;

--- a/src/agent/http_client/src/http_socket.hpp
+++ b/src/agent/http_client/src/http_socket.hpp
@@ -29,7 +29,7 @@ namespace http_client
 
         /// @brief Sets the timeout for requests in milliseconds.
         /// @param timeout Timeout in milliseconds applied to all requests
-        void SetTimeout(const time_t timeout) override;
+        void SetTimeout(const std::chrono::milliseconds timeout) override;
 
         /// @brief Connects the socket to the given endpoints
         /// @param endpoints The endpoints to connect to
@@ -75,6 +75,6 @@ namespace http_client
         std::shared_ptr<ISocketWrapper> m_socket;
 
         /// @brief Timeout in milliseconds used in every operation
-        time_t m_timeoutInMilliseconds = http_client::SOCKET_TIMEOUT_MSECS;
+        std::chrono::milliseconds m_timeout {http_client::SOCKET_TIMEOUT_MSECS};
     };
 } // namespace http_client

--- a/src/agent/http_client/src/http_socket.hpp
+++ b/src/agent/http_client/src/http_socket.hpp
@@ -27,6 +27,10 @@ namespace http_client
         /// @param verificationMode The verification mode to set
         void SetVerificationMode(const std::string& host, const std::string& verificationMode) override;
 
+        /// @brief Sets the timeout for requests in milliseconds.
+        /// @param timeout Timeout in milliseconds applied to all requests
+        void SetTimeout(const time_t timeout) override;
+
         /// @brief Connects the socket to the given endpoints
         /// @param endpoints The endpoints to connect to
         /// @param ec The error code, if any occurred
@@ -60,10 +64,8 @@ namespace http_client
         /// @brief Asynchronous version of Read
         /// @param res The response to read
         /// @param ec The error code, if any occurred
-        /// @param socketTimeout Timeout for reading in millisenconds
         boost::asio::awaitable<void> AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
-                                               boost::system::error_code& ec,
-                                               const time_t socketTimeout = http_client::SOCKET_TIMEOUT_MSECS) override;
+                                               boost::system::error_code& ec) override;
 
         /// @brief Closes the socket
         void Close() override;
@@ -71,5 +73,8 @@ namespace http_client
     private:
         /// @brief The socket to use for the HTTP connection
         std::shared_ptr<ISocketWrapper> m_socket;
+
+        /// @brief Timeout in milliseconds used in every operation
+        time_t m_timeoutInMilliseconds = http_client::SOCKET_TIMEOUT_MSECS;
     };
 } // namespace http_client

--- a/src/agent/http_client/src/http_socket_wrapper.hpp
+++ b/src/agent/http_client/src/http_socket_wrapper.hpp
@@ -32,6 +32,11 @@ namespace http_client
             m_socket.expires_after(seconds);
         }
 
+        void expires_after(std::chrono::milliseconds ms) override
+        {
+            m_socket.expires_after((ms / 1000));
+        }
+
         void connect(const boost::asio::ip::tcp::resolver::results_type& endpoints,
                      boost::system::error_code& ec) override
         {

--- a/src/agent/http_client/src/http_socket_wrapper.hpp
+++ b/src/agent/http_client/src/http_socket_wrapper.hpp
@@ -27,11 +27,6 @@ namespace http_client
         { // No implementation for Http
         }
 
-        void expires_after(std::chrono::seconds seconds) override
-        {
-            m_socket.expires_after(seconds);
-        }
-
         void expires_after(std::chrono::milliseconds ms) override
         {
             m_socket.expires_after(std::chrono::duration_cast<std::chrono::seconds>(ms));

--- a/src/agent/http_client/src/http_socket_wrapper.hpp
+++ b/src/agent/http_client/src/http_socket_wrapper.hpp
@@ -34,7 +34,7 @@ namespace http_client
 
         void expires_after(std::chrono::milliseconds ms) override
         {
-            m_socket.expires_after((ms / 1000));
+            m_socket.expires_after(std::chrono::duration_cast<std::chrono::seconds>(ms));
         }
 
         void connect(const boost::asio::ip::tcp::resolver::results_type& endpoints,

--- a/src/agent/http_client/src/http_socket_wrapper.hpp
+++ b/src/agent/http_client/src/http_socket_wrapper.hpp
@@ -29,7 +29,7 @@ namespace http_client
 
         void expires_after(std::chrono::milliseconds ms) override
         {
-            m_socket.expires_after(std::chrono::duration_cast<std::chrono::seconds>(ms));
+            m_socket.expires_after(ms);
         }
 
         void connect(const boost::asio::ip::tcp::resolver::results_type& endpoints,

--- a/src/agent/http_client/src/https_socket.cpp
+++ b/src/agent/http_client/src/https_socket.cpp
@@ -48,7 +48,7 @@ namespace http_client
     {
         try
         {
-            m_ssl_socket->expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS));
+            m_ssl_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
             m_ssl_socket->connect(endpoints, ec);
         }
         catch (const std::exception& e)
@@ -64,7 +64,7 @@ namespace http_client
     {
         try
         {
-            m_ssl_socket->expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS));
+            m_ssl_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
             co_await m_ssl_socket->async_connect(endpoints, ec);
         }
         catch (const std::exception& e)
@@ -79,7 +79,7 @@ namespace http_client
     {
         try
         {
-            m_ssl_socket->expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS));
+            m_ssl_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
             m_ssl_socket->write(req, ec);
         }
         catch (const std::exception& e)
@@ -94,7 +94,7 @@ namespace http_client
     {
         try
         {
-            m_ssl_socket->expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS));
+            m_ssl_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
             co_await m_ssl_socket->async_write(req, ec);
         }
         catch (const std::exception& e)
@@ -110,7 +110,7 @@ namespace http_client
         try
         {
             boost::beast::flat_buffer buffer;
-            m_ssl_socket->expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS));
+            m_ssl_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
             m_ssl_socket->read(buffer, res, ec);
         }
         catch (const std::exception& e)

--- a/src/agent/http_client/src/https_socket.cpp
+++ b/src/agent/http_client/src/https_socket.cpp
@@ -43,12 +43,17 @@ namespace http_client
         }
     }
 
+    void HttpsSocket::SetTimeout(const time_t timeout)
+    {
+        m_timeoutInMilliseconds = timeout;
+    }
+
     void HttpsSocket::Connect(const boost::asio::ip::tcp::resolver::results_type& endpoints,
                               boost::system::error_code& ec)
     {
         try
         {
-            m_ssl_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
+            m_ssl_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
             m_ssl_socket->connect(endpoints, ec);
         }
         catch (const std::exception& e)
@@ -64,7 +69,7 @@ namespace http_client
     {
         try
         {
-            m_ssl_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
+            m_ssl_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
             co_await m_ssl_socket->async_connect(endpoints, ec);
         }
         catch (const std::exception& e)
@@ -79,7 +84,7 @@ namespace http_client
     {
         try
         {
-            m_ssl_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
+            m_ssl_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
             m_ssl_socket->write(req, ec);
         }
         catch (const std::exception& e)
@@ -94,7 +99,7 @@ namespace http_client
     {
         try
         {
-            m_ssl_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
+            m_ssl_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
             co_await m_ssl_socket->async_write(req, ec);
         }
         catch (const std::exception& e)
@@ -110,7 +115,7 @@ namespace http_client
         try
         {
             boost::beast::flat_buffer buffer;
-            m_ssl_socket->expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS));
+            m_ssl_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
             m_ssl_socket->read(buffer, res, ec);
         }
         catch (const std::exception& e)
@@ -121,13 +126,12 @@ namespace http_client
 
     boost::asio::awaitable<void>
     HttpsSocket::AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
-                           boost::system::error_code& ec,
-                           const time_t socketTimeout)
+                           boost::system::error_code& ec)
     {
         try
         {
             boost::beast::flat_buffer buffer;
-            m_ssl_socket->expires_after(std::chrono::milliseconds(socketTimeout));
+            m_ssl_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
             co_await m_ssl_socket->async_read(buffer, res, ec);
         }
         catch (const std::exception& e)

--- a/src/agent/http_client/src/https_socket.cpp
+++ b/src/agent/http_client/src/https_socket.cpp
@@ -121,12 +121,13 @@ namespace http_client
 
     boost::asio::awaitable<void>
     HttpsSocket::AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
-                           boost::system::error_code& ec)
+                           boost::system::error_code& ec,
+                           const time_t socketTimeout)
     {
         try
         {
             boost::beast::flat_buffer buffer;
-            m_ssl_socket->expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS));
+            m_ssl_socket->expires_after(std::chrono::milliseconds(socketTimeout));
             co_await m_ssl_socket->async_read(buffer, res, ec);
         }
         catch (const std::exception& e)

--- a/src/agent/http_client/src/https_socket.cpp
+++ b/src/agent/http_client/src/https_socket.cpp
@@ -43,9 +43,9 @@ namespace http_client
         }
     }
 
-    void HttpsSocket::SetTimeout(const time_t timeout)
+    void HttpsSocket::SetTimeout(const std::chrono::milliseconds timeout)
     {
-        m_timeoutInMilliseconds = timeout;
+        m_timeout = timeout;
     }
 
     void HttpsSocket::Connect(const boost::asio::ip::tcp::resolver::results_type& endpoints,
@@ -53,7 +53,7 @@ namespace http_client
     {
         try
         {
-            m_ssl_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
+            m_ssl_socket->expires_after(m_timeout);
             m_ssl_socket->connect(endpoints, ec);
         }
         catch (const std::exception& e)
@@ -69,7 +69,7 @@ namespace http_client
     {
         try
         {
-            m_ssl_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
+            m_ssl_socket->expires_after(m_timeout);
             co_await m_ssl_socket->async_connect(endpoints, ec);
         }
         catch (const std::exception& e)
@@ -84,7 +84,7 @@ namespace http_client
     {
         try
         {
-            m_ssl_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
+            m_ssl_socket->expires_after(m_timeout);
             m_ssl_socket->write(req, ec);
         }
         catch (const std::exception& e)
@@ -99,7 +99,7 @@ namespace http_client
     {
         try
         {
-            m_ssl_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
+            m_ssl_socket->expires_after(m_timeout);
             co_await m_ssl_socket->async_write(req, ec);
         }
         catch (const std::exception& e)
@@ -115,7 +115,7 @@ namespace http_client
         try
         {
             boost::beast::flat_buffer buffer;
-            m_ssl_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
+            m_ssl_socket->expires_after(m_timeout);
             m_ssl_socket->read(buffer, res, ec);
         }
         catch (const std::exception& e)
@@ -131,7 +131,7 @@ namespace http_client
         try
         {
             boost::beast::flat_buffer buffer;
-            m_ssl_socket->expires_after(std::chrono::milliseconds(m_timeoutInMilliseconds));
+            m_ssl_socket->expires_after(m_timeout);
             co_await m_ssl_socket->async_read(buffer, res, ec);
         }
         catch (const std::exception& e)

--- a/src/agent/http_client/src/https_socket.hpp
+++ b/src/agent/http_client/src/https_socket.hpp
@@ -35,7 +35,7 @@ namespace http_client
 
         /// @brief Sets the timeout for requests in milliseconds.
         /// @param timeout Timeout in milliseconds applied to all requests
-        void SetTimeout(const time_t timeout) override;
+        void SetTimeout(const std::chrono::milliseconds timeout) override;
 
         /// @brief Connects the socket to the given endpoints
         /// @param endpoints The endpoints to connect to
@@ -70,7 +70,6 @@ namespace http_client
         /// @brief Asynchronous version of Read
         /// @param res The response to read
         /// @param ec The error code, if any occurred
-        /// @param socketTimeout Timeout for reading in millisenconds
         boost::asio::awaitable<void> AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
                                                boost::system::error_code& ec) override;
 
@@ -85,6 +84,6 @@ namespace http_client
         std::shared_ptr<ISocketWrapper> m_ssl_socket;
 
         /// @brief Timeout in milliseconds used in every operation
-        time_t m_timeoutInMilliseconds = http_client::SOCKET_TIMEOUT_MSECS;
+        std::chrono::milliseconds m_timeout {http_client::SOCKET_TIMEOUT_MSECS};
     };
 } // namespace http_client

--- a/src/agent/http_client/src/https_socket.hpp
+++ b/src/agent/http_client/src/https_socket.hpp
@@ -33,6 +33,10 @@ namespace http_client
         /// - "none": no verification is performed
         void SetVerificationMode(const std::string& host, const std::string& verificationMode) override;
 
+        /// @brief Sets the timeout for requests in milliseconds.
+        /// @param timeout Timeout in milliseconds applied to all requests
+        void SetTimeout(const time_t timeout) override;
+
         /// @brief Connects the socket to the given endpoints
         /// @param endpoints The endpoints to connect to
         /// @param ec The error code, if any occurred
@@ -68,8 +72,7 @@ namespace http_client
         /// @param ec The error code, if any occurred
         /// @param socketTimeout Timeout for reading in millisenconds
         boost::asio::awaitable<void> AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
-                                               boost::system::error_code& ec,
-                                               const time_t socketTimeout = http_client::SOCKET_TIMEOUT_MSECS) override;
+                                               boost::system::error_code& ec) override;
 
         /// @brief Closes the socket
         void Close() override;
@@ -80,5 +83,8 @@ namespace http_client
 
         /// @brief The SSL socket to use for the connection
         std::shared_ptr<ISocketWrapper> m_ssl_socket;
+
+        /// @brief Timeout in milliseconds used in every operation
+        time_t m_timeoutInMilliseconds = http_client::SOCKET_TIMEOUT_MSECS;
     };
 } // namespace http_client

--- a/src/agent/http_client/src/https_socket.hpp
+++ b/src/agent/http_client/src/https_socket.hpp
@@ -66,8 +66,10 @@ namespace http_client
         /// @brief Asynchronous version of Read
         /// @param res The response to read
         /// @param ec The error code, if any occurred
+        /// @param socketTimeout Timeout for reading in millisenconds
         boost::asio::awaitable<void> AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
-                                               boost::system::error_code& ec) override;
+                                               boost::system::error_code& ec,
+                                               const time_t socketTimeout = http_client::SOCKET_TIMEOUT_MSECS) override;
 
         /// @brief Closes the socket
         void Close() override;

--- a/src/agent/http_client/src/https_socket_wrapper.hpp
+++ b/src/agent/http_client/src/https_socket_wrapper.hpp
@@ -38,6 +38,11 @@ namespace http_client
             m_socket.next_layer().expires_after(seconds);
         }
 
+        void expires_after(std::chrono::milliseconds ms) override
+        {
+            m_socket.next_layer().expires_after(std::chrono::duration_cast<std::chrono::seconds>(ms));
+        }
+
         void connect(const boost::asio::ip::tcp::resolver::results_type& endpoints,
                      boost::system::error_code& ec) override
         {

--- a/src/agent/http_client/src/https_socket_wrapper.hpp
+++ b/src/agent/http_client/src/https_socket_wrapper.hpp
@@ -35,7 +35,7 @@ namespace http_client
 
         void expires_after(std::chrono::milliseconds ms) override
         {
-            m_socket.next_layer().expires_after(std::chrono::duration_cast<std::chrono::seconds>(ms));
+            m_socket.next_layer().expires_after(ms);
         }
 
         void connect(const boost::asio::ip::tcp::resolver::results_type& endpoints,

--- a/src/agent/http_client/src/https_socket_wrapper.hpp
+++ b/src/agent/http_client/src/https_socket_wrapper.hpp
@@ -33,11 +33,6 @@ namespace http_client
             m_socket.set_verify_callback(vf);
         }
 
-        void expires_after(std::chrono::seconds seconds) override
-        {
-            m_socket.next_layer().expires_after(seconds);
-        }
-
         void expires_after(std::chrono::milliseconds ms) override
         {
             m_socket.next_layer().expires_after(std::chrono::duration_cast<std::chrono::seconds>(ms));

--- a/src/agent/http_client/src/ihttp_socket.hpp
+++ b/src/agent/http_client/src/ihttp_socket.hpp
@@ -9,9 +9,8 @@
 
 namespace http_client
 {
-    /// @brief The socket timeout in seconds
-    constexpr int SOCKET_TIMEOUT_SECS = 60;
-    constexpr int SOCKET_TIMEOUT_MSECS = SOCKET_TIMEOUT_SECS * 1000;
+    /// @brief The socket timeout in milliseconds
+    constexpr int SOCKET_TIMEOUT_MSECS = 60000;
 
     /// @brief Interface for HTTP sockets
     class IHttpSocket

--- a/src/agent/http_client/src/ihttp_socket.hpp
+++ b/src/agent/http_client/src/ihttp_socket.hpp
@@ -11,6 +11,7 @@ namespace http_client
 {
     /// @brief The socket timeout in seconds
     constexpr int SOCKET_TIMEOUT_SECS = 60;
+    constexpr int SOCKET_TIMEOUT_MSECS = SOCKET_TIMEOUT_SECS * 1000;
 
     /// @brief Interface for HTTP sockets
     class IHttpSocket
@@ -58,9 +59,11 @@ namespace http_client
         /// @brief Asynchronous version of Read
         /// @param res The response to read
         /// @param ec The error code, if any occurred
+        /// @param socketTimeout Timeout for reading in millisenconds
         virtual boost::asio::awaitable<void>
         AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
-                  boost::system::error_code& ec) = 0;
+                  boost::system::error_code& ec,
+                  const time_t socketTimeout = http_client::SOCKET_TIMEOUT_MSECS) = 0;
 
         /// @brief Closes the socket
         virtual void Close() = 0;

--- a/src/agent/http_client/src/ihttp_socket.hpp
+++ b/src/agent/http_client/src/ihttp_socket.hpp
@@ -25,6 +25,10 @@ namespace http_client
         /// @param verificationMode The verification mode to set
         virtual void SetVerificationMode(const std::string& host, const std::string& verificationMode) = 0;
 
+        /// @brief Sets the timeout for requests in milliseconds.
+        /// @param timeout Timeout in milliseconds applied to all requests
+        virtual void SetTimeout(const time_t timeout) = 0;
+
         /// @brief Connects the socket to the given endpoints
         /// @param endpoints The endpoints to connect to
         /// @param ec The error code, if any occurred
@@ -59,11 +63,9 @@ namespace http_client
         /// @brief Asynchronous version of Read
         /// @param res The response to read
         /// @param ec The error code, if any occurred
-        /// @param socketTimeout Timeout for reading in millisenconds
         virtual boost::asio::awaitable<void>
         AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
-                  boost::system::error_code& ec,
-                  const time_t socketTimeout = http_client::SOCKET_TIMEOUT_MSECS) = 0;
+                  boost::system::error_code& ec) = 0;
 
         /// @brief Closes the socket
         virtual void Close() = 0;

--- a/src/agent/http_client/src/ihttp_socket.hpp
+++ b/src/agent/http_client/src/ihttp_socket.hpp
@@ -26,7 +26,7 @@ namespace http_client
 
         /// @brief Sets the timeout for requests in milliseconds.
         /// @param timeout Timeout in milliseconds applied to all requests
-        virtual void SetTimeout(const time_t timeout) = 0;
+        virtual void SetTimeout(const std::chrono::milliseconds timeout) = 0;
 
         /// @brief Connects the socket to the given endpoints
         /// @param endpoints The endpoints to connect to

--- a/src/agent/http_client/src/ihttp_socket_wrapper.hpp
+++ b/src/agent/http_client/src/ihttp_socket_wrapper.hpp
@@ -21,8 +21,6 @@ namespace http_client
 
         virtual void set_verify_callback(std::function<bool(bool, boost::asio::ssl::verify_context&)> vf) = 0;
 
-        virtual void expires_after(std::chrono::seconds seconds) = 0;
-
         virtual void expires_after(std::chrono::milliseconds ms) = 0;
 
         virtual void connect(const boost::asio::ip::tcp::resolver::results_type& endpoints,

--- a/src/agent/http_client/src/ihttp_socket_wrapper.hpp
+++ b/src/agent/http_client/src/ihttp_socket_wrapper.hpp
@@ -23,6 +23,8 @@ namespace http_client
 
         virtual void expires_after(std::chrono::seconds seconds) = 0;
 
+        virtual void expires_after(std::chrono::milliseconds ms) = 0;
+
         virtual void connect(const boost::asio::ip::tcp::resolver::results_type& endpoints,
                              boost::system::error_code& ec) = 0;
 

--- a/src/agent/http_client/tests/http_client_test.cpp
+++ b/src/agent/http_client/tests/http_client_test.cpp
@@ -98,10 +98,9 @@ protected:
 
     void SetupMockSocketReadExpectations(boost::beast::http::status status, boost::system::error_code readEc = {})
     {
-        EXPECT_CALL(*mockSocket, AsyncRead(_, _, _))
+        EXPECT_CALL(*mockSocket, AsyncRead(_, _))
             .WillOnce(Invoke(
-                [status, readEc](auto& res, boost::system::error_code& ec, [[maybe_unused]] const time_t timeout)
-                    -> boost::asio::awaitable<void>
+                [status, readEc](auto& res, boost::system::error_code& ec) -> boost::asio::awaitable<void>
                 {
                     res.result(status);
                     ec = readEc;

--- a/src/agent/http_client/tests/http_client_test.cpp
+++ b/src/agent/http_client/tests/http_client_test.cpp
@@ -98,9 +98,10 @@ protected:
 
     void SetupMockSocketReadExpectations(boost::beast::http::status status, boost::system::error_code readEc = {})
     {
-        EXPECT_CALL(*mockSocket, AsyncRead(_, _))
+        EXPECT_CALL(*mockSocket, AsyncRead(_, _, _))
             .WillOnce(Invoke(
-                [status, readEc](auto& res, boost::system::error_code& ec) -> boost::asio::awaitable<void>
+                [status, readEc](auto& res, boost::system::error_code& ec, [[maybe_unused]] const time_t timeout)
+                    -> boost::asio::awaitable<void>
                 {
                     res.result(status);
                     ec = readEc;

--- a/src/agent/http_client/tests/http_socket_test.cpp
+++ b/src/agent/http_client/tests/http_socket_test.cpp
@@ -343,8 +343,7 @@ TEST_F(HttpSocketTest, AsyncReadSuccess)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void>
-        { co_await m_socket->AsyncRead(res, result_ec, http_client::SOCKET_TIMEOUT_MSECS); },
+        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec); },
         boost::asio::detached);
 
     m_ioContext->run();
@@ -372,8 +371,7 @@ TEST_F(HttpSocketTest, AsyncReadFailure)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void>
-        { co_await m_socket->AsyncRead(res, result_ec, http_client::SOCKET_TIMEOUT_MSECS); },
+        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec); },
         boost::asio::detached);
 
     m_ioContext->run();
@@ -396,8 +394,7 @@ TEST_F(HttpSocketTest, AsyncReadException)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void>
-        { co_await m_socket->AsyncRead(res, result_ec, http_client::SOCKET_TIMEOUT_MSECS); },
+        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec); },
         boost::asio::detached);
 
     m_ioContext->run();

--- a/src/agent/http_client/tests/http_socket_test.cpp
+++ b/src/agent/http_client/tests/http_socket_test.cpp
@@ -56,7 +56,7 @@ TEST_F(HttpSocketTest, SetVerificationMode)
 
 TEST_F(HttpSocketTest, ConnectSocketSuccess)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _)).Times(1);
 
     boost::system::error_code ec;
@@ -67,7 +67,7 @@ TEST_F(HttpSocketTest, ConnectSocketSuccess)
 
 TEST_F(HttpSocketTest, ConnectSocketFailure)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _))
         .WillOnce([](const boost::asio::ip::tcp::resolver::results_type&, boost::system::error_code& ec)
                   { ec = boost::asio::error::operation_aborted; });
@@ -80,7 +80,7 @@ TEST_F(HttpSocketTest, ConnectSocketFailure)
 
 TEST_F(HttpSocketTest, ConnectSocketException)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _))
         .WillOnce([](const boost::asio::ip::tcp::resolver::results_type&, boost::system::error_code&)
                   { throw std::runtime_error("Test exception"); });
@@ -93,7 +93,7 @@ TEST_F(HttpSocketTest, ConnectSocketException)
 
 TEST_F(HttpSocketTest, AsyncConnectSuccess)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, async_connect(dummyResults, testing::_))
         .WillOnce(
             [](const boost::asio::ip::tcp::resolver::results_type&,
@@ -116,7 +116,7 @@ TEST_F(HttpSocketTest, AsyncConnectSuccess)
 
 TEST_F(HttpSocketTest, AsyncConnectFailure)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, async_connect(dummyResults, testing::_))
         .WillOnce(
             [](const boost::asio::ip::tcp::resolver::results_type&,
@@ -140,7 +140,7 @@ TEST_F(HttpSocketTest, AsyncConnectFailure)
 
 TEST_F(HttpSocketTest, AsyncConnectException)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, async_connect(dummyResults, testing::_))
         .WillOnce([](const boost::asio::ip::tcp::resolver::results_type&,
                      boost::system::error_code&) -> boost::asio::awaitable<void>
@@ -161,7 +161,7 @@ TEST_F(HttpSocketTest, WriteSuccess)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&, boost::system::error_code& ec)
                   { ec = boost::system::error_code {}; });
@@ -176,7 +176,7 @@ TEST_F(HttpSocketTest, WriteFailure)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&, boost::system::error_code& ec)
                   { ec = boost::asio::error::connection_refused; });
@@ -192,7 +192,7 @@ TEST_F(HttpSocketTest, WriteException)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&, boost::system::error_code&)
                   { throw std::runtime_error("Test exception"); });
@@ -207,7 +207,7 @@ TEST_F(HttpSocketTest, AsyncWriteSuccess)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, async_write(_, _))
         .WillOnce(
             [](const boost::beast::http::request<boost::beast::http::string_body>&,
@@ -231,7 +231,7 @@ TEST_F(HttpSocketTest, AsyncWriteFailure)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, async_write(_, _))
         .WillOnce(
             [](const boost::beast::http::request<boost::beast::http::string_body>&,
@@ -255,7 +255,7 @@ TEST_F(HttpSocketTest, AsyncWriteException)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, async_write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&,
                      boost::system::error_code&) -> boost::asio::awaitable<void>
@@ -276,7 +276,7 @@ TEST_F(HttpSocketTest, ReadSuccess)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, read(_, _, _))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -294,7 +294,7 @@ TEST_F(HttpSocketTest, ReadFailure)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, read(_, _, _))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -312,7 +312,7 @@ TEST_F(HttpSocketTest, ReadException)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, read(_, _, _))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -329,7 +329,7 @@ TEST_F(HttpSocketTest, AsyncReadSuccess)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, async_read(testing::_, testing::_, testing::_))
         .WillOnce(
             [](boost::beast::flat_buffer&,
@@ -357,7 +357,7 @@ TEST_F(HttpSocketTest, AsyncReadFailure)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, async_read(testing::_, testing::_, testing::_))
         .WillOnce(
             [](boost::beast::flat_buffer&,
@@ -384,7 +384,7 @@ TEST_F(HttpSocketTest, AsyncReadException)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, async_read(testing::_, testing::_, testing::_))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -404,7 +404,7 @@ TEST_F(HttpSocketTest, AsyncReadException)
 
 TEST_F(HttpSocketTest, CloseSocket)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _)).Times(1);
     EXPECT_CALL(*m_mockHelper, close()).Times(1);
 

--- a/src/agent/http_client/tests/http_socket_test.cpp
+++ b/src/agent/http_client/tests/http_socket_test.cpp
@@ -56,7 +56,7 @@ TEST_F(HttpSocketTest, SetVerificationMode)
 
 TEST_F(HttpSocketTest, ConnectSocketSuccess)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _)).Times(1);
 
     boost::system::error_code ec;
@@ -67,7 +67,7 @@ TEST_F(HttpSocketTest, ConnectSocketSuccess)
 
 TEST_F(HttpSocketTest, ConnectSocketFailure)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _))
         .WillOnce([](const boost::asio::ip::tcp::resolver::results_type&, boost::system::error_code& ec)
                   { ec = boost::asio::error::operation_aborted; });
@@ -80,7 +80,7 @@ TEST_F(HttpSocketTest, ConnectSocketFailure)
 
 TEST_F(HttpSocketTest, ConnectSocketException)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _))
         .WillOnce([](const boost::asio::ip::tcp::resolver::results_type&, boost::system::error_code&)
                   { throw std::runtime_error("Test exception"); });
@@ -93,7 +93,7 @@ TEST_F(HttpSocketTest, ConnectSocketException)
 
 TEST_F(HttpSocketTest, AsyncConnectSuccess)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, async_connect(dummyResults, testing::_))
         .WillOnce(
             [](const boost::asio::ip::tcp::resolver::results_type&,
@@ -116,7 +116,7 @@ TEST_F(HttpSocketTest, AsyncConnectSuccess)
 
 TEST_F(HttpSocketTest, AsyncConnectFailure)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, async_connect(dummyResults, testing::_))
         .WillOnce(
             [](const boost::asio::ip::tcp::resolver::results_type&,
@@ -140,7 +140,7 @@ TEST_F(HttpSocketTest, AsyncConnectFailure)
 
 TEST_F(HttpSocketTest, AsyncConnectException)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, async_connect(dummyResults, testing::_))
         .WillOnce([](const boost::asio::ip::tcp::resolver::results_type&,
                      boost::system::error_code&) -> boost::asio::awaitable<void>
@@ -161,7 +161,7 @@ TEST_F(HttpSocketTest, WriteSuccess)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&, boost::system::error_code& ec)
                   { ec = boost::system::error_code {}; });
@@ -176,7 +176,7 @@ TEST_F(HttpSocketTest, WriteFailure)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&, boost::system::error_code& ec)
                   { ec = boost::asio::error::connection_refused; });
@@ -192,7 +192,7 @@ TEST_F(HttpSocketTest, WriteException)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&, boost::system::error_code&)
                   { throw std::runtime_error("Test exception"); });
@@ -207,7 +207,7 @@ TEST_F(HttpSocketTest, AsyncWriteSuccess)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, async_write(_, _))
         .WillOnce(
             [](const boost::beast::http::request<boost::beast::http::string_body>&,
@@ -231,7 +231,7 @@ TEST_F(HttpSocketTest, AsyncWriteFailure)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, async_write(_, _))
         .WillOnce(
             [](const boost::beast::http::request<boost::beast::http::string_body>&,
@@ -255,7 +255,7 @@ TEST_F(HttpSocketTest, AsyncWriteException)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, async_write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&,
                      boost::system::error_code&) -> boost::asio::awaitable<void>
@@ -276,7 +276,7 @@ TEST_F(HttpSocketTest, ReadSuccess)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, read(_, _, _))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -294,7 +294,7 @@ TEST_F(HttpSocketTest, ReadFailure)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, read(_, _, _))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -312,7 +312,7 @@ TEST_F(HttpSocketTest, ReadException)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, read(_, _, _))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -407,7 +407,7 @@ TEST_F(HttpSocketTest, AsyncReadException)
 
 TEST_F(HttpSocketTest, CloseSocket)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(testing::An<std::chrono::seconds>())).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _)).Times(1);
     EXPECT_CALL(*m_mockHelper, close()).Times(1);
 

--- a/src/agent/http_client/tests/http_socket_test.cpp
+++ b/src/agent/http_client/tests/http_socket_test.cpp
@@ -343,7 +343,8 @@ TEST_F(HttpSocketTest, AsyncReadSuccess)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec); },
+        [&]() -> boost::asio::awaitable<void>
+        { co_await m_socket->AsyncRead(res, result_ec, http_client::SOCKET_TIMEOUT_MSECS); },
         boost::asio::detached);
 
     m_ioContext->run();
@@ -371,7 +372,8 @@ TEST_F(HttpSocketTest, AsyncReadFailure)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec); },
+        [&]() -> boost::asio::awaitable<void>
+        { co_await m_socket->AsyncRead(res, result_ec, http_client::SOCKET_TIMEOUT_MSECS); },
         boost::asio::detached);
 
     m_ioContext->run();
@@ -394,7 +396,8 @@ TEST_F(HttpSocketTest, AsyncReadException)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec); },
+        [&]() -> boost::asio::awaitable<void>
+        { co_await m_socket->AsyncRead(res, result_ec, http_client::SOCKET_TIMEOUT_MSECS); },
         boost::asio::detached);
 
     m_ioContext->run();

--- a/src/agent/http_client/tests/https_socket_test.cpp
+++ b/src/agent/http_client/tests/https_socket_test.cpp
@@ -56,7 +56,7 @@ TEST_F(HttpsSocketTest, SetVerificationMode)
 
 TEST_F(HttpsSocketTest, ConnectSocketSuccess)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _)).Times(1);
 
     boost::system::error_code ec;
@@ -67,7 +67,7 @@ TEST_F(HttpsSocketTest, ConnectSocketSuccess)
 
 TEST_F(HttpsSocketTest, ConnectSocketFailure)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _))
         .WillOnce([](const boost::asio::ip::tcp::resolver::results_type&, boost::system::error_code& ec)
                   { ec = boost::asio::error::operation_aborted; });
@@ -80,7 +80,7 @@ TEST_F(HttpsSocketTest, ConnectSocketFailure)
 
 TEST_F(HttpsSocketTest, ConnectSocketException)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _))
         .WillOnce([](const boost::asio::ip::tcp::resolver::results_type&, boost::system::error_code&)
                   { throw std::runtime_error("Test exception"); });
@@ -93,7 +93,7 @@ TEST_F(HttpsSocketTest, ConnectSocketException)
 
 TEST_F(HttpsSocketTest, AsyncConnectSuccess)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, async_connect(dummyResults, testing::_))
         .WillOnce(
             [](const boost::asio::ip::tcp::resolver::results_type&,
@@ -116,7 +116,7 @@ TEST_F(HttpsSocketTest, AsyncConnectSuccess)
 
 TEST_F(HttpsSocketTest, AsyncConnectFailure)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, async_connect(dummyResults, testing::_))
         .WillOnce(
             [](const boost::asio::ip::tcp::resolver::results_type&,
@@ -140,7 +140,7 @@ TEST_F(HttpsSocketTest, AsyncConnectFailure)
 
 TEST_F(HttpsSocketTest, AsyncConnectException)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, async_connect(dummyResults, testing::_))
         .WillOnce([](const boost::asio::ip::tcp::resolver::results_type&,
                      boost::system::error_code&) -> boost::asio::awaitable<void>
@@ -161,7 +161,7 @@ TEST_F(HttpsSocketTest, WriteSuccess)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&, boost::system::error_code& ec)
                   { ec = boost::system::error_code {}; });
@@ -176,7 +176,7 @@ TEST_F(HttpsSocketTest, WriteFailure)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&, boost::system::error_code& ec)
                   { ec = boost::asio::error::connection_refused; });
@@ -192,7 +192,7 @@ TEST_F(HttpsSocketTest, WriteException)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&, boost::system::error_code&)
                   { throw std::runtime_error("Test exception"); });
@@ -207,7 +207,7 @@ TEST_F(HttpsSocketTest, AsyncWriteSuccess)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, async_write(_, _))
         .WillOnce(
             [](const boost::beast::http::request<boost::beast::http::string_body>&,
@@ -231,7 +231,7 @@ TEST_F(HttpsSocketTest, AsyncWriteFailure)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, async_write(_, _))
         .WillOnce(
             [](const boost::beast::http::request<boost::beast::http::string_body>&,
@@ -255,7 +255,7 @@ TEST_F(HttpsSocketTest, AsyncWriteException)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, async_write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&,
                      boost::system::error_code&) -> boost::asio::awaitable<void>
@@ -276,7 +276,7 @@ TEST_F(HttpsSocketTest, ReadSuccess)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, read(_, _, _))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -294,7 +294,7 @@ TEST_F(HttpsSocketTest, ReadFailure)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, read(_, _, _))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -312,7 +312,7 @@ TEST_F(HttpsSocketTest, ReadException)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, read(_, _, _))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -329,7 +329,7 @@ TEST_F(HttpsSocketTest, AsyncReadSuccess)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, async_read(testing::_, testing::_, testing::_))
         .WillOnce(
             [](boost::beast::flat_buffer&,
@@ -343,7 +343,7 @@ TEST_F(HttpsSocketTest, AsyncReadSuccess)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec); },
+        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec, 60000); },
         boost::asio::detached);
 
     m_ioContext->run();
@@ -357,7 +357,7 @@ TEST_F(HttpsSocketTest, AsyncReadFailure)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, async_read(testing::_, testing::_, testing::_))
         .WillOnce(
             [](boost::beast::flat_buffer&,
@@ -371,7 +371,7 @@ TEST_F(HttpsSocketTest, AsyncReadFailure)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec); },
+        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec, 60000); },
         boost::asio::detached);
 
     m_ioContext->run();
@@ -384,7 +384,7 @@ TEST_F(HttpsSocketTest, AsyncReadException)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, async_read(testing::_, testing::_, testing::_))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -394,7 +394,7 @@ TEST_F(HttpsSocketTest, AsyncReadException)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec); },
+        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec, 60000); },
         boost::asio::detached);
 
     m_ioContext->run();
@@ -404,7 +404,7 @@ TEST_F(HttpsSocketTest, AsyncReadException)
 
 TEST_F(HttpsSocketTest, CloseSocket)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _)).Times(1);
     EXPECT_CALL(*m_mockHelper, close()).Times(1);
 

--- a/src/agent/http_client/tests/https_socket_test.cpp
+++ b/src/agent/http_client/tests/https_socket_test.cpp
@@ -343,7 +343,8 @@ TEST_F(HttpsSocketTest, AsyncReadSuccess)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec, 60000); },
+        [&]() -> boost::asio::awaitable<void>
+        { co_await m_socket->AsyncRead(res, result_ec, http_client::SOCKET_TIMEOUT_MSECS); },
         boost::asio::detached);
 
     m_ioContext->run();
@@ -371,7 +372,8 @@ TEST_F(HttpsSocketTest, AsyncReadFailure)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec, 60000); },
+        [&]() -> boost::asio::awaitable<void>
+        { co_await m_socket->AsyncRead(res, result_ec, http_client::SOCKET_TIMEOUT_MSECS); },
         boost::asio::detached);
 
     m_ioContext->run();
@@ -394,7 +396,8 @@ TEST_F(HttpsSocketTest, AsyncReadException)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec, 60000); },
+        [&]() -> boost::asio::awaitable<void>
+        { co_await m_socket->AsyncRead(res, result_ec, http_client::SOCKET_TIMEOUT_MSECS); },
         boost::asio::detached);
 
     m_ioContext->run();

--- a/src/agent/http_client/tests/https_socket_test.cpp
+++ b/src/agent/http_client/tests/https_socket_test.cpp
@@ -56,7 +56,7 @@ TEST_F(HttpsSocketTest, SetVerificationMode)
 
 TEST_F(HttpsSocketTest, ConnectSocketSuccess)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _)).Times(1);
 
     boost::system::error_code ec;
@@ -67,7 +67,7 @@ TEST_F(HttpsSocketTest, ConnectSocketSuccess)
 
 TEST_F(HttpsSocketTest, ConnectSocketFailure)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _))
         .WillOnce([](const boost::asio::ip::tcp::resolver::results_type&, boost::system::error_code& ec)
                   { ec = boost::asio::error::operation_aborted; });
@@ -80,7 +80,7 @@ TEST_F(HttpsSocketTest, ConnectSocketFailure)
 
 TEST_F(HttpsSocketTest, ConnectSocketException)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _))
         .WillOnce([](const boost::asio::ip::tcp::resolver::results_type&, boost::system::error_code&)
                   { throw std::runtime_error("Test exception"); });
@@ -93,7 +93,7 @@ TEST_F(HttpsSocketTest, ConnectSocketException)
 
 TEST_F(HttpsSocketTest, AsyncConnectSuccess)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, async_connect(dummyResults, testing::_))
         .WillOnce(
             [](const boost::asio::ip::tcp::resolver::results_type&,
@@ -116,7 +116,7 @@ TEST_F(HttpsSocketTest, AsyncConnectSuccess)
 
 TEST_F(HttpsSocketTest, AsyncConnectFailure)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, async_connect(dummyResults, testing::_))
         .WillOnce(
             [](const boost::asio::ip::tcp::resolver::results_type&,
@@ -140,7 +140,7 @@ TEST_F(HttpsSocketTest, AsyncConnectFailure)
 
 TEST_F(HttpsSocketTest, AsyncConnectException)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, async_connect(dummyResults, testing::_))
         .WillOnce([](const boost::asio::ip::tcp::resolver::results_type&,
                      boost::system::error_code&) -> boost::asio::awaitable<void>
@@ -161,7 +161,7 @@ TEST_F(HttpsSocketTest, WriteSuccess)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&, boost::system::error_code& ec)
                   { ec = boost::system::error_code {}; });
@@ -176,7 +176,7 @@ TEST_F(HttpsSocketTest, WriteFailure)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&, boost::system::error_code& ec)
                   { ec = boost::asio::error::connection_refused; });
@@ -192,7 +192,7 @@ TEST_F(HttpsSocketTest, WriteException)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&, boost::system::error_code&)
                   { throw std::runtime_error("Test exception"); });
@@ -207,7 +207,7 @@ TEST_F(HttpsSocketTest, AsyncWriteSuccess)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, async_write(_, _))
         .WillOnce(
             [](const boost::beast::http::request<boost::beast::http::string_body>&,
@@ -231,7 +231,7 @@ TEST_F(HttpsSocketTest, AsyncWriteFailure)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, async_write(_, _))
         .WillOnce(
             [](const boost::beast::http::request<boost::beast::http::string_body>&,
@@ -255,7 +255,7 @@ TEST_F(HttpsSocketTest, AsyncWriteException)
 {
     boost::beast::http::request<boost::beast::http::string_body> req {boost::beast::http::verb::get, "/", 11};
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, async_write(_, _))
         .WillOnce([](const boost::beast::http::request<boost::beast::http::string_body>&,
                      boost::system::error_code&) -> boost::asio::awaitable<void>
@@ -276,7 +276,7 @@ TEST_F(HttpsSocketTest, ReadSuccess)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, read(_, _, _))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -294,7 +294,7 @@ TEST_F(HttpsSocketTest, ReadFailure)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, read(_, _, _))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -312,7 +312,7 @@ TEST_F(HttpsSocketTest, ReadException)
     boost::beast::http::response<boost::beast::http::dynamic_body> res;
     res.result(boost::beast::http::status::ok);
 
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::milliseconds(http_client::SOCKET_TIMEOUT_MSECS))).Times(1);
     EXPECT_CALL(*m_mockHelper, read(_, _, _))
         .WillOnce([](boost::beast::flat_buffer&,
                      boost::beast::http::response<boost::beast::http::dynamic_body>&,
@@ -407,7 +407,7 @@ TEST_F(HttpsSocketTest, AsyncReadException)
 
 TEST_F(HttpsSocketTest, CloseSocket)
 {
-    EXPECT_CALL(*m_mockHelper, expires_after(std::chrono::seconds(http_client::SOCKET_TIMEOUT_SECS))).Times(1);
+    EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _)).Times(1);
     EXPECT_CALL(*m_mockHelper, close()).Times(1);
 

--- a/src/agent/http_client/tests/https_socket_test.cpp
+++ b/src/agent/http_client/tests/https_socket_test.cpp
@@ -343,8 +343,7 @@ TEST_F(HttpsSocketTest, AsyncReadSuccess)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void>
-        { co_await m_socket->AsyncRead(res, result_ec, http_client::SOCKET_TIMEOUT_MSECS); },
+        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec); },
         boost::asio::detached);
 
     m_ioContext->run();
@@ -372,8 +371,7 @@ TEST_F(HttpsSocketTest, AsyncReadFailure)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void>
-        { co_await m_socket->AsyncRead(res, result_ec, http_client::SOCKET_TIMEOUT_MSECS); },
+        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec); },
         boost::asio::detached);
 
     m_ioContext->run();
@@ -396,8 +394,7 @@ TEST_F(HttpsSocketTest, AsyncReadException)
     boost::system::error_code result_ec;
     boost::asio::co_spawn(
         *m_ioContext,
-        [&]() -> boost::asio::awaitable<void>
-        { co_await m_socket->AsyncRead(res, result_ec, http_client::SOCKET_TIMEOUT_MSECS); },
+        [&]() -> boost::asio::awaitable<void> { co_await m_socket->AsyncRead(res, result_ec); },
         boost::asio::detached);
 
     m_ioContext->run();

--- a/src/agent/http_client/tests/mocks/mock_http_socket.hpp
+++ b/src/agent/http_client/tests/mocks/mock_http_socket.hpp
@@ -35,7 +35,9 @@ public:
 
     MOCK_METHOD(boost::asio::awaitable<void>,
                 AsyncRead,
-                (boost::beast::http::response<boost::beast::http::dynamic_body> & res, boost::system::error_code& ec),
+                (boost::beast::http::response<boost::beast::http::dynamic_body> & res,
+                 boost::system::error_code& ec,
+                 const time_t timeout),
                 (override));
 
     MOCK_METHOD(void, Close, (), (override));

--- a/src/agent/http_client/tests/mocks/mock_http_socket.hpp
+++ b/src/agent/http_client/tests/mocks/mock_http_socket.hpp
@@ -6,7 +6,7 @@ class MockHttpSocket : public http_client::IHttpSocket
 {
 public:
     MOCK_METHOD(void, SetVerificationMode, (const std::string& host, const std::string& verificationMode), (override));
-    MOCK_METHOD(void, SetTimeout, (const time_t timeout), (override));
+    MOCK_METHOD(void, SetTimeout, (const std::chrono::milliseconds timeout), (override));
     MOCK_METHOD(void,
                 Connect,
                 (const boost::asio::ip::tcp::resolver::results_type& endpoints, boost::system::error_code& code),

--- a/src/agent/http_client/tests/mocks/mock_http_socket.hpp
+++ b/src/agent/http_client/tests/mocks/mock_http_socket.hpp
@@ -6,6 +6,7 @@ class MockHttpSocket : public http_client::IHttpSocket
 {
 public:
     MOCK_METHOD(void, SetVerificationMode, (const std::string& host, const std::string& verificationMode), (override));
+    MOCK_METHOD(void, SetTimeout, (const time_t timeout), (override));
     MOCK_METHOD(void,
                 Connect,
                 (const boost::asio::ip::tcp::resolver::results_type& endpoints, boost::system::error_code& code),
@@ -35,9 +36,7 @@ public:
 
     MOCK_METHOD(boost::asio::awaitable<void>,
                 AsyncRead,
-                (boost::beast::http::response<boost::beast::http::dynamic_body> & res,
-                 boost::system::error_code& ec,
-                 const time_t timeout),
+                (boost::beast::http::response<boost::beast::http::dynamic_body> & res, boost::system::error_code& ec),
                 (override));
 
     MOCK_METHOD(void, Close, (), (override));

--- a/src/agent/http_client/tests/mocks/mock_http_wrapper.hpp
+++ b/src/agent/http_client/tests/mocks/mock_http_wrapper.hpp
@@ -9,7 +9,6 @@ public:
 
     MOCK_METHOD(void, set_verify_callback, (std::function<bool(bool, boost::asio::ssl::verify_context&)>), (override));
 
-    MOCK_METHOD(void, expires_after, (std::chrono::seconds), (override));
     MOCK_METHOD(void, expires_after, (std::chrono::milliseconds), (override));
     MOCK_METHOD(void,
                 connect,

--- a/src/agent/http_client/tests/mocks/mock_http_wrapper.hpp
+++ b/src/agent/http_client/tests/mocks/mock_http_wrapper.hpp
@@ -10,6 +10,7 @@ public:
     MOCK_METHOD(void, set_verify_callback, (std::function<bool(bool, boost::asio::ssl::verify_context&)>), (override));
 
     MOCK_METHOD(void, expires_after, (std::chrono::seconds), (override));
+    MOCK_METHOD(void, expires_after, (std::chrono::milliseconds), (override));
     MOCK_METHOD(void,
                 connect,
                 (const boost::asio::ip::tcp::resolver::results_type&, boost::system::error_code&),

--- a/src/cmake/config.cmake
+++ b/src/cmake/config.cmake
@@ -62,4 +62,4 @@ set(QUEUE_STATUS_REFRESH_TIMER 100 CACHE STRING "Default Agent's queue refresh t
 
 set(QUEUE_DEFAULT_SIZE "\"10000B\"" CACHE STRING "Default Agent's queue size (10000)")
 
-set(DEFAULT_COMMANDS_REQUEST_TIMEOUT "\"60s\"" CACHE STRING "Default Agent's command request timeout (60s)")
+set(DEFAULT_COMMANDS_REQUEST_TIMEOUT "\"11m\"" CACHE STRING "Default Agent's command request timeout (11m)")

--- a/src/cmake/config.cmake
+++ b/src/cmake/config.cmake
@@ -62,4 +62,4 @@ set(QUEUE_STATUS_REFRESH_TIMER 100 CACHE STRING "Default Agent's queue refresh t
 
 set(QUEUE_DEFAULT_SIZE "\"10000B\"" CACHE STRING "Default Agent's queue size (10000)")
 
-set(DEFAULT_COMMANDS_REQUEST_TIMEOUT 60000 CACHE STRING "Default Agent's command request timeout (60s)")
+set(DEFAULT_COMMANDS_REQUEST_TIMEOUT "\"60s\"" CACHE STRING "Default Agent's command request timeout (60s)")

--- a/src/cmake/config.cmake
+++ b/src/cmake/config.cmake
@@ -61,3 +61,5 @@ set(DEFAULT_HOTFIXES true CACHE BOOL "Default inventory hotfixes")
 set(QUEUE_STATUS_REFRESH_TIMER 100 CACHE STRING "Default Agent's queue refresh timer (100ms)")
 
 set(QUEUE_DEFAULT_SIZE "\"10000B\"" CACHE STRING "Default Agent's queue size (10000)")
+
+set(DEFAULT_COMMANDS_REQUEST_TIMEOUT 60000 CACHE STRING "Default Agent's command request timeout (60s)")

--- a/src/common/config/include/config.h.in
+++ b/src/common/config/include/config.h.in
@@ -23,6 +23,7 @@ namespace config
         constexpr auto QUEUE_DEFAULT_SIZE = @QUEUE_DEFAULT_SIZE@;
         constexpr auto DEFAULT_VERIFICATION_MODE = "@DEFAULT_VERIFICATION_MODE@";
         constexpr std::array<const char*, 3> VALID_VERIFICATION_MODES = {"full", "certificate", "none"};
+        constexpr auto DEFAULT_COMMANDS_REQUEST_TIMEOUT = @DEFAULT_COMMANDS_REQUEST_TIMEOUT@;
     }
 
     namespace logcollector

--- a/src/tests/mock-server/config/commands.groovy
+++ b/src/tests/mock-server/config/commands.groovy
@@ -23,12 +23,12 @@ def actions = [
     ["name": "fetch-config", "version": "v5.0.0", "args": ""]
 ]
 
-def numCommands = new Random().nextInt(3)
+def numCommands = 1
 
 def commands = []
-if (numCommands > 0) {
+if (0) {
     for (int i = 0; i < numCommands; i++) {
-        def action = actions[new Random().nextInt(actions.size())]
+        def action = actions[3]
         def command = [
             "document_id": generateUUIDv7(),
             "action": action,
@@ -41,12 +41,13 @@ if (numCommands > 0) {
 
 if (commands.isEmpty()) {
     respond {
-        withStatusCode(408)
+        withStatusCode(200)
     }
 } else {
     def jsonResponse = JsonOutput.toJson(["commands": commands])
     respond {
         withStatusCode(200)
         withContent(jsonResponse)
+        sleep(9999999)
     }
 }

--- a/src/tests/mock-server/config/commands.groovy
+++ b/src/tests/mock-server/config/commands.groovy
@@ -23,12 +23,12 @@ def actions = [
     ["name": "fetch-config", "version": "v5.0.0", "args": ""]
 ]
 
-def numCommands = 1
+def numCommands = new Random().nextInt(3)
 
 def commands = []
-if (0) {
+if (numCommands > 0) {
     for (int i = 0; i < numCommands; i++) {
-        def action = actions[3]
+        def action = actions[new Random().nextInt(actions.size())]
         def command = [
             "document_id": generateUUIDv7(),
             "action": action,
@@ -41,13 +41,12 @@ if (0) {
 
 if (commands.isEmpty()) {
     respond {
-        withStatusCode(200)
+        withStatusCode(408)
     }
 } else {
     def jsonResponse = JsonOutput.toJson(["commands": commands])
     respond {
         withStatusCode(200)
         withContent(jsonResponse)
-        sleep(9999999)
     }
 }


### PR DESCRIPTION
## Description
Closes #588 

Currently, the agent continuously queries the server for potential commands. This request remains pending until one of the following conditions occurs:

1. The server responds with a list of commands for the agent to execute.
2. A timeout occurs on either the server or the agent.

The current timeout configuration is:
- **30 seconds** on the server.
- **1 minute** on the agent.

This makes the server the limiting factor in the request lifecycle.

## Requirements

-  Add a new option named `commands_request_timeout` in `wazuh-agent.yml`.
-  This option will control the timeout for the command request.
-  The accepted range for this option should align with the server's configuration.

### New configuration option example

```yaml
agent:
  commands_request_timeout: 15m
```

## Plan

1. Align with the Server team to define the acceptable timeout range.
2. Implement the new option in the agent to regulate the command request timeout.

## Testing

Integration tests should cover the following scenario:

- The agent stops a command request due to a timeout, according to the configured parameter.

## Definition of Done

- [x] A new option `commands_request_timeout` is available in `wazuh-agent.yml`.
- [x] The agent applies this option when querying for commands.
- [x] Integration tests validate the timeout behavior.
- [x] Reference documentation is updated accordingly.

## Proposed Changes

* adding new filed to `HttpRequestParams`
* Modification of `expires_after` to use milliseconds as all time configurations.
* apply to HTTP and https also.
* Check unit test and add new if needed.

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

* Mock server tests:

In order to check the timeout the LogError messages were added for testing purposes:

* default with _http_

Agent's log:
```console
# ./build/wazuh-agent 
[2025-02-14 18:50:13.940] [wazuh-agent] [info] [INFO] [process_options_unix.cpp:24] [StartAgent] Starting wazuh-agent
[2025-02-14 18:50:13.941] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:252] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-02-14 18:50:13.941] [wazuh-agent] [info] [INFO] [communicator.cpp:71] [Communicator] Using insecure connection.
[2025-02-14 18:50:13.942] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:252] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-02-14 18:50:13.954] [wazuh-agent] [info] [INFO] [communicator.cpp:108] [SendAuthenticationRequest] Successfully authenticated with the manager.
[2025-02-14 18:50:13.954] [wazuh-agent] [error] [ERROR] [communicator.cpp:398] [ExecuteRequestLoop] /*/*/*/*/ start waiting
[2025-02-14 18:50:13.954] [wazuh-agent] [error] [ERROR] [http_client.cpp:134] [Co_PerformHttpRequest] /*/*/*/*/ time 60000
[2025-02-14 18:50:13.954] [wazuh-agent] [info] [INFO] [inventory.cpp:15] [Start] Inventory module is disabled.
[2025-02-14 18:50:13.954] [wazuh-agent] [info] [INFO] [logcollector.cpp:28] [Start] Logcollector module is disabled.
[2025-02-14 18:51:13.955] [wazuh-agent] [error] [ERROR] [http_client.cpp:168] [Co_PerformHttpRequest] Error: Error handling response: Operation canceled. Endpoint: /api/v1/commands.
[2025-02-14 18:51:13.955] [wazuh-agent] [error] [ERROR] [communicator.cpp:400] [ExecuteRequestLoop] /*/*/*/*/ finished waiting
[2025-02-14 18:51:43.956] [wazuh-agent] [error] [ERROR] [communicator.cpp:398] [ExecuteRequestLoop] /*/*/*/*/ start waiting
[2025-02-14 18:51:43.956] [wazuh-agent] [error] [ERROR] [http_client.cpp:134] [Co_PerformHttpRequest] /*/*/*/*/ time 60000
^C[2025-02-14 18:51:47.331] [wazuh-agent] [info] [INFO] [inventory.cpp:73] [Stop] Inventory module stopping...
[2025-02-14 18:51:47.331] [wazuh-agent] [info] [INFO] [logcollector.cpp:101] [Stop] Logcollector module stopped.

``` 

server log's:
```console
# ./mock-server --http --log-stateful --log-stateless
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/opt/imposter/lib/log4j-slf4j-impl-2.18.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
18:48:12 INFO  i.g.i.Imposter - Starting mock engine 4.2.1
18:48:14 INFO  i.g.i.Imposter - Mock engine up and running on http://localhost:8080
18:48:23 INFO  i.g.i.p.r.RestPluginImpl - Handling object request for: POST http://localhost/api/v1/authentication
18:48:23 INFO  i.g.i.s.ResponseServiceImpl - Serving response data (316 bytes) for POST http://localhost/api/v1/authentication with status code 200
18:50:13 INFO  i.g.i.p.r.RestPluginImpl - Handling object request for: POST http://localhost/api/v1/authentication

``` 

* Changed values:

Agent's Config:



```yml
# cat /etc/wazuh-agent/wazuh-agent.yml 
agent:
  thread_count: 4
  server_url: https://localhost:27000
  retry_interval: 30s
  verification_mode: none
  commands_request_timeout: 40s
events:
  batch_interval: 10s
  batch_size: 1MB
inventory:
  enabled: false
  interval: 1h
``` 

Agent's log:
```console
# ./build/wazuh-agent 
[2025-02-14 18:48:23.487] [wazuh-agent] [info] [INFO] [process_options_unix.cpp:24] [StartAgent] Starting wazuh-agent
[2025-02-14 18:48:23.489] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:252] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-02-14 18:48:23.489] [wazuh-agent] [info] [INFO] [communicator.cpp:71] [Communicator] Using insecure connection.
[2025-02-14 18:48:23.778] [wazuh-agent] [info] [INFO] [communicator.cpp:108] [SendAuthenticationRequest] Successfully authenticated with the manager.
[2025-02-14 18:48:23.778] [wazuh-agent] [error] [ERROR] [communicator.cpp:398] [ExecuteRequestLoop] /*/*/*/*/ start waiting
[2025-02-14 18:48:23.779] [wazuh-agent] [error] [ERROR] [http_client.cpp:134] [Co_PerformHttpRequest] /*/*/*/*/ time 40000
[2025-02-14 18:48:23.779] [wazuh-agent] [info] [INFO] [inventory.cpp:15] [Start] Inventory module is disabled.
[2025-02-14 18:48:23.779] [wazuh-agent] [info] [INFO] [logcollector.cpp:28] [Start] Logcollector module is disabled.
[2025-02-14 18:49:03.780] [wazuh-agent] [error] [ERROR] [http_client.cpp:168] [Co_PerformHttpRequest] Error: Error handling response: Operation canceled. Endpoint: /api/v1/commands.
[2025-02-14 18:49:03.780] [wazuh-agent] [error] [ERROR] [communicator.cpp:400] [ExecuteRequestLoop] /*/*/*/*/ finished waiting
[2025-02-14 18:49:33.780] [wazuh-agent] [error] [ERROR] [communicator.cpp:398] [ExecuteRequestLoop] /*/*/*/*/ start waiting
[2025-02-14 18:49:33.781] [wazuh-agent] [error] [ERROR] [http_client.cpp:134] [Co_PerformHttpRequest] /*/*/*/*/ time 40000
^C[2025-02-14 18:49:35.457] [wazuh-agent] [info] [INFO] [inventory.cpp:73] [Stop] Inventory module stopping...
[2025-02-14 18:49:35.457] [wazuh-agent] [info] [INFO] [logcollector.cpp:101] [Stop] Logcollector module stopped.

``` 

server log's:
```console
# ./mock-server --http --log-stateful --log-stateless
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/opt/imposter/lib/log4j-slf4j-impl-2.18.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
18:48:12 INFO  i.g.i.Imposter - Starting mock engine 4.2.1
18:48:14 INFO  i.g.i.Imposter - Mock engine up and running on http://localhost:8080
18:48:23 INFO  i.g.i.p.r.RestPluginImpl - Handling object request for: POST http://localhost/api/v1/authentication
18:48:23 INFO  i.g.i.s.ResponseServiceImpl - Serving response data (316 bytes) for POST http://localhost/api/v1/authentication with status code 200
18:50:13 INFO  i.g.i.p.r.RestPluginImpl - Handling object request for: POST http://localhost/api/v1/authentication
18:50:13 INFO  i.g.i.s.ResponseServiceImpl - Serving response data (316 bytes) for POST http://localhost/api/v1/authentication with status code 200

``` 

* E2E tests:

Agent's log:

Adding the same LogError messages that in the previous tests.
```console
[2025-02-18 19:51:59.329] [wazuh-agent] [info] [INFO] [logcollector.cpp:28] [Start] Logcollector module is disabled.
[2025-02-18 19:51:59.349] [wazuh-agent] [error] [ERROR] [http_client.cpp:155] [Co_PerformHttpRequest] /*/*/*/*/ start
[2025-02-18 19:52:09.394] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:52:09.394] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:52:19.461] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:52:19.461] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:52:29.528] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:52:29.528] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:52:39.595] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:52:39.595] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:52:49.657] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:52:49.657] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:52:59.365] [wazuh-agent] [error] [ERROR] [http_client.cpp:157] [Co_PerformHttpRequest] /*/*/*/*/ finished
[2025-02-18 19:52:59.365] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:163] [Co_PerformHttpRequest] Request /api/v1/commands: Status 408
[2025-02-18 19:52:59.365] [wazuh-agent] [trace] [TRACE] [http_client.cpp:164] [Co_PerformHttpRequest] Request endpoint: /api/v1/commands
Response: HTTP/1.1 408 Request Timeout
date: Tue, 18 Feb 2025 19:51:59 GMT
server: uvicorn
server: Wazuh
content-length: 67
content-type: application/json
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store

{"message":"Request exceeded the processing time limit","code":408}
[2025-02-18 19:52:59.680] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:52:59.680] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:53:00.380] [wazuh-agent] [error] [ERROR] [http_client.cpp:155] [Co_PerformHttpRequest] /*/*/*/*/ start
[2025-02-18 19:53:09.747] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:53:09.747] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:53:19.815] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:53:19.815] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:53:29.881] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:53:29.881] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:53:39.949] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:53:39.949] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:53:50.017] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:53:50.017] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:54:00.086] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:54:00.086] [wazuh-agent] [debug] [DEBUG] [multitype_queue.cpp:209] [getNextBytesAwaitable] Timeout reached after 10000ms
[2025-02-18 19:54:00.388] [wazuh-agent] [error] [ERROR] [http_client.cpp:157] [Co_PerformHttpRequest] /*/*/*/*/ finished
[2025-02-18 19:54:00.388] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:163] [Co_PerformHttpRequest] Request /api/v1/commands: Status 408
[2025-02-18 19:54:00.389] [wazuh-agent] [trace] [TRACE] [http_client.cpp:164] [Co_PerformHttpRequest] Request endpoint: /api/v1/commands
Response: HTTP/1.1 408 Request Timeout
date: Tue, 18 Feb 2025 19:52:59 GMT
server: uvicorn
server: Wazuh
content-length: 67
content-type: application/json
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store

{"message":"Request exceeded the processing time limit","code":408}
[2025-02-18 19:54:01.462] [wazuh-agent] [error] [ERROR] [http_client.cpp:155] [Co_PerformHttpRequest] /*/*/*/*/ start

``` 

server log's:
Modifying the server's scripts for delaying more than the default 30s
```console
Feb 18 19:52:59 rhel-server env[7451]: 2025/02/18 19:52:59 DEBUG: [Communications API] Request headers: {'host': '192.168.100.100', 'user-agent': 'WazuhXDR/5.0.0 (Endpoint; x86_64; Linux)', 'accept': 'application/json', 'authorization': 'Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIENvbW11bmljYXRpb25zIEFQSSIsImlhdCI6MTczOTkwODMxOSwiZXhwIjoxNzM5OTA5MjE5LCJ1dWlkIjoiMTk4OGViYWUtZjg1Yy00Zjc1LWJiNDgtYzFiNjc4OGZhMTM3In0.6qJxiI9wqymEKEQY8lpmyHfryxED81G5DG3ACcCDQFD6Stkj2fd-6LvPxTq58aA09nbg9RslQcqwau8O_Zxp3Q'}
Feb 18 19:52:59 rhel-server env[7451]: 2025/02/18 19:52:59 INFO: [Communications API] (1988ebae-f85c-4f75-bb48-c1b6788fa137) "GET /api/v1/commands" with parameters {} and body {} done in 60.004s: 408
Feb 18 19:53:03 rhel-server env[6996]: 2025/02/18 19:53:03 INFO: [Master] [Local integrity] Starting.
Feb 18 19:53:03 rhel-server env[6996]: 2025/02/18 19:53:03 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 0 files.
Feb 18 19:53:06 rhel-server env[6996]: 2025/02/18 19:53:06 INFO: [Cluster] [Main] Getting orders from indexer
Feb 18 19:53:11 rhel-server env[6996]: 2025/02/18 19:53:11 INFO: [Master] [Local integrity] Starting.
Feb 18 19:53:11 rhel-server env[6996]: 2025/02/18 19:53:11 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 0 files.
Feb 18 19:53:16 rhel-server env[6996]: 2025/02/18 19:53:16 INFO: [Cluster] [Main] Getting orders from indexer
Feb 18 19:53:19 rhel-server env[6996]: 2025/02/18 19:53:19 INFO: [Master] [Local integrity] Starting.
Feb 18 19:53:19 rhel-server env[6996]: 2025/02/18 19:53:19 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 0 files.
Feb 18 19:53:26 rhel-server env[6996]: 2025/02/18 19:53:26 INFO: [Cluster] [Main] Getting orders from indexer
Feb 18 19:53:27 rhel-server env[6996]: 2025/02/18 19:53:27 INFO: [Master] [Local integrity] Starting.
Feb 18 19:53:27 rhel-server env[6996]: 2025/02/18 19:53:27 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
Feb 18 19:53:35 rhel-server env[6996]: 2025/02/18 19:53:35 INFO: [Master] [Local integrity] Starting.
Feb 18 19:53:35 rhel-server env[6996]: 2025/02/18 19:53:35 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 0 files.
Feb 18 19:53:36 rhel-server env[6996]: 2025/02/18 19:53:36 INFO: [Cluster] [Main] Getting orders from indexer
Feb 18 19:53:43 rhel-server env[6996]: 2025/02/18 19:53:43 INFO: [Master] [Local integrity] Starting.
Feb 18 19:53:43 rhel-server env[6996]: 2025/02/18 19:53:43 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 0 files.
Feb 18 19:53:46 rhel-server env[6996]: 2025/02/18 19:53:46 INFO: [Cluster] [Main] Getting orders from indexer
Feb 18 19:53:51 rhel-server env[6996]: 2025/02/18 19:53:51 INFO: [Master] [Local integrity] Starting.
Feb 18 19:53:51 rhel-server env[6996]: 2025/02/18 19:53:51 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
Feb 18 19:53:56 rhel-server env[6996]: 2025/02/18 19:53:56 INFO: [Cluster] [Main] Getting orders from indexer
Feb 18 19:53:59 rhel-server env[6996]: 2025/02/18 19:53:59 INFO: [Master] [Local integrity] Starting.
Feb 18 19:53:59 rhel-server env[6996]: 2025/02/18 19:53:59 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
Feb 18 19:54:00 rhel-server env[7451]: 2025/02/18 19:54:00 ERROR: [Communications API] Timeout executing API request
Feb 18 19:54:00 rhel-server env[7451]: 2025/02/18 19:54:00 DEBUG: [Communications API] Request headers: {'host': '192.168.100.100', 'user-agent': 'WazuhXDR/5.0.0 (Endpoint; x86_64; Linux)', 'accept': 'application/json', 'authorization': 'Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIENvbW11bmljYXRpb25zIEFQSSIsImlhdCI6MTczOTkwODMxOSwiZXhwIjoxNzM5OTA5MjE5LCJ1dWlkIjoiMTk4OGViYWUtZjg1Yy00Zjc1LWJiNDgtYzFiNjc4OGZhMTM3In0.6qJxiI9wqymEKEQY8lpmyHfryxED81G5DG3ACcCDQFD6Stkj2fd-6LvPxTq58aA09nbg9RslQcqwau8O_Zxp3Q'}
Feb 18 19:54:00 rhel-server env[7451]: 2025/02/18 19:54:00 INFO: [Communications API] (1988ebae-f85c-4f75-bb48-c1b6788fa137) "GET /api/v1/commands" with parameters {} and body {} done in 59.998s: 408
Feb 18 19:54:06 rhel-server env[6996]: 2025/02/18 19:54:06 INFO: [Cluster] [Main] Getting orders from indexer
``` 

* In the E2E we were able to check that the timeout on the agent's side has less priority than the server's. This impact greatly on the way of testing this, and makes it hard to check. So if the timeout of the agent is lower than the manager's then if the connection persist and the agent's timeout gets consumed the process continues. This may be related to setting the timeout to a socket.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
