### PR TITLE
Change agent enrollment option to --enroll

### DIFF
--- a/docs/dev/run-agent.md
+++ b/docs/dev/run-agent.md
@@ -2,14 +2,14 @@
 
 ## Enroll the Agent
 
-To allow the agent to successfully connect to a Wazuh server, it must first enroll with the server. This is done using the --enroll-agent option.
+To allow the agent to successfully connect to a Wazuh server, it must first enroll with the server. This is done using the --enroll option.
 Ensure that the server is online and ready to accept enrollment requests before proceeding.
 
 ### Enrollment Command
 
 ```
 cd build/
-./wazuh-agent --enroll-agent --enroll-url https://localhost:55000 --user <username> --password <password> [--name <agent-name>]
+./wazuh-agent --enroll --enroll-url https://localhost:55000 --user <username> --password <password> [--name <agent-name>]
 ```
 
 Replace:
@@ -24,7 +24,7 @@ For additional options and details, use:
 
 ```
 cd build/
-./wazuh-agent --enroll-agent --help
+./wazuh-agent --enroll --help
 ```
 
 ## Run the Agent on Linux

--- a/docs/ref/configuration.md
+++ b/docs/ref/configuration.md
@@ -32,7 +32,7 @@ This will start the `wazuh-agent` process with `debug` level logging, allowing f
 | `--run`               | Run agent in foreground (this is the default behavior)                                                 | N/A      |
 | `--status`            | Check if the agent is running (running or stopped)                                                     | N/A      |
 | `--config-file`       | Path to the Wazuh configuration file (optional)                                                        | N/A      |
-| `--enroll-agent`      | Use this option to enroll as a new agent                                                               | N/A      |
+| `--enroll`            | Use this option to enroll as a new agent                                                               | N/A      |
 | `--enroll-url`        | URL of the server management API enrollment endpoint                                                   | N/A      |
 | `--user`              | User to authenticate with the server management API                                                    | N/A      |
 | `--password`          | Password to authenticate with the server management API                                                | N/A      |

--- a/docs/ref/security.md
+++ b/docs/ref/security.md
@@ -19,7 +19,7 @@ The agent supports three validation modes:
 Use the `--verification-mode` flag when enrolling the agent:
 
 ```bash
-./wazuh-agent --enroll-agent --user wazuh --password wazuh --enroll-url https://server-ip:55000 --verification-mode certificate
+./wazuh-agent --enroll --user wazuh --password wazuh --enroll-url https://server-ip:55000 --verification-mode certificate
 ```
 
 #### During Agent Connection

--- a/src/agent/src/agent_runner.cpp
+++ b/src/agent/src/agent_runner.cpp
@@ -28,7 +28,7 @@ namespace
     const auto OPT_STATUS_DESC {"Check if the agent is running (running or stopped)"};
     const auto OPT_CONFIG_FILE {"config-file"};
     const auto OPT_CONFIG_FILE_DESC {"Path to the Wazuh configuration file (optional)"};
-    const auto OPT_ENROLL_AGENT {"enroll-agent"};
+    const auto OPT_ENROLL_AGENT {"enroll"};
     const auto OPT_ENROLL_AGENT_DESC {"Use this option to enroll as a new agent"};
     const auto OPT_ENROLL_URL {"enroll-url"};
     const auto OPT_ENROLL_URL_DESC {"URL of the server management API enrollment endpoint"};


### PR DESCRIPTION
## Description

This PR closes #655. We are replacing the enrollment option `--enroll-agent` with `--enroll`.

## Proposed Changes

### Results and Evidence

```
./wazuh-agent --enroll --help
```
> ```
> Enrollment options:
>   --enroll-url arg                URL of the server management API enrollment endpoint
>   --user arg                      User to authenticate with the server management API
>   --password arg                  Password to authenticate with the server management API
>   --connect-url arg               URL of the server. This option overwrites the server URL in the configuration
>                                   wazuh-agent.yaml file (optional)
>   --key arg                       Key to enroll the agent (optional)
>   --name arg                      Name to enroll the agent (optional)
>   --verification-mode arg (=none) Verification mode to be applied on HTTPS connection to the server (optional)
> ```

```
./wazuh-agent --config-file wazuh-agent.yml --enroll --enroll-url https://localhost:55000 --user wazuh --password topsecret --name dummy
```
> ```
> Starting wazuh-agent enrollment
> wazuh-agent enrolled
> ```

### Artifacts Affected

- wazuh-agent binary

### Configuration Changes

No changes.

### Documentation Updates

- Development guide
- Reference documentation
- Security guide

### Tests Introduced

No tests changed.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues