### PR TITLE
Enable suggest-override compiler flag and InsertBraces clang-format option

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -28,6 +28,7 @@ FixNamespaceComments: 'true'
 IncludeBlocks: Preserve
 IndentCaseLabels: 'true'
 IndentWidth: '4'
+InsertBraces: 'true'
 InsertNewlineAtEOF: 'true'
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All

--- a/src/agent/command_handler/src/command_store.cpp
+++ b/src/agent/command_handler/src/command_store.cpp
@@ -323,17 +323,27 @@ namespace command_store
     {
         Row fields;
         if (!cmd.Module.empty())
+        {
             fields.emplace_back(COMMAND_STORE_MODULE_COLUMN_NAME, ColumnType::TEXT, cmd.Module);
+        }
         if (!cmd.Command.empty())
+        {
             fields.emplace_back(COMMAND_STORE_COMMAND_COLUMN_NAME, ColumnType::TEXT, cmd.Command);
+        }
         if (!cmd.Parameters.empty())
+        {
             fields.emplace_back(COMMAND_STORE_PARAMETERS_COLUMN_NAME, ColumnType::TEXT, cmd.Parameters.dump());
+        }
         if (!cmd.ExecutionResult.Message.empty())
+        {
             fields.emplace_back(COMMAND_STORE_RESULT_COLUMN_NAME, ColumnType::TEXT, cmd.ExecutionResult.Message);
+        }
         if (cmd.ExecutionResult.ErrorCode != module_command::Status::UNKNOWN)
+        {
             fields.emplace_back(COMMAND_STORE_STATUS_COLUMN_NAME,
                                 ColumnType::INTEGER,
                                 std::to_string(static_cast<int>(cmd.ExecutionResult.ErrorCode)));
+        }
 
         Criteria filters;
         filters.emplace_back(COMMAND_STORE_ID_COLUMN_NAME, ColumnType::TEXT, cmd.Id);

--- a/src/agent/http_client/src/certificate/https_verifier_win.hpp
+++ b/src/agent/http_client/src/certificate/https_verifier_win.hpp
@@ -49,17 +49,23 @@ namespace https_socket_verify_utils
             m_certContextDeleter = [this](const CERT_CONTEXT* ctx)
             {
                 if (ctx)
+                {
                     m_certStoreUtils->FreeCertificateContext(ctx);
+                }
             };
             m_certStoreDeleter = [this](HCERTSTORE store)
             {
                 if (store)
+                {
                     m_certStoreUtils->CloseStore(store, 0);
+                }
             };
             m_chainContextDeleter = [this](const CERT_CHAIN_CONTEXT* ctx)
             {
                 if (ctx)
+                {
                     m_certStoreUtils->FreeCertificateChain(ctx);
+                }
             };
         }
 

--- a/src/agent/http_client/src/http_socket_factory.hpp
+++ b/src/agent/http_client/src/http_socket_factory.hpp
@@ -22,7 +22,9 @@ namespace http_client
         std::unique_ptr<IHttpSocket> Create(const boost::asio::any_io_executor& executor, const bool use_https) override
         {
             if (use_https)
+            {
                 return std::make_unique<HttpsSocket>(executor);
+            }
 
             return std::make_unique<HttpSocket>(executor);
         }

--- a/src/agent/multitype_queue/src/storage.cpp
+++ b/src/agent/multitype_queue/src/storage.cpp
@@ -202,9 +202,13 @@ int Storage::RemoveMultiple(int n,
 {
     Criteria filters;
     if (!moduleName.empty())
+    {
         filters.emplace_back(MODULE_NAME_COLUMN_NAME, ColumnType::TEXT, moduleName);
+    }
     if (!moduleType.empty())
+    {
         filters.emplace_back(MODULE_TYPE_COLUMN_NAME, ColumnType::TEXT, moduleType);
+    }
 
     int result = 0;
 
@@ -266,9 +270,13 @@ nlohmann::json Storage::RetrieveMultiple(int n,
 
     Criteria filters;
     if (!moduleName.empty())
+    {
         filters.emplace_back(MODULE_NAME_COLUMN_NAME, ColumnType::TEXT, moduleName);
+    }
     if (!moduleType.empty())
+    {
         filters.emplace_back(MODULE_TYPE_COLUMN_NAME, ColumnType::TEXT, moduleType);
+    }
 
     Names orderColumns;
     orderColumns.emplace_back(ROW_ID_COLUMN_NAME, ColumnType::INTEGER);
@@ -300,9 +308,13 @@ nlohmann::json Storage::RetrieveBySize(size_t n,
 
     Criteria filters;
     if (!moduleName.empty())
+    {
         filters.emplace_back(MODULE_NAME_COLUMN_NAME, ColumnType::TEXT, moduleName);
+    }
     if (!moduleType.empty())
+    {
         filters.emplace_back(MODULE_TYPE_COLUMN_NAME, ColumnType::TEXT, moduleType);
+    }
 
     Names orderColumns;
     orderColumns.emplace_back(ROW_ID_COLUMN_NAME, ColumnType::INTEGER);
@@ -325,9 +337,13 @@ int Storage::GetElementCount(const std::string& tableName, const std::string& mo
 {
     Criteria filters;
     if (!moduleName.empty())
+    {
         filters.emplace_back(MODULE_NAME_COLUMN_NAME, ColumnType::TEXT, moduleName);
+    }
     if (!moduleType.empty())
+    {
         filters.emplace_back(MODULE_TYPE_COLUMN_NAME, ColumnType::TEXT, moduleType);
+    }
 
     int count = 0;
 
@@ -349,9 +365,13 @@ size_t Storage::GetElementsStoredSize(const std::string& tableName,
 {
     Criteria filters;
     if (!moduleName.empty())
+    {
         filters.emplace_back(MODULE_NAME_COLUMN_NAME, ColumnType::TEXT, moduleName);
+    }
     if (!moduleType.empty())
+    {
         filters.emplace_back(MODULE_TYPE_COLUMN_NAME, ColumnType::TEXT, moduleType);
+    }
 
     size_t count = 0;
 

--- a/src/agent/persistence/src/sqlite_manager.cpp
+++ b/src/agent/persistence/src/sqlite_manager.cpp
@@ -32,10 +32,14 @@ namespace
 ColumnType SQLiteManager::ColumnTypeFromSQLiteType(const int type) const
 {
     if (type == SQLite::INTEGER)
+    {
         return ColumnType::INTEGER;
+    }
 
     if (type == SQLite::FLOAT)
+    {
         return ColumnType::REAL;
+    }
 
     return ColumnType::TEXT;
 }

--- a/src/agent/src/instance_handler_unix.cpp
+++ b/src/agent/src/instance_handler_unix.cpp
@@ -55,7 +55,9 @@ namespace instance_handler
     void InstanceHandler::releaseInstanceLock() const
     {
         if (!m_lockAcquired)
+        {
             return;
+        }
 
         const std::string filePath = fmt::format("{}/wazuh-agent.lock", m_lockFilePath);
         try

--- a/src/cmake/ConfigureTarget.cmake
+++ b/src/cmake/ConfigureTarget.cmake
@@ -19,6 +19,7 @@ function(configure_target target)
             -Wmissing-declarations
             -Wredundant-decls
             -Wpessimizing-move
+            -Wsuggest-override
         )
         target_compile_options(${target} PRIVATE ${common_warnings})
     else()

--- a/src/common/data_provider/include/sysInfo.hpp
+++ b/src/common/data_provider/include/sysInfo.hpp
@@ -26,15 +26,15 @@ class SysInfo: public ISysInfo
         // LCOV_EXCL_START
         virtual ~SysInfo() = default;
         // LCOV_EXCL_STOP
-        nlohmann::json hardware();
-        nlohmann::json packages();
-        nlohmann::json os();
-        nlohmann::json processes();
-        nlohmann::json networks();
-        nlohmann::json ports();
-        void packages(std::function<void(nlohmann::json&)>);
-        void processes(std::function<void(nlohmann::json&)>);
-        nlohmann::json hotfixes();
+        nlohmann::json hardware() override;
+        nlohmann::json packages() override;
+        nlohmann::json os() override;
+        nlohmann::json processes() override;
+        nlohmann::json networks() override;
+        nlohmann::json ports() override;
+        void packages(std::function<void(nlohmann::json&)>) override;
+        void processes(std::function<void(nlohmann::json&)>) override;
+        nlohmann::json hotfixes() override;
     private:
         virtual nlohmann::json getHardware() const;
         virtual nlohmann::json getPackages() const;

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -163,47 +163,87 @@ cJSON* Inventory::Dump() const
 
     // System provider values
     if (m_enabled)
+    {
         cJSON_AddStringToObject(invJson, "enabled", "yes");
+    }
     else
+    {
         cJSON_AddStringToObject(invJson, "enabled", "no");
+    }
     if (m_scanOnStart)
+    {
         cJSON_AddStringToObject(invJson, "scan-on-start", "yes");
+    }
     else
+    {
         cJSON_AddStringToObject(invJson, "scan-on-start", "no");
+    }
     cJSON_AddNumberToObject(invJson, "interval", static_cast<double>(m_intervalValue));
     if (m_networks)
+    {
         cJSON_AddStringToObject(invJson, "networks", "yes");
+    }
     else
+    {
         cJSON_AddStringToObject(invJson, "networks", "no");
+    }
     if (m_system)
+    {
         cJSON_AddStringToObject(invJson, "system", "yes");
+    }
     else
+    {
         cJSON_AddStringToObject(invJson, "system", "no");
+    }
     if (m_hardware)
+    {
         cJSON_AddStringToObject(invJson, "hardware", "yes");
+    }
     else
+    {
         cJSON_AddStringToObject(invJson, "hardware", "no");
+    }
     if (m_packages)
+    {
         cJSON_AddStringToObject(invJson, "packages", "yes");
+    }
     else
+    {
         cJSON_AddStringToObject(invJson, "packages", "no");
+    }
     if (m_ports)
+    {
         cJSON_AddStringToObject(invJson, "ports", "yes");
+    }
     else
+    {
         cJSON_AddStringToObject(invJson, "ports", "no");
+    }
     if (m_portsAll)
+    {
         cJSON_AddStringToObject(invJson, "ports_all", "yes");
+    }
     else
+    {
         cJSON_AddStringToObject(invJson, "ports_all", "no");
+    }
     if (m_processes)
+    {
         cJSON_AddStringToObject(invJson, "processes", "yes");
+    }
     else
+    {
         cJSON_AddStringToObject(invJson, "processes", "no");
+    }
 #ifdef WIN32
     if (m_hotfixes)
+    {
         cJSON_AddStringToObject(invJson, "hotfixes", "yes");
+    }
     else
+    {
         cJSON_AddStringToObject(invJson, "hotfixes", "no");
+    }
 #endif
 
     cJSON_AddItemToObject(rootJson, "inventory", invJson);

--- a/src/modules/inventory/src/statelessEvent.cpp
+++ b/src/modules/inventory/src/statelessEvent.cpp
@@ -282,19 +282,33 @@ std::unique_ptr<StatelessEvent> CreateStatelessEvent(const std::string& type,
                                                      const nlohmann::json& data)
 {
     if (type == "networks")
+    {
         return std::make_unique<NetworkEvent>(operation, created, data);
+    }
     if (type == "packages")
+    {
         return std::make_unique<PackageEvent>(operation, created, data);
+    }
     if (type == "hotfixes")
+    {
         return std::make_unique<HotfixEvent>(operation, created, data);
+    }
     if (type == "ports")
+    {
         return std::make_unique<PortEvent>(operation, created, data);
+    }
     if (type == "processes")
+    {
         return std::make_unique<ProcessEvent>(operation, created, data);
+    }
     if (type == "system")
+    {
         return std::make_unique<SystemEvent>(operation, created, data);
+    }
     if (type == "hardware")
+    {
         return std::make_unique<HardwareEvent>(operation, created, data);
+    }
 
     return nullptr;
 }

--- a/src/modules/logcollector/src/file_reader/include/file_reader.hpp
+++ b/src/modules/logcollector/src/file_reader/include/file_reader.hpp
@@ -83,10 +83,10 @@ namespace logcollector
 
         /// @brief Runs the file reader
         /// @return Awaitable result
-        Awaitable Run();
+        Awaitable Run() override;
 
         /// @brief Stops the file reader
-        void Stop();
+        void Stop() override;
 
         /// @brief Reloads the file list
         ///

--- a/src/modules/logcollector/src/logcollector_osx.cpp
+++ b/src/modules/logcollector/src/logcollector_osx.cpp
@@ -29,7 +29,9 @@ namespace
             item.erase(item.begin(), std::find_if(item.begin(), item.end(), isNotSpace));
             item.erase(std::find_if(item.rbegin(), item.rend(), isNotSpace).base(), item.end());
             if (!item.empty())
+            {
                 result.push_back(item);
+            }
         }
 
         return result;

--- a/src/modules/logcollector/src/logcollector_unix.cpp
+++ b/src/modules/logcollector/src/logcollector_unix.cpp
@@ -19,7 +19,9 @@ namespace logcollector
         for (const auto& config : journaldConfigs)
         {
             if (!config.IsMap())
+            {
                 continue;
+            }
 
             if (config["conditions"])
             {


### PR DESCRIPTION
## Description

This PR enables the flag `suggest-override` on both GCC and Clang and the clang-format flag `InsertBraces`. This will enforce the usage of the `override` keyword on overridden methods and insert braces automatically with clang-format. 

## Proposed Changes

Add flag to `ConfigureTarget.cmake`, fix new warnings.
Add new option to clang-format and re format files.

### Results and Evidence

Compilation works without errors.

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
