### PR TITLE
Use ubuntu-24.04 in deploy-docs gh

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
@@ -33,7 +33,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Description

This PR changes the usage of ubuntu-20.04 to ubuntu-24.04 in GitHub workflows runners.

## Proposed Changes

Change the usage of ubuntu-20.04 to ubuntu-24.04.

### Results and Evidence

N/A

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

N/A

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...
