### PR TITLE
Improve Agent, AgentInfo and AgentRegistration tests

### DIFF
--- a/src/agent/agent_info/CMakeLists.txt
+++ b/src/agent/agent_info/CMakeLists.txt
@@ -8,7 +8,7 @@ set_common_settings()
 find_package(Boost REQUIRED COMPONENTS uuid)
 find_package(nlohmann_json CONFIG REQUIRED)
 
-add_library(AgentInfo src/agent_info.cpp src/agent_info_persistance.cpp)
+add_library(AgentInfo src/agent_info.cpp src/agent_info_persistence.cpp)
 target_include_directories(AgentInfo PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-class AgentInfoPersistance;
+class AgentInfoPersistence;
 
 /// @brief Stores and manages information about an agent.
 ///
@@ -27,12 +27,12 @@ public:
     /// @param getOSInfo Function to retrieve OS information in JSON format.
     /// @param getNetworksInfo Function to retrieve network information in JSON format.
     /// @param agentIsEnrolling True if the agent is enrolling, false otherwise.
-    /// @param persistence Optional pointer to an AgentInfoPersistance object.
+    /// @param persistence Optional pointer to an AgentInfoPersistence object.
     AgentInfo(const std::string& dbFolderPath,
               std::function<nlohmann::json()> getOSInfo = nullptr,
               std::function<nlohmann::json()> getNetworksInfo = nullptr,
               bool agentIsEnrolling = false,
-              std::shared_ptr<AgentInfoPersistance> persistence = nullptr);
+              std::shared_ptr<AgentInfoPersistence> persistence = nullptr);
 
     /// @brief Gets the agent's name.
     /// @return The agent's name.
@@ -144,5 +144,5 @@ private:
     bool m_agentIsEnrolling;
 
     /// @brief Pointer to the agent info persistence instance.
-    std::shared_ptr<AgentInfoPersistance> m_persistence;
+    std::shared_ptr<AgentInfoPersistence> m_persistence;
 };

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iagent_info.hpp>
 #include <iagent_info_persistence.hpp>
 
 #include <nlohmann/json.hpp>
@@ -9,14 +10,12 @@
 #include <string>
 #include <vector>
 
-class AgentInfoPersistence;
-
 /// @brief Stores and manages information about an agent.
 ///
 /// This class provides methods for getting and setting the agent's name, key,
 /// UUID, and groups. It also includes private methods for creating and
 /// validating the key.
-class AgentInfo
+class AgentInfo : public IAgentInfo
 {
 public:
     /// @brief Constructs an AgentInfo object with OS and network information retrieval functions.
@@ -38,60 +37,60 @@ public:
 
     /// @brief Gets the agent's name.
     /// @return The agent's name.
-    std::string GetName() const;
+    std::string GetName() const override;
 
     /// @brief Gets the agent's key.
     /// @return The agent's key.
-    std::string GetKey() const;
+    std::string GetKey() const override;
 
     /// @brief Gets the agent's UUID.
     /// @return The agent's UUID.
-    std::string GetUUID() const;
+    std::string GetUUID() const override;
 
     /// @brief Gets the agent's groups.
     /// @return A vector of the agent's groups.
-    std::vector<std::string> GetGroups() const;
+    std::vector<std::string> GetGroups() const override;
 
     /// @brief Sets the agent's name. The change is not saved to the database until `Save` is called.
     /// @param name The agent's new name.
     /// @return True if the name was successfully set, false otherwise.
-    bool SetName(const std::string& name);
+    bool SetName(const std::string& name) override;
 
     /// @brief Sets the agent's key. The change is not saved to the database until `Save` is called.
     /// @param key The agent's new key.
     /// @return True if the key was successfully set, false otherwise.
-    bool SetKey(const std::string& key);
+    bool SetKey(const std::string& key) override;
 
     /// @brief Sets the agent's UUID. The change is not saved to the database until `Save` is called.
     /// @param uuid The agent's new UUID.
-    void SetUUID(const std::string& uuid);
+    void SetUUID(const std::string& uuid) override;
 
     /// @brief Sets the agent's groups. The change is not saved to the database until `Save` is called.
     /// @param groupList A vector of the agent's new groups.
-    void SetGroups(const std::vector<std::string>& groupList);
+    void SetGroups(const std::vector<std::string>& groupList) override;
 
     /// @brief Gets the agent's type.
     /// @return The agent's type.
-    std::string GetType() const;
+    std::string GetType() const override;
 
     /// @brief Gets the agent's version.
     /// @return The agent's version.
-    std::string GetVersion() const;
+    std::string GetVersion() const override;
 
     /// @brief Gets the agent information for the request header.
     /// @return A string with the information for the request header.
-    std::string GetHeaderInfo() const;
+    std::string GetHeaderInfo() const override;
 
     /// @brief Gets all the information about the agent.
     /// @return A string with all information about the agent.
-    std::string GetMetadataInfo() const;
+    std::string GetMetadataInfo() const override;
 
     /// @brief Restores and saves the agent's information to the database.
-    void Save() const;
+    void Save() const override;
 
     /// @brief Saves the agent's group information to the database.
     /// @return True if the operation was successful, false otherwise.
-    bool SaveGroups() const;
+    bool SaveGroups() const override;
 
 private:
     /// @brief Creates a random key for the agent.

--- a/src/agent/agent_info/include/agent_info.hpp
+++ b/src/agent/agent_info/include/agent_info.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <iagent_info_persistence.hpp>
+
 #include <nlohmann/json.hpp>
 
 #include <functional>
@@ -27,12 +29,12 @@ public:
     /// @param getOSInfo Function to retrieve OS information in JSON format.
     /// @param getNetworksInfo Function to retrieve network information in JSON format.
     /// @param agentIsEnrolling True if the agent is enrolling, false otherwise.
-    /// @param persistence Optional pointer to an AgentInfoPersistence object.
+    /// @param persistence Optional pointer to an IAgentInfoPersistence object.
     AgentInfo(const std::string& dbFolderPath,
               std::function<nlohmann::json()> getOSInfo = nullptr,
               std::function<nlohmann::json()> getNetworksInfo = nullptr,
               bool agentIsEnrolling = false,
-              std::shared_ptr<AgentInfoPersistence> persistence = nullptr);
+              std::shared_ptr<IAgentInfoPersistence> persistence = nullptr);
 
     /// @brief Gets the agent's name.
     /// @return The agent's name.
@@ -144,5 +146,5 @@ private:
     bool m_agentIsEnrolling;
 
     /// @brief Pointer to the agent info persistence instance.
-    std::shared_ptr<AgentInfoPersistence> m_persistence;
+    std::shared_ptr<IAgentInfoPersistence> m_persistence;
 };

--- a/src/agent/agent_info/include/iagent_info.hpp
+++ b/src/agent/agent_info/include/iagent_info.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <functional>
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/agent/agent_info/include/iagent_info.hpp
+++ b/src/agent/agent_info/include/iagent_info.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+/// @brief Interface for managing agent information.
+class IAgentInfo
+{
+public:
+    virtual ~IAgentInfo() = default;
+
+    /// @brief Gets the agent's name.
+    /// @return The agent's name.
+    virtual std::string GetName() const = 0;
+
+    /// @brief Gets the agent's key.
+    /// @return The agent's key.
+    virtual std::string GetKey() const = 0;
+
+    /// @brief Gets the agent's UUID.
+    /// @return The agent's UUID.
+    virtual std::string GetUUID() const = 0;
+
+    /// @brief Gets the agent's groups.
+    /// @return A vector of the agent's groups.
+    virtual std::vector<std::string> GetGroups() const = 0;
+
+    /// @brief Sets the agent's name. The change is not saved to the database until `Save` is called.
+    /// @param name The agent's new name.
+    /// @return True if the name was successfully set, false otherwise.
+    virtual bool SetName(const std::string& name) = 0;
+
+    /// @brief Sets the agent's key. The change is not saved to the database until `Save` is called.
+    /// @param key The agent's new key.
+    /// @return True if the key was successfully set, false otherwise.
+    virtual bool SetKey(const std::string& key) = 0;
+
+    /// @brief Sets the agent's UUID. The change is not saved to the database until `Save` is called.
+    /// @param uuid The agent's new UUID.
+    virtual void SetUUID(const std::string& uuid) = 0;
+
+    /// @brief Sets the agent's groups. The change is not saved to the database until `Save` is called.
+    /// @param groupList A vector of the agent's new groups.
+    virtual void SetGroups(const std::vector<std::string>& groupList) = 0;
+
+    /// @brief Gets the agent's type.
+    /// @return The agent's type.
+    virtual std::string GetType() const = 0;
+
+    /// @brief Gets the agent's version.
+    /// @return The agent's version.
+    virtual std::string GetVersion() const = 0;
+
+    /// @brief Gets the agent information for the request header.
+    /// @return A string with the information for the request header.
+    virtual std::string GetHeaderInfo() const = 0;
+
+    /// @brief Gets all the information about the agent.
+    /// @return A string with all information about the agent.
+    virtual std::string GetMetadataInfo() const = 0;
+
+    /// @brief Restores and saves the agent's information to the database.
+    virtual void Save() const = 0;
+
+    /// @brief Saves the agent's group information to the database.
+    /// @return True if the operation was successful, false otherwise.
+    virtual bool SaveGroups() const = 0;
+};

--- a/src/agent/agent_info/include/iagent_info_persistence.hpp
+++ b/src/agent/agent_info/include/iagent_info_persistence.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/agent/agent_info/include/iagent_info_persistence.hpp
+++ b/src/agent/agent_info/include/iagent_info_persistence.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+/// @brief Interface for managing persistence of agent information and groups in a database.
+class IAgentInfoPersistence
+{
+public:
+    virtual ~IAgentInfoPersistence() = default;
+
+    /// @brief Retrieves the agent's name from the database.
+    /// @return The name of the agent as a string.
+    virtual std::string GetName() const = 0;
+
+    /// @brief Retrieves the agent's key from the database.
+    /// @return The key of the agent as a string.
+    virtual std::string GetKey() const = 0;
+
+    /// @brief Retrieves the agent's UUID from the database.
+    /// @return The UUID of the agent as a string.
+    virtual std::string GetUUID() const = 0;
+
+    /// @brief Retrieves the list of agent groups from the database.
+    /// @return A vector of strings, each representing a group name.
+    virtual std::vector<std::string> GetGroups() const = 0;
+
+    /// @brief Sets the agent's name in the database.
+    /// @param name The name to set.
+    /// @return True if the operation was successful, false otherwise.
+    virtual bool SetName(const std::string& name) = 0;
+
+    /// @brief Sets the agent's key in the database.
+    /// @param key The key to set.
+    /// @return True if the operation was successful, false otherwise.
+    virtual bool SetKey(const std::string& key) = 0;
+
+    /// @brief Sets the agent's UUID in the database.
+    /// @param uuid The UUID to set.
+    /// @return True if the operation was successful, false otherwise.
+    virtual bool SetUUID(const std::string& uuid) = 0;
+
+    /// @brief Sets the agent's group list in the database, replacing any existing groups.
+    /// @param groupList A vector of strings, each representing a group name.
+    /// @return True if the operation was successful, false otherwise.
+    virtual bool SetGroups(const std::vector<std::string>& groupList) = 0;
+
+    /// @brief Resets the database tables to default values, clearing all data.
+    /// @return True if the reset was successful, false otherwise.
+    virtual bool ResetToDefault() = 0;
+};

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -21,7 +21,7 @@ AgentInfo::AgentInfo(const std::string& dbFolderPath,
                      std::function<nlohmann::json()> getOSInfo,
                      std::function<nlohmann::json()> getNetworksInfo,
                      bool agentIsEnrolling,
-                     std::shared_ptr<AgentInfoPersistence> persistence)
+                     std::shared_ptr<IAgentInfoPersistence> persistence)
     : m_agentIsEnrolling(agentIsEnrolling)
     , m_persistence(persistence ? std::move(persistence) : std::make_shared<AgentInfoPersistence>(dbFolderPath))
 {

--- a/src/agent/agent_info/src/agent_info.cpp
+++ b/src/agent/agent_info/src/agent_info.cpp
@@ -1,6 +1,6 @@
 #include <agent_info.hpp>
 
-#include <agent_info_persistance.hpp>
+#include <agent_info_persistence.hpp>
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -21,9 +21,9 @@ AgentInfo::AgentInfo(const std::string& dbFolderPath,
                      std::function<nlohmann::json()> getOSInfo,
                      std::function<nlohmann::json()> getNetworksInfo,
                      bool agentIsEnrolling,
-                     std::shared_ptr<AgentInfoPersistance> persistence)
+                     std::shared_ptr<AgentInfoPersistence> persistence)
     : m_agentIsEnrolling(agentIsEnrolling)
-    , m_persistence(persistence ? std::move(persistence) : std::make_shared<AgentInfoPersistance>(dbFolderPath))
+    , m_persistence(persistence ? std::move(persistence) : std::make_shared<AgentInfoPersistence>(dbFolderPath))
 {
     if (!m_agentIsEnrolling)
     {

--- a/src/agent/agent_info/src/agent_info_persistence.cpp
+++ b/src/agent/agent_info/src/agent_info_persistence.cpp
@@ -3,6 +3,7 @@
 #include <logger.hpp>
 
 #include <column.hpp>
+#include <persistence.hpp>
 #include <persistence_factory.hpp>
 
 using namespace column;

--- a/src/agent/agent_info/src/agent_info_persistence.cpp
+++ b/src/agent/agent_info/src/agent_info_persistence.cpp
@@ -1,4 +1,4 @@
-#include <agent_info_persistance.hpp>
+#include <agent_info_persistence.hpp>
 
 #include <logger.hpp>
 
@@ -24,7 +24,7 @@ namespace
     const std::string AGENT_GROUP_NAME_COLUMN_NAME = "name";
 } // namespace
 
-AgentInfoPersistance::AgentInfoPersistance(const std::string& dbFolderPath, std::unique_ptr<Persistence> persistence)
+AgentInfoPersistence::AgentInfoPersistence(const std::string& dbFolderPath, std::unique_ptr<Persistence> persistence)
 {
     const auto dbFilePath = dbFolderPath + "/" + AGENT_INFO_DB_NAME;
 
@@ -60,9 +60,9 @@ AgentInfoPersistance::AgentInfoPersistance(const std::string& dbFolderPath, std:
     }
 }
 
-AgentInfoPersistance::~AgentInfoPersistance() = default;
+AgentInfoPersistence::~AgentInfoPersistence() = default;
 
-bool AgentInfoPersistance::AgentInfoIsEmpty() const
+bool AgentInfoPersistence::AgentInfoIsEmpty() const
 {
     try
     {
@@ -76,7 +76,7 @@ bool AgentInfoPersistance::AgentInfoIsEmpty() const
     return false;
 }
 
-void AgentInfoPersistance::CreateAgentInfoTable()
+void AgentInfoPersistence::CreateAgentInfoTable()
 {
     try
     {
@@ -93,7 +93,7 @@ void AgentInfoPersistance::CreateAgentInfoTable()
     }
 }
 
-void AgentInfoPersistance::CreateAgentGroupTable()
+void AgentInfoPersistence::CreateAgentGroupTable()
 {
     try
     {
@@ -110,7 +110,7 @@ void AgentInfoPersistance::CreateAgentGroupTable()
     }
 }
 
-void AgentInfoPersistance::InsertDefaultAgentInfo()
+void AgentInfoPersistence::InsertDefaultAgentInfo()
 {
     try
     {
@@ -132,7 +132,7 @@ void AgentInfoPersistance::InsertDefaultAgentInfo()
     }
 }
 
-bool AgentInfoPersistance::SetAgentInfoValue(const std::string& column, const std::string& value)
+bool AgentInfoPersistence::SetAgentInfoValue(const std::string& column, const std::string& value)
 {
     try
     {
@@ -148,7 +148,7 @@ bool AgentInfoPersistance::SetAgentInfoValue(const std::string& column, const st
     return false;
 }
 
-std::string AgentInfoPersistance::GetAgentInfoValue(const std::string& column) const
+std::string AgentInfoPersistence::GetAgentInfoValue(const std::string& column) const
 {
     std::string value;
 
@@ -170,22 +170,22 @@ std::string AgentInfoPersistance::GetAgentInfoValue(const std::string& column) c
     return value;
 }
 
-std::string AgentInfoPersistance::GetName() const
+std::string AgentInfoPersistence::GetName() const
 {
     return GetAgentInfoValue(AGENT_INFO_NAME_COLUMN_NAME);
 }
 
-std::string AgentInfoPersistance::GetKey() const
+std::string AgentInfoPersistence::GetKey() const
 {
     return GetAgentInfoValue(AGENT_INFO_KEY_COLUMN_NAME);
 }
 
-std::string AgentInfoPersistance::GetUUID() const
+std::string AgentInfoPersistence::GetUUID() const
 {
     return GetAgentInfoValue(AGENT_INFO_UUID_COLUMN_NAME);
 }
 
-std::vector<std::string> AgentInfoPersistance::GetGroups() const
+std::vector<std::string> AgentInfoPersistence::GetGroups() const
 {
     std::vector<std::string> groupList;
 
@@ -210,22 +210,22 @@ std::vector<std::string> AgentInfoPersistance::GetGroups() const
     return groupList;
 }
 
-bool AgentInfoPersistance::SetName(const std::string& name)
+bool AgentInfoPersistence::SetName(const std::string& name)
 {
     return SetAgentInfoValue(AGENT_INFO_NAME_COLUMN_NAME, name);
 }
 
-bool AgentInfoPersistance::SetKey(const std::string& key)
+bool AgentInfoPersistence::SetKey(const std::string& key)
 {
     return SetAgentInfoValue(AGENT_INFO_KEY_COLUMN_NAME, key);
 }
 
-bool AgentInfoPersistance::SetUUID(const std::string& uuid)
+bool AgentInfoPersistence::SetUUID(const std::string& uuid)
 {
     return SetAgentInfoValue(AGENT_INFO_UUID_COLUMN_NAME, uuid);
 }
 
-bool AgentInfoPersistance::SetGroups(const std::vector<std::string>& groupList)
+bool AgentInfoPersistence::SetGroups(const std::vector<std::string>& groupList)
 {
     TransactionId transaction = 0;
 
@@ -270,7 +270,7 @@ bool AgentInfoPersistance::SetGroups(const std::vector<std::string>& groupList)
     return true;
 }
 
-bool AgentInfoPersistance::ResetToDefault()
+bool AgentInfoPersistence::ResetToDefault()
 {
     try
     {

--- a/src/agent/agent_info/src/agent_info_persistence.hpp
+++ b/src/agent/agent_info/src/agent_info_persistence.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iagent_info_persistence.hpp>
 #include <persistence.hpp>
 
 #include <memory>
@@ -7,7 +8,7 @@
 #include <vector>
 
 /// @brief Manages persistence of agent information and groups in a database.
-class AgentInfoPersistence
+class AgentInfoPersistence : public IAgentInfoPersistence
 {
 public:
     /// @brief Constructs the persistence manager for agent info, initializing the database and tables if necessary.
@@ -32,43 +33,43 @@ public:
 
     /// @brief Retrieves the agent's name from the database.
     /// @return The name of the agent as a string.
-    std::string GetName() const;
+    std::string GetName() const override;
 
     /// @brief Retrieves the agent's key from the database.
     /// @return The key of the agent as a string.
-    std::string GetKey() const;
+    std::string GetKey() const override;
 
     /// @brief Retrieves the agent's UUID from the database.
     /// @return The UUID of the agent as a string.
-    std::string GetUUID() const;
+    std::string GetUUID() const override;
 
     /// @brief Retrieves the list of agent groups from the database.
     /// @return A vector of strings, each representing a group name.
-    std::vector<std::string> GetGroups() const;
+    std::vector<std::string> GetGroups() const override;
 
     /// @brief Sets the agent's name in the database.
     /// @param name The name to set.
     /// @return True if the operation was successful, false otherwise.
-    bool SetName(const std::string& name);
+    bool SetName(const std::string& name) override;
 
     /// @brief Sets the agent's key in the database.
     /// @param key The key to set.
     /// @return True if the operation was successful, false otherwise.
-    bool SetKey(const std::string& key);
+    bool SetKey(const std::string& key) override;
 
     /// @brief Sets the agent's UUID in the database.
     /// @param uuid The UUID to set.
     /// @return True if the operation was successful, false otherwise.
-    bool SetUUID(const std::string& uuid);
+    bool SetUUID(const std::string& uuid) override;
 
     /// @brief Sets the agent's group list in the database, replacing any existing groups.
     /// @param groupList A vector of strings, each representing a group name.
     /// @return True if the operation was successful, false otherwise.
-    bool SetGroups(const std::vector<std::string>& groupList);
+    bool SetGroups(const std::vector<std::string>& groupList) override;
 
     /// @brief Resets the database tables to default values, clearing all data.
     /// @return True if the reset was successful, false otherwise.
-    bool ResetToDefault();
+    bool ResetToDefault() override;
 
 private:
     /// @brief Checks if the agent info table is empty.

--- a/src/agent/agent_info/src/agent_info_persistence.hpp
+++ b/src/agent/agent_info/src/agent_info_persistence.hpp
@@ -7,28 +7,28 @@
 #include <vector>
 
 /// @brief Manages persistence of agent information and groups in a database.
-class AgentInfoPersistance
+class AgentInfoPersistence
 {
 public:
     /// @brief Constructs the persistence manager for agent info, initializing the database and tables if necessary.
     /// @param dbFolderPath Path to the database folder.
     /// @param persistence Optional pointer to an existing persistence object.
-    explicit AgentInfoPersistance(const std::string& dbFolderPath, std::unique_ptr<Persistence> persistence = nullptr);
+    explicit AgentInfoPersistence(const std::string& dbFolderPath, std::unique_ptr<Persistence> persistence = nullptr);
 
-    /// @brief Destructor for AgentInfoPersistance.
-    ~AgentInfoPersistance();
+    /// @brief Destructor for AgentInfoPersistence.
+    ~AgentInfoPersistence();
 
     /// @brief Deleted copy constructor.
-    AgentInfoPersistance(const AgentInfoPersistance&) = delete;
+    AgentInfoPersistence(const AgentInfoPersistence&) = delete;
 
     /// @brief Deleted copy assignment operator.
-    AgentInfoPersistance& operator=(const AgentInfoPersistance&) = delete;
+    AgentInfoPersistence& operator=(const AgentInfoPersistence&) = delete;
 
     /// @brief Deleted move constructor.
-    AgentInfoPersistance(AgentInfoPersistance&&) = delete;
+    AgentInfoPersistence(AgentInfoPersistence&&) = delete;
 
     /// @brief Deleted move assignment operator.
-    AgentInfoPersistance& operator=(AgentInfoPersistance&&) = delete;
+    AgentInfoPersistence& operator=(AgentInfoPersistence&&) = delete;
 
     /// @brief Retrieves the agent's name from the database.
     /// @return The name of the agent as a string.

--- a/src/agent/agent_info/tests/CMakeLists.txt
+++ b/src/agent/agent_info/tests/CMakeLists.txt
@@ -8,10 +8,10 @@ target_include_directories(agent_info_test PRIVATE
 target_link_libraries(agent_info_test PRIVATE AgentInfo Persistence GTest::gtest GTest::gmock GTest::gmock_main)
 add_test(NAME AgentInfoTest COMMAND agent_info_test)
 
-add_executable(agent_info_persistance_test agent_info_persistance_test.cpp)
-configure_target(agent_info_persistance_test)
-target_include_directories(agent_info_persistance_test PRIVATE
+add_executable(agent_info_persistence_test agent_info_persistence_test.cpp)
+configure_target(agent_info_persistence_test)
+target_include_directories(agent_info_persistence_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
     ${CMAKE_CURRENT_SOURCE_DIR}/../../persistence/tests/mocks)
-target_link_libraries(agent_info_persistance_test PRIVATE AgentInfo Persistence GTest::gtest GTest::gmock)
-add_test(NAME AgentInfoPersistanceTest COMMAND agent_info_persistance_test)
+target_link_libraries(agent_info_persistence_test PRIVATE AgentInfo Persistence GTest::gtest GTest::gmock)
+add_test(NAME AgentInfoPersistenceTest COMMAND agent_info_persistence_test)

--- a/src/agent/agent_info/tests/CMakeLists.txt
+++ b/src/agent/agent_info/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(agent_info_test agent_info_test.cpp)
 configure_target(agent_info_test)
 target_include_directories(agent_info_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/mocks
     ${CMAKE_CURRENT_SOURCE_DIR}/../../persistence/tests/mocks)
 target_link_libraries(agent_info_test PRIVATE AgentInfo Persistence GTest::gtest GTest::gmock GTest::gmock_main)
 add_test(NAME AgentInfoTest COMMAND agent_info_test)

--- a/src/agent/agent_info/tests/agent_info_persistence_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_persistence_test.cpp
@@ -1,17 +1,17 @@
 #include <gtest/gtest.h>
 
-#include <agent_info_persistance.hpp>
+#include <agent_info_persistence.hpp>
 #include <mocks_persistence.hpp>
 
 #include <memory>
 #include <string>
 #include <vector>
 
-class AgentInfoPersistanceTest : public ::testing::Test
+class AgentInfoPersistenceTest : public ::testing::Test
 {
 protected:
     MockPersistence* mockPersistence = nullptr;
-    std::unique_ptr<AgentInfoPersistance> agentInfoPersistance;
+    std::unique_ptr<AgentInfoPersistence> agentInfoPersistence;
 
     void SetUp() override
     {
@@ -25,94 +25,94 @@ protected:
             .WillOnce(testing::Return(0));
         EXPECT_CALL(*mockPersistence, Insert("agent_info", testing::_)).Times(1);
 
-        agentInfoPersistance = std::make_unique<AgentInfoPersistance>("db_path", std::move(mockPersistencePtr));
+        agentInfoPersistence = std::make_unique<AgentInfoPersistence>("db_path", std::move(mockPersistencePtr));
     }
 };
 
-TEST_F(AgentInfoPersistanceTest, TestConstruction)
+TEST_F(AgentInfoPersistenceTest, TestConstruction)
 {
-    EXPECT_NE(agentInfoPersistance, nullptr);
+    EXPECT_NE(agentInfoPersistence, nullptr);
 }
 
-TEST_F(AgentInfoPersistanceTest, TestGetNameValue)
+TEST_F(AgentInfoPersistenceTest, TestGetNameValue)
 {
     const std::vector<column::Row> mockRowName = {{column::ColumnValue("name", column::ColumnType::TEXT, "name_test")}};
     EXPECT_CALL(*mockPersistence,
                 Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Return(mockRowName));
-    EXPECT_EQ(agentInfoPersistance->GetName(), "name_test");
+    EXPECT_EQ(agentInfoPersistence->GetName(), "name_test");
 }
 
-TEST_F(AgentInfoPersistanceTest, TestGetNameNotValue)
+TEST_F(AgentInfoPersistenceTest, TestGetNameNotValue)
 {
     const std::vector<column::Row> mockRowName = {};
     EXPECT_CALL(*mockPersistence,
                 Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Return(mockRowName));
-    EXPECT_EQ(agentInfoPersistance->GetName(), "");
+    EXPECT_EQ(agentInfoPersistence->GetName(), "");
 }
 
-TEST_F(AgentInfoPersistanceTest, TestGetNameCatch)
+TEST_F(AgentInfoPersistenceTest, TestGetNameCatch)
 {
     EXPECT_CALL(*mockPersistence,
                 Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Throw(std::runtime_error("Error Select")));
-    EXPECT_EQ(agentInfoPersistance->GetName(), "");
+    EXPECT_EQ(agentInfoPersistence->GetName(), "");
 }
 
-TEST_F(AgentInfoPersistanceTest, TestGetKeyValue)
+TEST_F(AgentInfoPersistenceTest, TestGetKeyValue)
 {
     const std::vector<column::Row> mockRowKey = {{column::ColumnValue("key", column::ColumnType::TEXT, "key_test")}};
     EXPECT_CALL(*mockPersistence,
                 Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Return(mockRowKey));
-    EXPECT_EQ(agentInfoPersistance->GetKey(), "key_test");
+    EXPECT_EQ(agentInfoPersistence->GetKey(), "key_test");
 }
 
-TEST_F(AgentInfoPersistanceTest, TestGetKeyNotValue)
+TEST_F(AgentInfoPersistenceTest, TestGetKeyNotValue)
 {
     const std::vector<column::Row> mockRowKey = {};
     EXPECT_CALL(*mockPersistence,
                 Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Return(mockRowKey));
-    EXPECT_EQ(agentInfoPersistance->GetKey(), "");
+    EXPECT_EQ(agentInfoPersistence->GetKey(), "");
 }
 
-TEST_F(AgentInfoPersistanceTest, TestGetKeyCatch)
+TEST_F(AgentInfoPersistenceTest, TestGetKeyCatch)
 {
     EXPECT_CALL(*mockPersistence,
                 Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Throw(std::runtime_error("Error Select")));
-    EXPECT_EQ(agentInfoPersistance->GetKey(), "");
+    EXPECT_EQ(agentInfoPersistence->GetKey(), "");
 }
 
-TEST_F(AgentInfoPersistanceTest, TestGetUUIDValue)
+TEST_F(AgentInfoPersistenceTest, TestGetUUIDValue)
 {
     const std::vector<column::Row> mockRowUUID = {{column::ColumnValue("uuid", column::ColumnType::TEXT, "uuid_test")}};
     EXPECT_CALL(*mockPersistence,
                 Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Return(mockRowUUID));
-    EXPECT_EQ(agentInfoPersistance->GetUUID(), "uuid_test");
+    EXPECT_EQ(agentInfoPersistence->GetUUID(), "uuid_test");
 }
 
-TEST_F(AgentInfoPersistanceTest, TestGetUUIDNotValue)
+TEST_F(AgentInfoPersistenceTest, TestGetUUIDNotValue)
 {
     const std::vector<column::Row> mockRowUUID = {};
     EXPECT_CALL(*mockPersistence,
                 Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Return(mockRowUUID));
-    EXPECT_EQ(agentInfoPersistance->GetUUID(), "");
+    EXPECT_EQ(agentInfoPersistence->GetUUID(), "");
 }
 
-TEST_F(AgentInfoPersistanceTest, TestGetUUIDCatch)
+TEST_F(AgentInfoPersistenceTest, TestGetUUIDCatch)
 {
     EXPECT_CALL(*mockPersistence,
                 Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Throw(std::runtime_error("Error Select")));
-    EXPECT_EQ(agentInfoPersistance->GetUUID(), "");
+    EXPECT_EQ(agentInfoPersistence->GetUUID(), "");
 }
 
-TEST_F(AgentInfoPersistanceTest, TestGetGroupsValue)
+TEST_F(AgentInfoPersistenceTest, TestGetGroupsValue)
 {
     const std::vector<column::Row> mockRowGroups = {{column::ColumnValue("name", column::ColumnType::TEXT, "group_1")},
                                                     {column::ColumnValue("name", column::ColumnType::TEXT, "group_2")}};
@@ -121,10 +121,10 @@ TEST_F(AgentInfoPersistanceTest, TestGetGroupsValue)
         .WillOnce(testing::Return(mockRowGroups));
 
     const std::vector<std::string> expectedGroups = {"group_1", "group_2"};
-    EXPECT_EQ(agentInfoPersistance->GetGroups(), expectedGroups);
+    EXPECT_EQ(agentInfoPersistence->GetGroups(), expectedGroups);
 }
 
-TEST_F(AgentInfoPersistanceTest, TestGetGroupsNotValue)
+TEST_F(AgentInfoPersistenceTest, TestGetGroupsNotValue)
 {
     const std::vector<column::Row> mockRowGroups = {};
     EXPECT_CALL(*mockPersistence,
@@ -132,20 +132,20 @@ TEST_F(AgentInfoPersistanceTest, TestGetGroupsNotValue)
         .WillOnce(testing::Return(mockRowGroups));
 
     const std::vector<std::string> expectedGroups = {};
-    EXPECT_EQ(agentInfoPersistance->GetGroups(), expectedGroups);
+    EXPECT_EQ(agentInfoPersistence->GetGroups(), expectedGroups);
 }
 
-TEST_F(AgentInfoPersistanceTest, TestGetGroupsCatch)
+TEST_F(AgentInfoPersistenceTest, TestGetGroupsCatch)
 {
     EXPECT_CALL(*mockPersistence,
                 Select("agent_group", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Throw(std::runtime_error("Error Select")));
 
     const std::vector<std::string> expectedGroups = {};
-    EXPECT_EQ(agentInfoPersistance->GetGroups(), expectedGroups);
+    EXPECT_EQ(agentInfoPersistence->GetGroups(), expectedGroups);
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetName)
+TEST_F(AgentInfoPersistenceTest, TestSetName)
 {
     const std::string expectedColumn = "name";
     const std::string newName = "new_name";
@@ -159,10 +159,10 @@ TEST_F(AgentInfoPersistanceTest, TestSetName)
                        testing::_,
                        testing::_))
         .Times(1);
-    EXPECT_TRUE(agentInfoPersistance->SetName(newName));
+    EXPECT_TRUE(agentInfoPersistence->SetName(newName));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetNameCatch)
+TEST_F(AgentInfoPersistenceTest, TestSetNameCatch)
 {
     const std::string expectedColumn = "name";
     const std::string newName = "new_name";
@@ -176,10 +176,10 @@ TEST_F(AgentInfoPersistanceTest, TestSetNameCatch)
                        testing::_,
                        testing::_))
         .WillOnce(testing::Throw(std::runtime_error("Error Update")));
-    EXPECT_FALSE(agentInfoPersistance->SetName(newName));
+    EXPECT_FALSE(agentInfoPersistence->SetName(newName));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetKey)
+TEST_F(AgentInfoPersistenceTest, TestSetKey)
 {
     const std::string expectedColumn = "key";
     const std::string newKey = "new_key";
@@ -193,10 +193,10 @@ TEST_F(AgentInfoPersistanceTest, TestSetKey)
                        testing::_,
                        testing::_))
         .Times(1);
-    EXPECT_TRUE(agentInfoPersistance->SetKey(newKey));
+    EXPECT_TRUE(agentInfoPersistence->SetKey(newKey));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetKeyCatch)
+TEST_F(AgentInfoPersistenceTest, TestSetKeyCatch)
 {
     const std::string expectedColumn = "key";
     const std::string newKey = "new_key";
@@ -210,10 +210,10 @@ TEST_F(AgentInfoPersistanceTest, TestSetKeyCatch)
                        testing::_,
                        testing::_))
         .WillOnce(testing::Throw(std::runtime_error("Error Update")));
-    EXPECT_FALSE(agentInfoPersistance->SetKey(newKey));
+    EXPECT_FALSE(agentInfoPersistence->SetKey(newKey));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetUUID)
+TEST_F(AgentInfoPersistenceTest, TestSetUUID)
 {
     const std::string expectedColumn = "uuid";
     const std::string newUUID = "new_uuid";
@@ -227,10 +227,10 @@ TEST_F(AgentInfoPersistanceTest, TestSetUUID)
                        testing::_,
                        testing::_))
         .Times(1);
-    EXPECT_TRUE(agentInfoPersistance->SetUUID(newUUID));
+    EXPECT_TRUE(agentInfoPersistence->SetUUID(newUUID));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetUUIDCatch)
+TEST_F(AgentInfoPersistenceTest, TestSetUUIDCatch)
 {
     const std::string expectedColumn = "uuid";
     const std::string newUUID = "new_uuid";
@@ -244,10 +244,10 @@ TEST_F(AgentInfoPersistanceTest, TestSetUUIDCatch)
                        testing::_,
                        testing::_))
         .WillOnce(testing::Throw(std::runtime_error("Error Update")));
-    EXPECT_FALSE(agentInfoPersistance->SetUUID(newUUID));
+    EXPECT_FALSE(agentInfoPersistence->SetUUID(newUUID));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetGroupsSuccess)
+TEST_F(AgentInfoPersistenceTest, TestSetGroupsSuccess)
 {
     const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
 
@@ -256,20 +256,20 @@ TEST_F(AgentInfoPersistanceTest, TestSetGroupsSuccess)
     EXPECT_CALL(*mockPersistence, Insert("agent_group", testing::_)).Times(2);
     EXPECT_CALL(*mockPersistence, CommitTransaction(testing::_)).Times(1);
 
-    EXPECT_TRUE(agentInfoPersistance->SetGroups(newGroups));
+    EXPECT_TRUE(agentInfoPersistence->SetGroups(newGroups));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetGroupsBeginTransactionFails)
+TEST_F(AgentInfoPersistenceTest, TestSetGroupsBeginTransactionFails)
 {
     const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
 
     EXPECT_CALL(*mockPersistence, BeginTransaction())
         .WillOnce(testing::Throw(std::runtime_error("Error BeginTransaction")));
 
-    EXPECT_FALSE(agentInfoPersistance->SetGroups(newGroups));
+    EXPECT_FALSE(agentInfoPersistence->SetGroups(newGroups));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetGroupsRemoveFails)
+TEST_F(AgentInfoPersistenceTest, TestSetGroupsRemoveFails)
 {
     const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
 
@@ -278,10 +278,10 @@ TEST_F(AgentInfoPersistanceTest, TestSetGroupsRemoveFails)
         .WillOnce(testing::Throw(std::runtime_error("Error Remove")));
     EXPECT_CALL(*mockPersistence, RollbackTransaction(testing::_)).Times(1);
 
-    EXPECT_FALSE(agentInfoPersistance->SetGroups(newGroups));
+    EXPECT_FALSE(agentInfoPersistence->SetGroups(newGroups));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetGroupsInsertFails1)
+TEST_F(AgentInfoPersistenceTest, TestSetGroupsInsertFails1)
 {
     const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
 
@@ -291,10 +291,10 @@ TEST_F(AgentInfoPersistanceTest, TestSetGroupsInsertFails1)
         .WillOnce(testing::Throw(std::runtime_error("Error Insert")));
     EXPECT_CALL(*mockPersistence, RollbackTransaction(testing::_)).Times(1);
 
-    EXPECT_FALSE(agentInfoPersistance->SetGroups(newGroups));
+    EXPECT_FALSE(agentInfoPersistence->SetGroups(newGroups));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetGroupsInsertFails2)
+TEST_F(AgentInfoPersistenceTest, TestSetGroupsInsertFails2)
 {
     const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
 
@@ -308,10 +308,10 @@ TEST_F(AgentInfoPersistanceTest, TestSetGroupsInsertFails2)
         .WillOnce(testing::Throw(std::runtime_error("Error Insert")));
     EXPECT_CALL(*mockPersistence, RollbackTransaction(testing::_)).Times(1);
 
-    EXPECT_FALSE(agentInfoPersistance->SetGroups(newGroups));
+    EXPECT_FALSE(agentInfoPersistence->SetGroups(newGroups));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetGroupsCommitFails)
+TEST_F(AgentInfoPersistenceTest, TestSetGroupsCommitFails)
 {
     const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
 
@@ -322,10 +322,10 @@ TEST_F(AgentInfoPersistanceTest, TestSetGroupsCommitFails)
         .WillOnce(testing::Throw(std::runtime_error("Error Commit")));
     EXPECT_CALL(*mockPersistence, RollbackTransaction(testing::_)).Times(1);
 
-    EXPECT_FALSE(agentInfoPersistance->SetGroups(newGroups));
+    EXPECT_FALSE(agentInfoPersistence->SetGroups(newGroups));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestSetGroupsRollbackFails)
+TEST_F(AgentInfoPersistenceTest, TestSetGroupsRollbackFails)
 {
     const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
 
@@ -337,10 +337,10 @@ TEST_F(AgentInfoPersistanceTest, TestSetGroupsRollbackFails)
     EXPECT_CALL(*mockPersistence, RollbackTransaction(testing::_))
         .WillOnce(testing::Throw(std::runtime_error("Error Rollback")));
 
-    EXPECT_FALSE(agentInfoPersistance->SetGroups(newGroups));
+    EXPECT_FALSE(agentInfoPersistence->SetGroups(newGroups));
 }
 
-TEST_F(AgentInfoPersistanceTest, TestResetToDefaultSuccess)
+TEST_F(AgentInfoPersistenceTest, TestResetToDefaultSuccess)
 {
     EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
     EXPECT_CALL(*mockPersistence, DropTable("agent_group")).Times(1);
@@ -349,37 +349,37 @@ TEST_F(AgentInfoPersistanceTest, TestResetToDefaultSuccess)
     EXPECT_CALL(*mockPersistence, GetCount("agent_info", testing::_, testing::_)).WillOnce(testing::Return(0));
     EXPECT_CALL(*mockPersistence, Insert(testing::_, testing::_)).Times(1);
 
-    EXPECT_TRUE(agentInfoPersistance->ResetToDefault());
+    EXPECT_TRUE(agentInfoPersistence->ResetToDefault());
 }
 
-TEST_F(AgentInfoPersistanceTest, TestResetToDefaultDropTableAgentInfoFails)
+TEST_F(AgentInfoPersistenceTest, TestResetToDefaultDropTableAgentInfoFails)
 {
     EXPECT_CALL(*mockPersistence, DropTable("agent_info"))
         .WillOnce(testing::Throw(std::runtime_error("Error DropTable")));
 
-    EXPECT_FALSE(agentInfoPersistance->ResetToDefault());
+    EXPECT_FALSE(agentInfoPersistence->ResetToDefault());
 }
 
-TEST_F(AgentInfoPersistanceTest, TestResetToDefaultDropTableAgentGroupFails)
+TEST_F(AgentInfoPersistenceTest, TestResetToDefaultDropTableAgentGroupFails)
 {
     EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
     EXPECT_CALL(*mockPersistence, DropTable("agent_group"))
         .WillOnce(testing::Throw(std::runtime_error("Error DropTable")));
 
-    EXPECT_FALSE(agentInfoPersistance->ResetToDefault());
+    EXPECT_FALSE(agentInfoPersistence->ResetToDefault());
 }
 
-TEST_F(AgentInfoPersistanceTest, TestResetToDefaultCreateAgentInfoTableFails)
+TEST_F(AgentInfoPersistenceTest, TestResetToDefaultCreateAgentInfoTableFails)
 {
     EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
     EXPECT_CALL(*mockPersistence, DropTable("agent_group")).Times(1);
     EXPECT_CALL(*mockPersistence, CreateTable("agent_info", testing::_))
         .WillOnce(testing::Throw(std::runtime_error("Error CreateAgentInfoTable")));
 
-    EXPECT_FALSE(agentInfoPersistance->ResetToDefault());
+    EXPECT_FALSE(agentInfoPersistence->ResetToDefault());
 }
 
-TEST_F(AgentInfoPersistanceTest, TestResetToDefaultCreateAgentGroupTableFails)
+TEST_F(AgentInfoPersistenceTest, TestResetToDefaultCreateAgentGroupTableFails)
 {
     EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
     EXPECT_CALL(*mockPersistence, DropTable("agent_group")).Times(1);
@@ -387,10 +387,10 @@ TEST_F(AgentInfoPersistanceTest, TestResetToDefaultCreateAgentGroupTableFails)
     EXPECT_CALL(*mockPersistence, CreateTable("agent_group", testing::_))
         .WillOnce(testing::Throw(std::runtime_error("Error CreateAgentGroupTable")));
 
-    EXPECT_FALSE(agentInfoPersistance->ResetToDefault());
+    EXPECT_FALSE(agentInfoPersistence->ResetToDefault());
 }
 
-TEST_F(AgentInfoPersistanceTest, TestResetToDefaultInsertFails)
+TEST_F(AgentInfoPersistenceTest, TestResetToDefaultInsertFails)
 {
     EXPECT_CALL(*mockPersistence, DropTable("agent_info")).Times(1);
     EXPECT_CALL(*mockPersistence, DropTable("agent_group")).Times(1);
@@ -400,7 +400,7 @@ TEST_F(AgentInfoPersistanceTest, TestResetToDefaultInsertFails)
     EXPECT_CALL(*mockPersistence, Insert("agent_info", testing::_))
         .WillOnce(testing::Throw(std::runtime_error("Error Insert")));
 
-    EXPECT_FALSE(agentInfoPersistance->ResetToDefault());
+    EXPECT_FALSE(agentInfoPersistence->ResetToDefault());
 }
 
 int main(int argc, char** argv)

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <agent_info.hpp>
-#include <agent_info_persistance.hpp>
+#include <agent_info_persistence.hpp>
 #include <mocks_persistence.hpp>
 
 #include <memory>
@@ -12,7 +12,7 @@ class AgentInfoTest : public ::testing::Test
 {
 protected:
     MockPersistence* m_mockPersistence = nullptr;
-    std::shared_ptr<AgentInfoPersistance> m_agentPersistence;
+    std::shared_ptr<AgentInfoPersistence> m_agentPersistence;
     std::unique_ptr<AgentInfo> m_agentInfo;
 
     void SetUp() override
@@ -34,7 +34,7 @@ protected:
             SetUpAgentInfoInitialization();
         }
 
-        m_agentPersistence = std::make_shared<AgentInfoPersistance>("db_path", std::move(mockPersistencePtr));
+        m_agentPersistence = std::make_shared<AgentInfoPersistence>("db_path", std::move(mockPersistencePtr));
 
         m_agentInfo = std::make_unique<AgentInfo>("db_path",
                                                   osLambda ? osLambda : nullptr,

--- a/src/agent/agent_info/tests/agent_info_test.cpp
+++ b/src/agent/agent_info/tests/agent_info_test.cpp
@@ -1,8 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <agent_info.hpp>
-#include <agent_info_persistence.hpp>
-#include <mocks_persistence.hpp>
+#include <mock_agent_info_persistence.hpp>
 
 #include <memory>
 #include <string>
@@ -11,8 +10,7 @@
 class AgentInfoTest : public ::testing::Test
 {
 protected:
-    MockPersistence* m_mockPersistence = nullptr;
-    std::shared_ptr<AgentInfoPersistence> m_agentPersistence;
+    std::shared_ptr<MockAgentInfoPersistence> m_agentPersistence;
     std::unique_ptr<AgentInfo> m_agentInfo;
 
     void SetUp() override
@@ -24,52 +22,31 @@ protected:
                              const std::function<nlohmann::json()>& networksLambda = nullptr,
                              bool agentIsEnrolling = false)
     {
-        auto mockPersistencePtr = std::make_unique<MockPersistence>();
-        m_mockPersistence = mockPersistencePtr.get();
-
-        SetUpPersistenceMock();
+        m_agentPersistence = std::make_shared<MockAgentInfoPersistence>();
 
         if (!agentIsEnrolling)
         {
             SetUpAgentInfoInitialization();
         }
 
-        m_agentPersistence = std::make_shared<AgentInfoPersistence>("db_path", std::move(mockPersistencePtr));
-
         m_agentInfo = std::make_unique<AgentInfo>("db_path",
                                                   osLambda ? osLambda : nullptr,
                                                   networksLambda ? networksLambda : nullptr,
                                                   agentIsEnrolling,
-                                                  std::move(m_agentPersistence));
-    }
-
-    void SetUpPersistenceMock()
-    {
-        EXPECT_CALL(*m_mockPersistence, TableExists("agent_info")).WillOnce(testing::Return(true));
-        EXPECT_CALL(*m_mockPersistence, TableExists("agent_group")).WillOnce(testing::Return(true));
-        EXPECT_CALL(*m_mockPersistence, GetCount("agent_info", testing::_, testing::_)).WillOnce(testing::Return(1));
+                                                  m_agentPersistence);
     }
 
     void SetUpAgentInfoInitialization()
     {
-        const std::vector<column::Row> mockRowName = {
-            {column::ColumnValue("name", column::ColumnType::TEXT, "name_test")}};
-        const std::vector<column::Row> mockRowKey = {
-            {column::ColumnValue("key", column::ColumnType::TEXT, "key_test")}};
-        const std::vector<column::Row> mockRowUUID = {
-            {column::ColumnValue("uuid", column::ColumnType::TEXT, "uuid_test")}};
-        const std::vector<column::Row> mockRowGroup = {{}};
+        const std::string mockName = "name_test";
+        const std::string mockKey = "key_test";
+        const std::string mockUUID = "uuid_test";
+        const std::vector<std::string> mockGroup = {};
 
-        const testing::Sequence seq;
-        EXPECT_CALL(*m_mockPersistence,
-                    Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
-            .InSequence(seq)
-            .WillOnce(testing::Return(mockRowName))
-            .WillOnce(testing::Return(mockRowKey))
-            .WillOnce(testing::Return(mockRowUUID));
-        EXPECT_CALL(*m_mockPersistence,
-                    Select("agent_group", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
-            .WillOnce(testing::Return(mockRowGroup));
+        EXPECT_CALL(*m_agentPersistence, GetName()).WillOnce(testing::Return(mockName));
+        EXPECT_CALL(*m_agentPersistence, GetKey()).WillOnce(testing::Return(mockKey));
+        EXPECT_CALL(*m_agentPersistence, GetUUID()).WillOnce(testing::Return(mockUUID));
+        EXPECT_CALL(*m_agentPersistence, GetGroups()).WillOnce(testing::Return(mockGroup));
     }
 };
 
@@ -131,36 +108,28 @@ TEST_F(AgentInfoTest, TestSetGroups)
     EXPECT_EQ(m_agentInfo->GetGroups(), newGroups);
 }
 
+TEST_F(AgentInfoTest, TestSaveGroupsFail)
+{
+    EXPECT_CALL(*m_agentPersistence, SetGroups(testing::_)).WillOnce(testing::Return(false));
+
+    EXPECT_FALSE(m_agentInfo->SaveGroups());
+}
+
 TEST_F(AgentInfoTest, TestSaveGroups)
 {
-    const std::vector<std::string> newGroups = {"t_group_1", "t_group_2"};
+    EXPECT_CALL(*m_agentPersistence, SetGroups(testing::_)).WillOnce(testing::Return(true));
 
-    EXPECT_CALL(*m_mockPersistence, BeginTransaction()).Times(1);
-    EXPECT_CALL(*m_mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
-    EXPECT_CALL(*m_mockPersistence, Insert("agent_group", testing::_)).Times(2);
-    EXPECT_CALL(*m_mockPersistence, CommitTransaction(testing::_)).Times(1);
-
-    m_agentInfo->SetGroups(newGroups);
     EXPECT_TRUE(m_agentInfo->SaveGroups());
-    EXPECT_EQ(m_agentInfo->GetGroups(), newGroups);
 }
 
 TEST_F(AgentInfoTest, TestSave)
 {
-    // Mock for: m_persistence->ResetToDefault();
-    EXPECT_CALL(*m_mockPersistence, DropTable("agent_info")).Times(1);
-    EXPECT_CALL(*m_mockPersistence, DropTable("agent_group")).Times(1);
-    EXPECT_CALL(*m_mockPersistence, CreateTable(testing::_, testing::_)).Times(2);
-    EXPECT_CALL(*m_mockPersistence, GetCount("agent_info", testing::_, testing::_)).WillOnce(testing::Return(0));
-    EXPECT_CALL(*m_mockPersistence, Insert(testing::_, testing::_)).Times(1);
+    EXPECT_CALL(*m_agentPersistence, ResetToDefault()).Times(1);
+    EXPECT_CALL(*m_agentPersistence, SetName(testing::_)).Times(1);
+    EXPECT_CALL(*m_agentPersistence, SetKey(testing::_)).Times(1);
+    EXPECT_CALL(*m_agentPersistence, SetUUID(testing::_)).Times(1);
+    EXPECT_CALL(*m_agentPersistence, SetGroups(testing::_)).Times(1);
 
-    // Mock for: m_persistence->SetName(m_name); m_persistence->SetKey(m_key); m_persistence->SetUUID(m_uuid);
-    EXPECT_CALL(*m_mockPersistence, Update("agent_info", testing::_, testing::_, testing::_)).Times(3);
-
-    // Mock for: m_persistence->SetGroups(m_groups);
-    EXPECT_CALL(*m_mockPersistence, BeginTransaction()).Times(1);
-    EXPECT_CALL(*m_mockPersistence, Remove("agent_group", testing::_, testing::_)).Times(1);
-    EXPECT_CALL(*m_mockPersistence, CommitTransaction(testing::_)).Times(1);
     m_agentInfo->Save();
 }
 

--- a/src/agent/agent_info/tests/mocks/mock_agent_info.hpp
+++ b/src/agent/agent_info/tests/mocks/mock_agent_info.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <iagent_info.hpp>
+
+#include <string>
+#include <vector>
+
+class MockAgentInfo : public IAgentInfo
+{
+public:
+    MOCK_METHOD(std::string, GetName, (), (const, override));
+    MOCK_METHOD(std::string, GetKey, (), (const, override));
+    MOCK_METHOD(std::string, GetUUID, (), (const, override));
+    MOCK_METHOD(std::vector<std::string>, GetGroups, (), (const, override));
+    MOCK_METHOD(bool, SetName, (const std::string& name), (override));
+    MOCK_METHOD(bool, SetKey, (const std::string& key), (override));
+    MOCK_METHOD(void, SetUUID, (const std::string& uuid), (override));
+    MOCK_METHOD(void, SetGroups, (const std::vector<std::string>& groupList), (override));
+    MOCK_METHOD(std::string, GetType, (), (const, override));
+    MOCK_METHOD(std::string, GetVersion, (), (const, override));
+    MOCK_METHOD(std::string, GetHeaderInfo, (), (const, override));
+    MOCK_METHOD(std::string, GetMetadataInfo, (), (const, override));
+    MOCK_METHOD(void, Save, (), (const, override));
+    MOCK_METHOD(bool, SaveGroups, (), (const, override));
+};

--- a/src/agent/agent_info/tests/mocks/mock_agent_info_persistence.hpp
+++ b/src/agent/agent_info/tests/mocks/mock_agent_info_persistence.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <iagent_info_persistence.hpp>
+
+#include <string>
+#include <vector>
+
+class MockAgentInfoPersistence : public IAgentInfoPersistence
+{
+public:
+    MOCK_METHOD(std::string, GetName, (), (const, override));
+    MOCK_METHOD(std::string, GetKey, (), (const, override));
+    MOCK_METHOD(std::string, GetUUID, (), (const, override));
+    MOCK_METHOD(std::vector<std::string>, GetGroups, (), (const, override));
+    MOCK_METHOD(bool, SetName, (const std::string& name), (override));
+    MOCK_METHOD(bool, SetKey, (const std::string& key), (override));
+    MOCK_METHOD(bool, SetUUID, (const std::string& uuid), (override));
+    MOCK_METHOD(bool, SetGroups, (const std::vector<std::string>& groupList), (override));
+    MOCK_METHOD(bool, ResetToDefault, (), (override));
+};

--- a/src/agent/centralized_configuration/tests/CMakeLists.txt
+++ b/src/agent/centralized_configuration/tests/CMakeLists.txt
@@ -2,5 +2,7 @@ find_package(GTest CONFIG REQUIRED)
 
 add_executable(centralized_configuration_test centralized_configuration_tests.cpp)
 configure_target(centralized_configuration_test)
+target_include_directories(centralized_configuration_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../common/file_helper/filesystem/tests/mocks/)
 target_link_libraries(centralized_configuration_test PRIVATE CentralizedConfiguration GTest::gtest GTest::gmock GTest::gmock_main)
 add_test(NAME CentralizedConfiguration COMMAND centralized_configuration_test)

--- a/src/agent/centralized_configuration/tests/centralized_configuration_tests.cpp
+++ b/src/agent/centralized_configuration/tests/centralized_configuration_tests.cpp
@@ -3,6 +3,8 @@
 
 #include <centralized_configuration.hpp>
 
+#include <mock_filesystem.hpp>
+
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
@@ -10,11 +12,9 @@
 
 #include <nlohmann/json.hpp>
 
+#include <filesystem>
 #include <string>
 #include <vector>
-
-#include "../../../common/file_helper/filesystem/tests/mocks/mock_filesystem.hpp"
-#include <filesystem>
 
 using centralized_configuration::CentralizedConfiguration;
 using namespace testing;

--- a/src/agent/command_handler/include/command_handler.hpp
+++ b/src/agent/command_handler/include/command_handler.hpp
@@ -2,6 +2,7 @@
 
 #include <command_entry.hpp>
 #include <configuration_parser.hpp>
+#include <icommand_handler.hpp>
 #include <icommand_store.hpp>
 
 #include <boost/asio/awaitable.hpp>
@@ -20,7 +21,7 @@ namespace command_handler
     /// This class is responsible for executing commands retrieved from the command
     /// store. It provides a way to dispatch commands to the corresponding
     /// command handlers and manage the command execution results.
-    class CommandHandler
+    class CommandHandler : public ICommandHandler
     {
     public:
         /// @brief CommandHandler constructor
@@ -45,10 +46,10 @@ namespace command_handler
                                const std::function<void()> popCommandFromQueue,
                                const std::function<void(module_command::CommandEntry&)> reportCommandResult,
                                const std::function<boost::asio::awaitable<module_command::CommandExecutionResult>(
-                                   module_command::CommandEntry&)> dispatchCommand);
+                                   module_command::CommandEntry&)> dispatchCommand) override;
 
         /// @brief Stops the command handler
-        void Stop();
+        void Stop() override;
 
     private:
         /// @brief Clean up commands that are in progress when the agent is stopped

--- a/src/agent/command_handler/include/icommand_handler.hpp
+++ b/src/agent/command_handler/include/icommand_handler.hpp
@@ -1,17 +1,11 @@
 #pragma once
 
 #include <command_entry.hpp>
-#include <configuration_parser.hpp>
-#include <icommand_store.hpp>
 
 #include <boost/asio/awaitable.hpp>
 
-#include <atomic>
-#include <chrono>
-#include <memory>
+#include <functional>
 #include <optional>
-#include <string>
-#include <vector>
 
 namespace command_handler
 {

--- a/src/agent/command_handler/include/icommand_handler.hpp
+++ b/src/agent/command_handler/include/icommand_handler.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <command_entry.hpp>
+#include <configuration_parser.hpp>
+#include <icommand_store.hpp>
+
+#include <boost/asio/awaitable.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace command_handler
+{
+    /// @brief Interface for the CommandHandler class
+    class ICommandHandler
+    {
+    public:
+        virtual ~ICommandHandler() = default;
+
+        /// @brief Processes commands asynchronously
+        ///
+        /// This task retrieves commands from the queue and dispatches them for execution.
+        /// If no command is available, it waits for a specified duration before retrying.
+        ///
+        /// @param getCommandFromQueue Function to retrieve a command from the queue
+        /// @param popCommandFromQueue Function to remove a command from the queue
+        /// @param reportCommandResult Function to report a command result
+        /// @param dispatchCommand Function to dispatch the command for execution
+        virtual boost::asio::awaitable<void>
+        CommandsProcessingTask(const std::function<std::optional<module_command::CommandEntry>()> getCommandFromQueue,
+                               const std::function<void()> popCommandFromQueue,
+                               const std::function<void(module_command::CommandEntry&)> reportCommandResult,
+                               const std::function<boost::asio::awaitable<module_command::CommandExecutionResult>(
+                                   module_command::CommandEntry&)> dispatchCommand) = 0;
+
+        /// @brief Stops the command handler
+        virtual void Stop() = 0;
+    };
+} // namespace command_handler

--- a/src/agent/command_handler/tests/mocks/mock_command_handler.hpp
+++ b/src/agent/command_handler/tests/mocks/mock_command_handler.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <icommand_handler.hpp>
+
+#include <boost/asio/awaitable.hpp>
+
+namespace command_handler
+{
+    class MockCommandHandler : public command_handler::ICommandHandler
+    {
+    public:
+        MOCK_METHOD(boost::asio::awaitable<void>,
+                    CommandsProcessingTask,
+                    (const std::function<std::optional<module_command::CommandEntry>()>,
+                     const std::function<void()>,
+                     const std::function<void(module_command::CommandEntry&)>,
+                     const std::function<boost::asio::awaitable<module_command::CommandExecutionResult>(
+                         module_command::CommandEntry&)>),
+                    (override));
+
+        MOCK_METHOD(void, Stop, (), (override));
+    };
+} // namespace command_handler

--- a/src/agent/command_handler/tests/mocks/mock_command_handler.hpp
+++ b/src/agent/command_handler/tests/mocks/mock_command_handler.hpp
@@ -2,9 +2,13 @@
 
 #include <gmock/gmock.h>
 
+#include <command_entry.hpp>
 #include <icommand_handler.hpp>
 
 #include <boost/asio/awaitable.hpp>
+
+#include <functional>
+#include <optional>
 
 namespace command_handler
 {

--- a/src/agent/command_handler/tests/mocks/mock_command_processing_task_functions.hpp
+++ b/src/agent/command_handler/tests/mocks/mock_command_processing_task_functions.hpp
@@ -3,8 +3,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <command_handler.hpp>
-
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>

--- a/src/agent/communicator/tests/CMakeLists.txt
+++ b/src/agent/communicator/tests/CMakeLists.txt
@@ -2,7 +2,9 @@ find_package(GTest CONFIG REQUIRED)
 
 add_executable(communicator_test communicator_test.cpp)
 configure_target(communicator_test)
-target_include_directories(communicator_test SYSTEM PRIVATE ${JWT_CPP_INCLUDE_DIRS})
+target_include_directories(communicator_test SYSTEM PRIVATE
+    ${JWT_CPP_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../http_client/tests/mocks)
 target_compile_definitions(communicator_test PRIVATE -DJWT_DISABLE_PICOJSON=ON)
 target_link_libraries(communicator_test PUBLIC Communicator GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
 add_test(NAME CommunicatorTest COMMAND communicator_test)

--- a/src/agent/communicator/tests/communicator_test.cpp
+++ b/src/agent/communicator/tests/communicator_test.cpp
@@ -4,11 +4,10 @@
 #include <communicator.hpp>
 #include <http_request_params.hpp>
 #include <ihttp_client.hpp>
+#include <mock_http_client.hpp>
 
 #include <jwt-cpp/jwt.h>
 #include <jwt-cpp/traits/nlohmann-json/traits.h>
-
-#include "../../http_client/tests/mocks/mock_http_client.hpp"
 
 #include <boost/asio.hpp>
 

--- a/src/agent/include/agent.hpp
+++ b/src/agent/include/agent.hpp
@@ -2,10 +2,9 @@
 
 #include <agent_info.hpp>
 #include <centralized_configuration.hpp>
-#include <command_handler.hpp>
 #include <communicator.hpp>
 #include <configuration_parser.hpp>
-#include <icommand_store.hpp>
+#include <icommand_handler.hpp>
 #include <ihttp_client.hpp>
 #include <imultitype_queue.hpp>
 #include <isignal_handler.hpp>
@@ -31,7 +30,7 @@ public:
     /// @param signalHandler Pointer to a custom ISignalHandler implementation
     /// @param httpClient Pointer to an IHttpClient implementation
     /// @param agentInfo Pointer to a custom IAgentInfo implementation
-    /// @param commandStore Pointer to a custom ICommandStore implementation
+    /// @param commandHandler Pointer to a custom ICommandHandler implementation
     /// @param messageQueue Pointer to a custom IMultiTypeQueue implementation
     /// @throws std::runtime_error If the Agent is not enrolled
     /// @throws Any exception propagated from dependencies used within the constructor
@@ -39,7 +38,7 @@ public:
           std::unique_ptr<ISignalHandler> signalHandler = std::make_unique<SignalHandler>(),
           std::unique_ptr<http_client::IHttpClient> httpClient = nullptr,
           std::unique_ptr<IAgentInfo> agentInfo = nullptr,
-          std::unique_ptr<command_store::ICommandStore> commandStore = nullptr,
+          std::unique_ptr<command_handler::ICommandHandler> commandHandler = nullptr,
           std::shared_ptr<IMultiTypeQueue> messageQueue = nullptr);
 
     /// @brief Destructor
@@ -81,7 +80,7 @@ private:
     ModuleManager m_moduleManager;
 
     /// @brief Command handler
-    command_handler::CommandHandler m_commandHandler;
+    std::unique_ptr<command_handler::ICommandHandler> m_commandHandler;
 
     /// @brief Centralized configuration
     centralized_configuration::CentralizedConfiguration m_centralizedConfiguration;

--- a/src/agent/include/agent.hpp
+++ b/src/agent/include/agent.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <agent_info.hpp>
 #include <centralized_configuration.hpp>
 #include <communicator.hpp>
 #include <configuration_parser.hpp>
+#include <iagent_info.hpp>
 #include <icommand_handler.hpp>
 #include <ihttp_client.hpp>
 #include <imultitype_queue.hpp>

--- a/src/agent/include/agent.hpp
+++ b/src/agent/include/agent.hpp
@@ -30,7 +30,7 @@ public:
     /// @param configFilePath Path to the configuration file
     /// @param signalHandler Pointer to a custom ISignalHandler implementation
     /// @param httpClient Pointer to an IHttpClient implementation
-    /// @param agentInfo Optional AgentInfo object
+    /// @param agentInfo Pointer to a custom IAgentInfo implementation
     /// @param commandStore Pointer to a custom ICommandStore implementation
     /// @param messageQueue Pointer to a custom IMultiTypeQueue implementation
     /// @throws std::runtime_error If the Agent is not enrolled
@@ -38,7 +38,7 @@ public:
     Agent(const std::string& configFilePath,
           std::unique_ptr<ISignalHandler> signalHandler = std::make_unique<SignalHandler>(),
           std::unique_ptr<http_client::IHttpClient> httpClient = nullptr,
-          std::optional<AgentInfo> agentInfo = std::nullopt,
+          std::unique_ptr<IAgentInfo> agentInfo = nullptr,
           std::unique_ptr<command_store::ICommandStore> commandStore = nullptr,
           std::shared_ptr<IMultiTypeQueue> messageQueue = nullptr);
 
@@ -69,7 +69,7 @@ private:
     std::shared_ptr<configuration::ConfigurationParser> m_configurationParser;
 
     /// @brief Agent info
-    AgentInfo m_agentInfo;
+    std::unique_ptr<IAgentInfo> m_agentInfo;
 
     /// @brief Queue for storing messages
     std::shared_ptr<IMultiTypeQueue> m_messageQueue;

--- a/src/agent/include/agent_enrollment.hpp
+++ b/src/agent/include/agent_enrollment.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <agent_info.hpp>
+#include <iagent_info.hpp>
 #include <ihttp_client.hpp>
 
 #include <sysInfo.hpp>
@@ -35,7 +35,7 @@ namespace agent_enrollment
         /// @param name The agent's name.
         /// @param dbFolderPath The path to the database folder.
         /// @param verificationMode The connection verification mode.
-        /// @param agentInfo Optional agent's information object.
+        /// @param agentInfo Pointer to a custom IAgentInfo implementation.
         AgentEnrollment(std::unique_ptr<http_client::IHttpClient> httpClient,
                         std::string url,
                         std::string user,
@@ -44,7 +44,7 @@ namespace agent_enrollment
                         const std::string& name,
                         const std::string& dbFolderPath,
                         std::string verificationMode,
-                        std::optional<AgentInfo> agentInfo = std::nullopt);
+                        std::unique_ptr<IAgentInfo> agentInfo = nullptr);
 
         /// @brief Enrolls the agent with the manager.
         ///
@@ -64,7 +64,7 @@ namespace agent_enrollment
         SysInfo m_sysInfo;
 
         /// @brief The agent's information.
-        AgentInfo m_agentInfo;
+        std::unique_ptr<IAgentInfo> m_agentInfo;
 
         /// @brief The URL of the manager.
         std::string m_serverUrl;

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -17,36 +17,36 @@
 Agent::Agent(const std::string& configFilePath,
              std::unique_ptr<ISignalHandler> signalHandler,
              std::unique_ptr<http_client::IHttpClient> httpClient,
-             std::optional<AgentInfo> agentInfo,
+             std::unique_ptr<IAgentInfo> agentInfo,
              std::unique_ptr<command_store::ICommandStore> commandStore,
              std::shared_ptr<IMultiTypeQueue> messageQueue)
     : m_signalHandler(std::move(signalHandler))
     , m_configurationParser(configFilePath.empty() ? std::make_shared<configuration::ConfigurationParser>()
                                                    : std::make_shared<configuration::ConfigurationParser>(
                                                          std::filesystem::path(configFilePath)))
-    , m_agentInfo(agentInfo.has_value()
-                      ? std::move(*agentInfo)
-                      : AgentInfo(
+    , m_agentInfo(agentInfo
+                      ? std::move(agentInfo)
+                      : std::make_unique<AgentInfo>(
                             m_configurationParser->GetConfigOrDefault(config::DEFAULT_DATA_PATH, "agent", "path.data"),
                             [this]() { return m_sysInfo.os(); },
                             [this]() { return m_sysInfo.networks(); }))
     , m_messageQueue(messageQueue ? std::move(messageQueue) : std::make_shared<MultiTypeQueue>(m_configurationParser))
     , m_communicator(httpClient ? std::move(httpClient) : std::make_unique<http_client::HttpClient>(),
                      m_configurationParser,
-                     m_agentInfo.GetUUID(),
-                     m_agentInfo.GetKey(),
-                     [this]() { return m_agentInfo.GetHeaderInfo(); })
+                     m_agentInfo->GetUUID(),
+                     m_agentInfo->GetKey(),
+                     [this]() { return m_agentInfo->GetHeaderInfo(); })
     , m_moduleManager([this](Message message) -> int { return m_messageQueue->push(std::move(message)); },
                       m_configurationParser,
-                      m_agentInfo.GetUUID())
+                      m_agentInfo->GetUUID())
     , m_commandHandler(m_configurationParser, commandStore ? std::move(commandStore) : nullptr)
     , m_centralizedConfiguration(
           [this](const std::vector<std::string>& groups)
           {
-              m_agentInfo.SetGroups(groups);
-              return m_agentInfo.SaveGroups();
+              m_agentInfo->SetGroups(groups);
+              return m_agentInfo->SaveGroups();
           },
-          [this]() { return m_agentInfo.GetGroups(); },
+          [this]() { return m_agentInfo->GetGroups(); },
           // NOLINTBEGIN(cppcoreguidelines-avoid-capturing-lambda-coroutines)
           [this](std::string groupId, std::string destinationPath) -> boost::asio::awaitable<bool> {
               co_return co_await m_communicator.GetGroupConfigurationFromManager(std::move(groupId),
@@ -58,12 +58,12 @@ Agent::Agent(const std::string& configFilePath,
           [this]() { ReloadModules(); })
 {
     // Check if agent is enrolled
-    if (m_agentInfo.GetName().empty() || m_agentInfo.GetKey().empty() || m_agentInfo.GetUUID().empty())
+    if (m_agentInfo->GetName().empty() || m_agentInfo->GetKey().empty() || m_agentInfo->GetUUID().empty())
     {
         throw std::runtime_error("The agent is not enrolled");
     }
 
-    m_configurationParser->SetGetGroupIdsFunction([this]() { return m_agentInfo.GetGroups(); });
+    m_configurationParser->SetGetGroupIdsFunction([this]() { return m_agentInfo->GetGroups(); });
 
     m_agentThreadCount =
         m_configurationParser->GetConfigInRangeOrDefault<size_t>(config::DEFAULT_THREAD_COUNT,
@@ -123,7 +123,7 @@ void Agent::Run()
                                       return GetMessagesFromQueue(m_messageQueue,
                                                                   MessageType::STATEFUL,
                                                                   numMessages,
-                                                                  [this]() { return m_agentInfo.GetMetadataInfo(); });
+                                                                  [this]() { return m_agentInfo->GetMetadataInfo(); });
                                   },
                                   [this]([[maybe_unused]] const int messageCount, const std::string&)
                                   { PopMessagesFromQueue(m_messageQueue, MessageType::STATEFUL, messageCount); }),
@@ -135,7 +135,7 @@ void Agent::Run()
                                       return GetMessagesFromQueue(m_messageQueue,
                                                                   MessageType::STATELESS,
                                                                   numMessages,
-                                                                  [this]() { return m_agentInfo.GetMetadataInfo(); });
+                                                                  [this]() { return m_agentInfo->GetMetadataInfo(); });
                                   },
                                   [this]([[maybe_unused]] const int messageCount, const std::string&)
                                   { PopMessagesFromQueue(m_messageQueue, MessageType::STATELESS, messageCount); }),

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -1,5 +1,6 @@
 #include <agent.hpp>
 
+#include <agent_info.hpp>
 #include <command_entry.hpp>
 #include <command_handler.hpp>
 #include <command_handler_utils.hpp>

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -18,7 +18,8 @@ add_executable(agent_enrollment_test agent_enrollment_test.cpp)
 configure_target(agent_enrollment_test)
 target_include_directories(agent_enrollment_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
-    ${CMAKE_CURRENT_SOURCE_DIR}/../agent_info/tests/mocks)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../agent_info/tests/mocks
+    ${CMAKE_CURRENT_SOURCE_DIR}/../http_client/tests/mocks)
 target_link_libraries(agent_enrollment_test PRIVATE Agent Persistence GTest::gmock GTest::gtest)
 add_test(NAME AgentEnrollmentTest COMMAND agent_enrollment_test)
 

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ target_include_directories(agent_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
     ${CMAKE_CURRENT_SOURCE_DIR}/../agent_info/tests/mocks
     ${CMAKE_CURRENT_SOURCE_DIR}/../command_handler/tests/mocks
+    ${CMAKE_CURRENT_SOURCE_DIR}/../http_client/tests/mocks
     ${CMAKE_CURRENT_SOURCE_DIR}/../multitype_queue/tests/mocks)
 target_link_libraries(agent_test PRIVATE Agent Persistence GTest::gtest GTest::gmock)
 

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -4,8 +4,7 @@ add_executable(agent_test agent_test.cpp)
 configure_target(agent_test)
 target_include_directories(agent_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
-    ${CMAKE_CURRENT_SOURCE_DIR}/../agent_info/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/../persistence/tests/mocks
+    ${CMAKE_CURRENT_SOURCE_DIR}/../agent_info/tests/mocks
     ${CMAKE_CURRENT_SOURCE_DIR}/../command_handler/tests/mocks
     ${CMAKE_CURRENT_SOURCE_DIR}/../multitype_queue/tests/mocks)
 target_link_libraries(agent_test PRIVATE Agent Persistence GTest::gtest GTest::gmock)

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -18,8 +18,7 @@ add_executable(agent_enrollment_test agent_enrollment_test.cpp)
 configure_target(agent_enrollment_test)
 target_include_directories(agent_enrollment_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
-    ${CMAKE_CURRENT_SOURCE_DIR}/../agent_info/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/../persistence/tests/mocks)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../agent_info/tests/mocks)
 target_link_libraries(agent_enrollment_test PRIVATE Agent Persistence GTest::gmock GTest::gtest)
 add_test(NAME AgentEnrollmentTest COMMAND agent_enrollment_test)
 

--- a/src/agent/tests/agent_enrollment_test.cpp
+++ b/src/agent/tests/agent_enrollment_test.cpp
@@ -3,7 +3,7 @@
 
 #include <agent_enrollment.hpp>
 #include <agent_info.hpp>
-#include <agent_info_persistance.hpp>
+#include <agent_info_persistence.hpp>
 #include <http_request_params.hpp>
 #include <ihttp_client.hpp>
 
@@ -33,7 +33,7 @@ protected:
             [sysInfo]() mutable { return sysInfo.os(); },
             [sysInfo]() mutable { return sysInfo.networks(); },
             true,
-            std::make_shared<AgentInfoPersistance>("db_path", std::move(mockPersistencePtr)));
+            std::make_shared<AgentInfoPersistence>("db_path", std::move(mockPersistencePtr)));
 
         m_agentInfo->SetKey("4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj");
         m_agentInfo->SetName("agent_name");

--- a/src/agent/tests/agent_test.cpp
+++ b/src/agent/tests/agent_test.cpp
@@ -1,14 +1,13 @@
 #include "../http_client/tests/mocks/mock_http_client.hpp"
 #include <agent.hpp>
-#include <agent_info_persistence.hpp>
 #include <cstdio>
 #include <fstream>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <isignal_handler.hpp>
+#include <mock_agent_info.hpp>
 #include <mock_command_store.hpp>
 #include <mock_multitype_queue.hpp>
-#include <mocks_persistence.hpp>
 
 class MockSignalHandler : public ISignalHandler
 {
@@ -21,8 +20,6 @@ class AgentTests : public ::testing::Test
 protected:
     std::string AGENT_CONFIG_PATH;
     std::string AGENT_PATH;
-    std::unique_ptr<AgentInfo> m_agentInfo;
-    MockPersistence* m_mockPersistence = nullptr;
 
     void SetUp() override
     {
@@ -40,22 +37,6 @@ protected:
 #endif
 
         CreateTempConfigFile();
-
-        auto mockPersistencePtr = std::make_unique<MockPersistence>();
-        m_mockPersistence = mockPersistencePtr.get();
-
-        SetConstructorPersistenceExpectCalls();
-
-        SysInfo sysInfo;
-        m_agentInfo = std::make_unique<AgentInfo>(
-            AGENT_PATH,
-            [sysInfo]() mutable { return sysInfo.os(); },
-            [sysInfo]() mutable { return sysInfo.networks(); },
-            false,
-            std::make_shared<AgentInfoPersistence>("db_path", std::move(mockPersistencePtr)));
-
-        m_agentInfo->SetKey("4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj");
-        m_agentInfo->SetName("agent_name");
     }
 
     void TearDown() override
@@ -100,34 +81,6 @@ logcollector:
     {
         std::remove(AGENT_CONFIG_PATH.c_str());
     }
-
-    void SetConstructorPersistenceExpectCalls()
-    {
-        const std::vector<column::Row> mockRowName = {
-            {column::ColumnValue("name", column::ColumnType::TEXT, "agent_name")}};
-        const std::vector<column::Row> mockRowKey = {
-            {column::ColumnValue("key", column::ColumnType::TEXT, "4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj")}};
-        const std::vector<column::Row> mockRowUUID = {{}};
-        const std::vector<column::Row> mockRowGroup = {{}};
-
-        EXPECT_CALL(*m_mockPersistence, TableExists("agent_info")).WillOnce(testing::Return(true));
-        EXPECT_CALL(*m_mockPersistence, TableExists("agent_group")).WillOnce(testing::Return(true));
-        EXPECT_CALL(*m_mockPersistence, GetCount("agent_info", testing::_, testing::_))
-            .WillOnce(testing::Return(0))
-            .WillOnce(testing::Return(0));
-        EXPECT_CALL(*m_mockPersistence, Insert("agent_info", testing::_)).Times(1);
-
-        const testing::Sequence seq;
-        EXPECT_CALL(*m_mockPersistence,
-                    Select("agent_info", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
-            .InSequence(seq)
-            .WillOnce(testing::Return(mockRowName))
-            .WillOnce(testing::Return(mockRowKey))
-            .WillOnce(testing::Return(mockRowUUID));
-        EXPECT_CALL(*m_mockPersistence,
-                    Select("agent_group", testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
-            .WillOnce(testing::Return(mockRowGroup));
-    }
 };
 
 TEST_F(AgentTests, AgentStopsWhenSignalReceived)
@@ -141,7 +94,17 @@ TEST_F(AgentTests, AgentStopsWhenSignalReceived)
 
     auto mockMultiTypeQueue = std::make_shared<MockMultiTypeQueue>();
 
+    auto mockAgentInfo = std::make_unique<MockAgentInfo>();
+    MockAgentInfo* mockAgentInfoPtr = mockAgentInfo.get();
+
     auto WaitForSignalCalled = false;
+
+    const std::vector<std::string> mockGroups = {"group1", "group2"};
+    EXPECT_CALL(*mockAgentInfoPtr, GetUUID()).Times(3).WillRepeatedly(testing::Return("mock_uuid"));
+    EXPECT_CALL(*mockAgentInfoPtr, GetKey()).Times(2).WillRepeatedly(testing::Return("mock_key"));
+    EXPECT_CALL(*mockAgentInfoPtr, GetName()).WillOnce(testing::Return("mock_name"));
+    EXPECT_CALL(*mockAgentInfoPtr, GetGroups()).WillOnce(testing::Return(mockGroups));
+    EXPECT_CALL(*mockAgentInfoPtr, GetHeaderInfo()).WillRepeatedly(testing::Return("header_info"));
 
     EXPECT_CALL(*mockSignalHandlerPtr, WaitForSignal())
         .Times(1)
@@ -157,7 +120,7 @@ TEST_F(AgentTests, AgentStopsWhenSignalReceived)
     Agent agent(AGENT_CONFIG_PATH,
                 std::move(mockSignalHandler),
                 std::move(mockHttpClient),
-                std::move(*m_agentInfo),
+                std::move(mockAgentInfo),
                 std::move(mockCommandStore),
                 std::move(mockMultiTypeQueue));
 

--- a/src/agent/tests/agent_test.cpp
+++ b/src/agent/tests/agent_test.cpp
@@ -1,4 +1,3 @@
-#include "../http_client/tests/mocks/mock_http_client.hpp"
 #include <agent.hpp>
 #include <cstdio>
 #include <fstream>
@@ -7,6 +6,7 @@
 #include <isignal_handler.hpp>
 #include <mock_agent_info.hpp>
 #include <mock_command_store.hpp>
+#include <mock_http_client.hpp>
 #include <mock_multitype_queue.hpp>
 
 class MockSignalHandler : public ISignalHandler

--- a/src/agent/tests/agent_test.cpp
+++ b/src/agent/tests/agent_test.cpp
@@ -1,6 +1,6 @@
 #include "../http_client/tests/mocks/mock_http_client.hpp"
 #include <agent.hpp>
-#include <agent_info_persistance.hpp>
+#include <agent_info_persistence.hpp>
 #include <cstdio>
 #include <fstream>
 #include <gmock/gmock.h>
@@ -52,7 +52,7 @@ protected:
             [sysInfo]() mutable { return sysInfo.os(); },
             [sysInfo]() mutable { return sysInfo.networks(); },
             false,
-            std::make_shared<AgentInfoPersistance>("db_path", std::move(mockPersistencePtr)));
+            std::make_shared<AgentInfoPersistence>("db_path", std::move(mockPersistencePtr)));
 
         m_agentInfo->SetKey("4GhT7uFm1zQa9c2Vb7Lk8pYsX0WqZrNj");
         m_agentInfo->SetName("agent_name");


### PR DESCRIPTION
## Description

Closes #593

This PR adds the last changes to finish the refactor of the UTs of the classes that access the agent_info.db, command_store.db and queue.db databases.

## Proposed Changes

The following changes have been introduced:

- The name of the AgentInfoPersistance class was changed to AgentInfoPersistence
- An interface was created for the class AgentInfoPersistence
- An AgentInfoPersistence mock was created and is used in AgentInfo tests
- An interface was created for the class AgentInfo
- An AgentInfo mock was created and is used in AgenEnrollment tests and Agent tests
- An interface was created for the class CommandHandler
- A CommandHandlermock was created and is used in Agent tests

### Results and Evidence

```bash
nico@nico-VirtualBox:~/wazuh-agent/build$ ls /var/lib/wazuh-agent/
nico@nico-VirtualBox:~/wazuh-agent/build$ sudo ./wazuh-agent --enroll-agent --enroll-url https://192.168.0.177:55000 --user wazuh --password wazuh
Starting wazuh-agent enrollment
wazuh-agent enrolled
nico@nico-VirtualBox:~/wazuh-agent/build$ ls /var/lib/wazuh-agent/
agent_info.db
nico@nico-VirtualBox:~/wazuh-agent/build$ sqlite3 /var/lib/wazuh-agent/agent_info.db "select * from agent_info;"
nico-VirtualBox|C3zty8vI30llJSe6VhLD6seXDBT2mqsC|9e5b3bed-d27a-4cc6-9401-d8538b7dedb8
```


```bash
nico@nico-VirtualBox:~/wazuh-agent/build$ sudo ./wazuh-agent 
[2025-02-28 09:14:07.528] [wazuh-agent] [info] [INFO] [agent_runner.cpp:195] [StartAgent] Starting wazuh-agent
[2025-02-28 09:14:07.559] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:256] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-02-28 09:14:07.560] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:256] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-02-28 09:14:08.750] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:256] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-02-28 09:14:08.751] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:235] [GetParsedConfigInRangeOrDefault] Invalid range: min value is greater or equal to max value.
[2025-02-28 09:14:09.464] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:102] [GetConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-02-28 09:14:11.673] [wazuh-agent] [info] [INFO] [communicator.cpp:109] [SendAuthenticationRequest] Successfully authenticated with the manager.
[2025-02-28 09:14:11.729] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:256] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-02-28 09:14:11.822] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:256] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-02-28 09:14:11.927] [wazuh-agent] [info] [INFO] [inventory.cpp:20] [Start] Inventory module started.
[2025-02-28 09:14:12.034] [wazuh-agent] [info] [INFO] [logcollector.cpp:28] [Start] Logcollector module is disabled.
[2025-02-28 09:14:12.039] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:988] [SyncLoop] Module started.
[2025-02-28 09:16:12.374] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:971] [Scan] Starting evaluation.
[2025-02-28 09:17:36.095] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:983] [Scan] Evaluation finished.
^C[2025-02-28 09:18:28.583] [wazuh-agent] [info] [INFO] [inventory.cpp:73] [Stop] Inventory module stopping...
[2025-02-28 09:18:28.584] [wazuh-agent] [info] [INFO] [logcollector.cpp:101] [Stop] Logcollector module stopped.
[2025-02-28 09:18:28.592] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:971] [Scan] Starting evaluation.
[2025-02-28 09:18:28.592] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:983] [Scan] Evaluation finished.
[2025-02-28 09:18:28.601] [wazuh-agent] [info] [INFO] [inventory.cpp:40] [Start] Inventory module stopped.
nico@nico-VirtualBox:~/wazuh-agent/build$ ls /var/lib/wazuh-agent/
agent_info.db  command_store.db  local.db  local.db-journal  queue.db
```

<details><summary>agent_enrollment_test</summary>

```bash
./agent_enrollment_test 
[==========] Running 8 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 8 tests from EnrollmentTest
[ RUN      ] EnrollmentTest.EnrollmentTestSuccess
[       OK ] EnrollmentTest.EnrollmentTestSuccess (2 ms)
[ RUN      ] EnrollmentTest.EnrollmentFailsIfAuthenticationFails
Error authenticating: 401.
Failed to authenticate with the manager
[       OK ] EnrollmentTest.EnrollmentFailsIfAuthenticationFails (0 ms)
[ RUN      ] EnrollmentTest.EnrollmentFailsIfServerResponseIsNotOk
Enrollment error: 400.
[       OK ] EnrollmentTest.EnrollmentFailsIfServerResponseIsNotOk (0 ms)
[ RUN      ] EnrollmentTest.EnrollmentWithoutAKeyGeneratesOneAutomatically
[       OK ] EnrollmentTest.EnrollmentWithoutAKeyGeneratesOneAutomatically (0 ms)
[ RUN      ] EnrollmentTest.EnrollmentTestFailWithBadKey
[       OK ] EnrollmentTest.EnrollmentTestFailWithBadKey (3 ms)
[ RUN      ] EnrollmentTest.EnrollmentTestFailWithHttpClientError
[       OK ] EnrollmentTest.EnrollmentTestFailWithHttpClientError (0 ms)
[ RUN      ] EnrollmentTest.AuthenticateWithUserPassword_Success
[       OK ] EnrollmentTest.AuthenticateWithUserPassword_Success (0 ms)
[ RUN      ] EnrollmentTest.AuthenticateWithUserPassword_Failure
Error authenticating: 401.
[       OK ] EnrollmentTest.AuthenticateWithUserPassword_Failure (0 ms)
[----------] 8 tests from EnrollmentTest (6 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (6 ms total)
[  PASSED  ] 8 tests.
```

</details>

<details><summary>agent_test</summary>

```bash
./agent_test 
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from AgentTests
[ RUN      ] AgentTests.AgentStopsWhenSignalReceived
[2025-02-28 12:21:30.072] [warning] [WARN] [configuration_parser.hpp:256] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-02-28 12:21:30.072] [warning] [WARN] [configuration_parser.hpp:235] [GetParsedConfigInRangeOrDefault] Invalid range: min value is greater or equal to max value.
[2025-02-28 12:21:30.073] [warning] [WARN] [configuration_parser.cpp:132] [LoadSharedConfig] Load shared configuration failed: bad file: /etc/wazuh-agent/shared/group1.yml
[2025-02-28 12:21:30.073] [warning] [WARN] [configuration_parser.hpp:102] [GetConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-02-28 12:21:30.074] [warning] [WARN] [communicator.cpp:177] [AuthenticateWithUuidAndKey] Error: 401.
[2025-02-28 12:21:30.074] [warning] [WARN] [communicator.cpp:113] [SendAuthenticationRequest] Failed to authenticate with the manager. Retrying in 30 seconds.
[2025-02-28 12:21:30.074] [warning] [WARN] [communicator.cpp:177] [AuthenticateWithUuidAndKey] Error: 401.
[2025-02-28 12:21:30.074] [warning] [WARN] [communicator.cpp:113] [SendAuthenticationRequest] Failed to authenticate with the manager. Retrying in 30 seconds.
[2025-02-28 12:21:30.077] [info] [INFO] [inventory.cpp:15] [Start] Inventory module is disabled.
[2025-02-28 12:21:30.077] [info] [INFO] [logcollector.cpp:28] [Start] Logcollector module is disabled.
[2025-02-28 12:21:30.088] [info] [INFO] [inventory.cpp:73] [Stop] Inventory module stopping...
[2025-02-28 12:21:30.088] [info] [INFO] [logcollector.cpp:101] [Stop] Logcollector module stopped.
[       OK ] AgentTests.AgentStopsWhenSignalReceived (22 ms)
[----------] 1 test from AgentTests (22 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (22 ms total)
[  PASSED  ] 1 test.
```

</details>

<details><summary>agent_info_test</summary>

```bash
./agent_info_test 
[==========] Running 14 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 14 tests from AgentInfoTest
[ RUN      ] AgentInfoTest.TestDefaultConstructorDefaultValues
[       OK ] AgentInfoTest.TestDefaultConstructorDefaultValues (1 ms)
[ RUN      ] AgentInfoTest.TestSetName
[       OK ] AgentInfoTest.TestSetName (0 ms)
[ RUN      ] AgentInfoTest.TestSetKey
[       OK ] AgentInfoTest.TestSetKey (0 ms)
[ RUN      ] AgentInfoTest.TestSetBadKey
[       OK ] AgentInfoTest.TestSetBadKey (0 ms)
[ RUN      ] AgentInfoTest.TestSetEmptyKey
[       OK ] AgentInfoTest.TestSetEmptyKey (0 ms)
[ RUN      ] AgentInfoTest.TestSetUUID
[       OK ] AgentInfoTest.TestSetUUID (0 ms)
[ RUN      ] AgentInfoTest.TestSetGroups
[       OK ] AgentInfoTest.TestSetGroups (0 ms)
[ RUN      ] AgentInfoTest.TestSaveGroupsFail
[       OK ] AgentInfoTest.TestSaveGroupsFail (0 ms)
[ RUN      ] AgentInfoTest.TestSaveGroups
[       OK ] AgentInfoTest.TestSaveGroups (0 ms)
[ RUN      ] AgentInfoTest.TestSave
[       OK ] AgentInfoTest.TestSave (0 ms)
[ RUN      ] AgentInfoTest.TestLoadMetadataInfoNoSysInfo
[       OK ] AgentInfoTest.TestLoadMetadataInfoNoSysInfo (0 ms)
[ RUN      ] AgentInfoTest.TestLoadMetadataInfoEnrollment
[       OK ] AgentInfoTest.TestLoadMetadataInfoEnrollment (1 ms)
[ RUN      ] AgentInfoTest.TestLoadMetadataInfoConnected
[       OK ] AgentInfoTest.TestLoadMetadataInfoConnected (0 ms)
[ RUN      ] AgentInfoTest.TestLoadHeaderInfo
[       OK ] AgentInfoTest.TestLoadHeaderInfo (0 ms)
[----------] 14 tests from AgentInfoTest (3 ms total)

[----------] Global test environment tear-down
[==========] 14 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 14 tests.
```

</details>

### Artifacts Affected

Executable files, all platforms.

### Configuration Changes

None

### Documentation Updates

None

### Tests Introduced

Fixed:

- AgentInfo
- Agent
- AgentEnrollment

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
