### PR TITLE
Improve implementation of tests

### DIFF
--- a/src/agent/include/agent.hpp
+++ b/src/agent/include/agent.hpp
@@ -26,7 +26,7 @@ class Agent
 {
 public:
     /// @brief Constructor
-    /// @param configFilePath Path to the configuration file
+    /// @param configurationParser Pointer to ConfigurationParser instance
     /// @param signalHandler Pointer to a custom ISignalHandler implementation
     /// @param httpClient Pointer to an IHttpClient implementation
     /// @param agentInfo Pointer to a custom IAgentInfo implementation
@@ -34,7 +34,8 @@ public:
     /// @param messageQueue Pointer to a custom IMultiTypeQueue implementation
     /// @throws std::runtime_error If the Agent is not enrolled
     /// @throws Any exception propagated from dependencies used within the constructor
-    Agent(const std::string& configFilePath,
+    Agent(std::unique_ptr<configuration::ConfigurationParser> configurationParser =
+              std::make_unique<configuration::ConfigurationParser>(),
           std::unique_ptr<ISignalHandler> signalHandler = std::make_unique<SignalHandler>(),
           std::unique_ptr<http_client::IHttpClient> httpClient = nullptr,
           std::unique_ptr<IAgentInfo> agentInfo = nullptr,

--- a/src/agent/src/agent.cpp
+++ b/src/agent/src/agent.cpp
@@ -13,19 +13,16 @@
 
 #include <nlohmann/json.hpp>
 
-#include <filesystem>
 #include <memory>
 
-Agent::Agent(const std::string& configFilePath,
+Agent::Agent(std::unique_ptr<configuration::ConfigurationParser> configurationParser,
              std::unique_ptr<ISignalHandler> signalHandler,
              std::unique_ptr<http_client::IHttpClient> httpClient,
              std::unique_ptr<IAgentInfo> agentInfo,
              std::unique_ptr<command_handler::ICommandHandler> commandHandler,
              std::shared_ptr<IMultiTypeQueue> messageQueue)
     : m_signalHandler(std::move(signalHandler))
-    , m_configurationParser(configFilePath.empty() ? std::make_shared<configuration::ConfigurationParser>()
-                                                   : std::make_shared<configuration::ConfigurationParser>(
-                                                         std::filesystem::path(configFilePath)))
+    , m_configurationParser(std::move(configurationParser))
     , m_agentInfo(agentInfo
                       ? std::move(agentInfo)
                       : std::make_unique<AgentInfo>(

--- a/src/agent/src/agent_runner.cpp
+++ b/src/agent/src/agent_runner.cpp
@@ -9,6 +9,7 @@
 #include <logger.hpp>
 #include <restart_handler.hpp>
 
+#include <filesystem>
 #include <fmt/format.h>
 
 #include <iostream>
@@ -194,7 +195,7 @@ int AgentRunner::StartAgent() const
 
         LogInfo("Starting wazuh-agent");
 
-        Agent agent(configFilePath);
+        Agent agent(std::make_unique<configuration::ConfigurationParser>(std::filesystem::path(configFilePath)));
         agent.Run();
     }
     catch (const std::exception& e)

--- a/src/agent/src/instance_handler.hpp
+++ b/src/agent/src/instance_handler.hpp
@@ -57,11 +57,15 @@ namespace instance_handler
 
     /// @brief Gets the status of the daemon
     /// @param configFilePath The path to the configuration file
+    /// @param fileSystemWrapper An optional filesystem wrapper to allow for a mock to be passed in unit tests
     /// @return A string indicating whether the daemon is "running" or "stopped"
-    std::string GetAgentStatus(const std::string& configFilePath);
+    std::string GetAgentStatus(const std::string& configFilePath,
+                               std::shared_ptr<IFileSystemWrapper> fileSystemWrapper = nullptr);
 
     /// @brief Generates an instance handler for the daemon
     /// @param configFilePath The path to the configuration file
+    /// @param fileSystemWrapper An optional filesystem wrapper to allow for a mock to be passed in unit tests
     /// @return An InstanceHandler object
-    InstanceHandler GetInstanceHandler(const std::string& configFilePath);
+    InstanceHandler GetInstanceHandler(const std::string& configFilePath,
+                                       std::shared_ptr<IFileSystemWrapper> fileSystemWrapper = nullptr);
 } // namespace instance_handler

--- a/src/agent/src/instance_handler_unix.cpp
+++ b/src/agent/src/instance_handler_unix.cpp
@@ -102,7 +102,8 @@ namespace instance_handler
         return true;
     }
 
-    InstanceHandler GetInstanceHandler(const std::string& configFilePath)
+    InstanceHandler GetInstanceHandler(const std::string& configFilePath,
+                                       std::shared_ptr<IFileSystemWrapper> fileSystemWrapper)
     {
         const auto configurationParser =
             configFilePath.empty() ? configuration::ConfigurationParser()
@@ -110,12 +111,12 @@ namespace instance_handler
 
         const auto lockFilePath = configurationParser.GetConfigOrDefault(config::DEFAULT_RUN_PATH, "agent", "path.run");
 
-        return {InstanceHandler(lockFilePath)};
+        return {InstanceHandler(lockFilePath, fileSystemWrapper)};
     }
 
-    std::string GetAgentStatus(const std::string& configFilePath)
+    std::string GetAgentStatus(const std::string& configFilePath, std::shared_ptr<IFileSystemWrapper> fileSystemWrapper)
     {
-        const InstanceHandler instanceHandler = GetInstanceHandler(configFilePath);
+        const InstanceHandler instanceHandler = GetInstanceHandler(configFilePath, fileSystemWrapper);
 
         if (!instanceHandler.isLockAcquired())
         {

--- a/src/agent/src/instance_handler_win.cpp
+++ b/src/agent/src/instance_handler_win.cpp
@@ -56,7 +56,8 @@ namespace instance_handler
 
     void InstanceHandler::releaseInstanceLock() const {}
 
-    std::string GetAgentStatus(const std::string& configFilePath)
+    std::string GetAgentStatus(const std::string& configFilePath,
+                               [[maybe_unused]] std::shared_ptr<IFileSystemWrapper> fileSystemWrapper)
     {
         InstanceHandler instanceHandler = GetInstanceHandler(configFilePath);
 

--- a/src/agent/src/instance_handler_win.cpp
+++ b/src/agent/src/instance_handler_win.cpp
@@ -48,7 +48,8 @@ namespace instance_handler
         return true;
     }
 
-    InstanceHandler GetInstanceHandler([[maybe_unused]] const std::string& configFilePath)
+    InstanceHandler GetInstanceHandler([[maybe_unused]] const std::string& configFilePath,
+                                       [[maybe_unused]] std::shared_ptr<IFileSystemWrapper> fileSystemWrapper)
     {
         return {InstanceHandler("")};
     }

--- a/src/agent/src/windows/windows_service.cpp
+++ b/src/agent/src/windows/windows_service.cpp
@@ -238,7 +238,7 @@ namespace windows_service
 
             LogInfo("Starting Wazuh Agent.");
 
-            Agent agent(configFilePath);
+            Agent agent(std::make_unique<configuration::ConfigurationParser>(std::filesystem::path(configFilePath)));
             agent.Run();
         }
         catch (const std::exception& e)

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -40,8 +40,10 @@ add_test(NAME MessageQueueUtilsTest COMMAND message_queue_utils_test)
 if(UNIX)
     add_executable(instance_handler_test instance_handler_test.cpp)
     configure_target(instance_handler_test)
-    target_include_directories(instance_handler_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-    target_link_libraries(instance_handler_test PRIVATE Agent GTest::gtest)
+    target_include_directories(instance_handler_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../common/file_helper/filesystem/tests/mocks/)
+    target_link_libraries(instance_handler_test PRIVATE Agent GTest::gtest GTest::gmock)
     add_test(NAME InstanceHandlerTest COMMAND instance_handler_test)
 endif()
 

--- a/src/agent/tests/instance_handler_test.cpp
+++ b/src/agent/tests/instance_handler_test.cpp
@@ -1,6 +1,8 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <instance_handler.hpp>
+#include <mock_filesystem_wrapper.hpp>
 
 #include <filesystem>
 #include <fstream>
@@ -9,6 +11,17 @@ class InstanceHandlerTest : public ::testing::Test
 {
 protected:
     static std::filesystem::path m_tempConfigFilePath;
+    std::shared_ptr<MockFileSystemWrapper> m_fileSystemWrapper;
+
+    void SetUp() override
+    {
+        m_fileSystemWrapper = std::make_shared<MockFileSystemWrapper>();
+    }
+
+    void TearDown() override
+    {
+        m_fileSystemWrapper.reset();
+    }
 
     static void SetUpTestSuite()
     {
@@ -32,41 +45,92 @@ std::filesystem::path InstanceHandlerTest::m_tempConfigFilePath;
 
 TEST_F(InstanceHandlerTest, GetInstanceLock)
 {
-    auto instanceHandler = instance_handler::GetInstanceHandler("./temp_wazuh-agent.yml");
+    EXPECT_CALL(*m_fileSystemWrapper, exists(testing::_)).WillOnce(::testing::Return(false));
+    EXPECT_CALL(*m_fileSystemWrapper, create_directories(testing::_)).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, open(testing::_, testing::_, testing::_)).WillOnce(::testing::Return(1));
+    EXPECT_CALL(*m_fileSystemWrapper, flock(testing::_, testing::_)).WillOnce(::testing::Return(1));
+    EXPECT_CALL(*m_fileSystemWrapper, remove(testing::_)).WillOnce(::testing::Return(1));
+
+    auto instanceHandler = instance_handler::GetInstanceHandler("./temp_wazuh-agent.yml", m_fileSystemWrapper);
     const bool res = instanceHandler.isLockAcquired();
     ASSERT_TRUE(res);
 }
 
 TEST_F(InstanceHandlerTest, GetInstanceLockTwice)
 {
-    auto instanceHandler = instance_handler::GetInstanceHandler("./temp_wazuh-agent.yml");
-    auto instanceHandler2 = instance_handler::GetInstanceHandler("./temp_wazuh-agent.yml");
+    EXPECT_CALL(*m_fileSystemWrapper, exists(testing::_))
+        .WillOnce(::testing::Return(false))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, create_directories(testing::_)).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, open(testing::_, testing::_, testing::_)).WillRepeatedly(::testing::Return(1));
+    EXPECT_CALL(*m_fileSystemWrapper, flock(testing::_, testing::_))
+        .WillOnce(::testing::Return(1))   // the first time flock succeeds
+        .WillOnce(::testing::Return(-1)); // the second time flock fails
 
-    const bool resinstanceHandler = instanceHandler.isLockAcquired();
-    const bool resinstanceHandler2 = instanceHandler2.isLockAcquired();
+    EXPECT_CALL(*m_fileSystemWrapper, is_directory(testing::_)).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, close);
+    EXPECT_CALL(*m_fileSystemWrapper, remove(testing::_)).WillOnce(::testing::Return(1));
 
-    ASSERT_TRUE(resinstanceHandler);
-    ASSERT_FALSE(resinstanceHandler2);
+    auto instanceHandler = instance_handler::GetInstanceHandler("./temp_wazuh-agent.yml", m_fileSystemWrapper);
+    auto instanceHandler2 = instance_handler::GetInstanceHandler("./temp_wazuh-agent.yml", m_fileSystemWrapper);
+
+    const bool retInstanceHandler = instanceHandler.isLockAcquired();
+    const bool retInstanceHandler2 = instanceHandler2.isLockAcquired();
+
+    ASSERT_TRUE(retInstanceHandler);
+    ASSERT_FALSE(retInstanceHandler2);
 }
 
 TEST_F(InstanceHandlerTest, GetAgentStatusRunning)
 {
-    auto instanceHandler = instance_handler::GetInstanceHandler("./temp_wazuh-agent.yml");
-    const std::string res = instance_handler::GetAgentStatus("./temp_wazuh-agent.yml");
+    EXPECT_CALL(*m_fileSystemWrapper, exists(testing::_)).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, create_directories(testing::_)).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, open(testing::_, testing::_, testing::_)).WillRepeatedly(::testing::Return(1));
+    EXPECT_CALL(*m_fileSystemWrapper, flock(testing::_, testing::_))
+        .WillOnce(::testing::Return(1)) // the first time flock() succeeds
+        .WillOnce(::testing::Invoke(
+            [](int, int)
+            {
+                errno = EAGAIN;
+                return -1;
+            })); // the second time flock() fails and sets errno as needed in GetAgentStatus()
+    EXPECT_CALL(*m_fileSystemWrapper, is_directory(testing::_)).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, close);
+    EXPECT_CALL(*m_fileSystemWrapper, remove(testing::_)).WillRepeatedly(::testing::Return(1));
+
+    auto instanceHandler = instance_handler::GetInstanceHandler("./temp_wazuh-agent.yml", m_fileSystemWrapper);
+    const bool retInstanceHandler = instanceHandler.isLockAcquired();
+    ASSERT_TRUE(retInstanceHandler);
+
+    const std::string res = instance_handler::GetAgentStatus("./temp_wazuh-agent.yml", m_fileSystemWrapper);
     ASSERT_EQ(res, "running");
 }
 
 TEST_F(InstanceHandlerTest, GetAgentStatusStoppedPrevInstanceDestroyed)
 {
+    EXPECT_CALL(*m_fileSystemWrapper, exists(testing::_)).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, create_directories(testing::_)).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, open(testing::_, testing::_, testing::_)).WillRepeatedly(::testing::Return(1));
+    EXPECT_CALL(*m_fileSystemWrapper, flock(testing::_, testing::_)).WillRepeatedly(::testing::Return(1));
+    EXPECT_CALL(*m_fileSystemWrapper, is_directory(testing::_)).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, remove(testing::_)).WillRepeatedly(::testing::Return(1));
+
     {
-        auto instanceHandler = instance_handler::GetInstanceHandler("./temp_wazuh-agent.yml");
+        auto instanceHandler = instance_handler::GetInstanceHandler("./temp_wazuh-agent.yml", m_fileSystemWrapper);
     }
-    const std::string res = instance_handler::GetAgentStatus("./temp_wazuh-agent.yml");
+    const std::string res = instance_handler::GetAgentStatus("./temp_wazuh-agent.yml", m_fileSystemWrapper);
     ASSERT_EQ(res, "stopped");
 }
 
 TEST_F(InstanceHandlerTest, GetAgentStatusStoppedNoPrevInstance)
 {
+    EXPECT_CALL(*m_fileSystemWrapper, exists(testing::_)).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, create_directories(testing::_)).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, open(testing::_, testing::_, testing::_)).WillRepeatedly(::testing::Return(1));
+    EXPECT_CALL(*m_fileSystemWrapper, flock(testing::_, testing::_)).WillRepeatedly(::testing::Return(1));
+    EXPECT_CALL(*m_fileSystemWrapper, is_directory(testing::_)).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(*m_fileSystemWrapper, remove(testing::_)).WillRepeatedly(::testing::Return(1));
+
     const std::string res = instance_handler::GetAgentStatus("./temp_wazuh-agent.yml");
     ASSERT_EQ(res, "stopped");
 }

--- a/src/common/file_helper/CMakeLists.txt
+++ b/src/common/file_helper/CMakeLists.txt
@@ -8,7 +8,22 @@ set_common_settings()
 include(../../cmake/ConfigureTarget.cmake)
 
 # FilesystemWrapper target
-add_library(FilesystemWrapper STATIC ${CMAKE_CURRENT_SOURCE_DIR}/filesystem/src/filesystem_wrapper.cpp  ${CMAKE_CURRENT_SOURCE_DIR}/filesystem/src/filesystem_utils.cpp)
+if(WIN32)
+    set(SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/filesystem/src/filesystem_wrapper_win.cpp
+    )
+else()
+    set(SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/filesystem/src/filesystem_wrapper_unix.cpp
+    )
+endif()
+
+list(APPEND SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/filesystem/src/filesystem_wrapper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/filesystem/src/filesystem_utils.cpp
+)
+
+add_library(FilesystemWrapper STATIC ${SOURCES})
 target_include_directories(FilesystemWrapper PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/filesystem/include)
 target_link_libraries(FilesystemWrapper PRIVATE glob_helper)
 configure_target(FilesystemWrapper)

--- a/src/common/file_helper/filesystem/include/filesystem_wrapper.hpp
+++ b/src/common/file_helper/filesystem/include/filesystem_wrapper.hpp
@@ -42,5 +42,14 @@ namespace file_system
 
         /// @copydoc IFileSystemWrapper::remove
         bool remove(const std::filesystem::path& path) const override;
+
+        /// @copydoc IFileSystemWrapper::open
+        int open(const char* path, int flags, int mode) const override;
+
+        /// @copydoc IFileSystemWrapper::flock
+        int flock(int fd, int operation) const override;
+
+        /// @copydoc IFileSystemWrapper::close
+        int close(int fd) const override;
     };
 } // namespace file_system

--- a/src/common/file_helper/filesystem/include/ifilesystem_wrapper.hpp
+++ b/src/common/file_helper/filesystem/include/ifilesystem_wrapper.hpp
@@ -65,4 +65,22 @@ public:
     /// @param path The file or directory to remove.
     /// @return Returns true if the file or directory was successfully removed, otherwise false.
     virtual bool remove(const std::filesystem::path& path) const = 0;
+
+    /// @brief Opens a file
+    /// @param path The file to open
+    /// @param flags Flags to use when opening the file
+    /// @param mode Mode to use when opening the file
+    /// @return File descriptor or -1 on error
+    virtual int open(const char* path, int flags, int mode) const = 0;
+
+    /// @brief Applies or removes a lock on an open file descriptor
+    /// @param fd File descriptor
+    /// @param operation Lock operation
+    /// @return 0 on success, -1 on error
+    virtual int flock(int fd, int operation) const = 0;
+
+    /// @brief Closes a file descriptor
+    /// @param fd File descriptor
+    /// @return 0 on success, -1 on error
+    virtual int close(int fd) const = 0;
 };

--- a/src/common/file_helper/filesystem/src/filesystem_wrapper_unix.cpp
+++ b/src/common/file_helper/filesystem/src/filesystem_wrapper_unix.cpp
@@ -1,0 +1,23 @@
+#include <filesystem_wrapper.hpp>
+
+#include <sys/file.h>
+#include <unistd.h>
+
+namespace file_system
+{
+    int FileSystemWrapper::open(const char* path, int flags, int mode) const
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+        return ::open(path, flags, mode);
+    }
+
+    int FileSystemWrapper::flock(int fd, int operation) const
+    {
+        return ::flock(fd, operation);
+    }
+
+    int FileSystemWrapper::close(int fd) const
+    {
+        return ::close(fd);
+    }
+} // namespace file_system

--- a/src/common/file_helper/filesystem/src/filesystem_wrapper_win.cpp
+++ b/src/common/file_helper/filesystem/src/filesystem_wrapper_win.cpp
@@ -1,0 +1,20 @@
+#include <filesystem_wrapper.hpp>
+
+namespace file_system
+{
+    int
+    FileSystemWrapper::open([[maybe_unused]] const char*, [[maybe_unused]] int flags, [[maybe_unused]] int mode) const
+    {
+        return 0;
+    }
+
+    int FileSystemWrapper::flock([[maybe_unused]] int fd, [[maybe_unused]] int operation) const
+    {
+        return 0;
+    }
+
+    int FileSystemWrapper::close([[maybe_unused]] int fd) const
+    {
+        return 0;
+    }
+} // namespace file_system

--- a/src/common/file_helper/filesystem/tests/mocks/mock_filesystem_wrapper.hpp
+++ b/src/common/file_helper/filesystem/tests/mocks/mock_filesystem_wrapper.hpp
@@ -18,4 +18,7 @@ public:
                 (const, override));
     MOCK_METHOD(void, rename, (const std::filesystem::path& from, const std::filesystem::path& to), (const, override));
     MOCK_METHOD(bool, remove, (const std::filesystem::path& path), (const, override));
+    MOCK_METHOD(int, open, (const char* path, int flags, int mode), (const, override));
+    MOCK_METHOD(int, flock, (int fd, int operation), (const, override));
+    MOCK_METHOD(int, close, (int fd), (const, override));
 };


### PR DESCRIPTION
## Description

Re implement unit tests as necessary so that no files are created / read during unit tests.

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes
- Modify GetInstanceHandler() and GetAgentStatus() functions to take a FileSystemWrapper parameter that will allow to pass a mock instead in unit tests.
- Add missing functions to IFileSystemWrapper to allow more thorough testing:
  - open()
  - flock()
  - close()
- Modify InstanceHandlerTest to use the new mock and avoid using real files on disk.

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence
```
╭─ariel@ariel-work-asus ~/Documents/wazuh-agent/src/build ‹enhancement/640-improve-tests●› 
╰─$ ctest    
Test project /home/ariel/Documents/wazuh-agent/src/build
      Start  1: byteArrayHelperTests
 1/54 Test  #1: byteArrayHelperTests .....................   Passed    0.00 sec
      Start  2: cmdHelperTests
 2/54 Test  #2: cmdHelperTests ...........................   Passed    0.00 sec
      Start  3: sysInfoPackagesLinuxHelper_unit_test
 3/54 Test  #3: sysInfoPackagesLinuxHelper_unit_test .....   Passed    0.00 sec
      Start  4: sysInfoPackagesBerkeleyDB_unit_test
 4/54 Test  #4: sysInfoPackagesBerkeleyDB_unit_test ......   Passed    0.00 sec
      Start  5: sysInfoNetworkLinux_unit_test
 5/54 Test  #5: sysInfoNetworkLinux_unit_test ............   Passed    0.00 sec
      Start  6: sysInfoRpm_unit_test
 6/54 Test  #6: sysInfoRpm_unit_test .....................   Passed    0.00 sec
      Start  7: sysInfoPackageLinuxParserRPM_unit_test
 7/54 Test  #7: sysInfoPackageLinuxParserRPM_unit_test ...   Passed    0.00 sec
      Start  8: sysinfo_unit_test
 8/54 Test  #8: sysinfo_unit_test ........................   Passed    0.01 sec
      Start  9: sysInfoPackages_unit_test
 9/54 Test  #9: sysInfoPackages_unit_test ................   Passed    0.00 sec
      Start 10: sysInfoPort_unit_test
10/54 Test #10: sysInfoPort_unit_test ....................   Passed    0.00 sec
      Start 11: dbsync_unit_test
11/54 Test #11: dbsync_unit_test .........................   Passed    0.07 sec
      Start 12: dbsyncPipelineFactory_unit_test
12/54 Test #12: dbsyncPipelineFactory_unit_test ..........   Passed    0.01 sec
      Start 13: dbengine_unit_test
13/54 Test #13: dbengine_unit_test .......................   Passed    0.00 sec
      Start 14: fim_integration_test
14/54 Test #14: fim_integration_test .....................   Passed    0.25 sec
      Start 15: Filesystem
15/54 Test #15: Filesystem ...............................   Passed    0.00 sec
      Start 16: FileIO
16/54 Test #16: FileIO ...................................   Passed    0.00 sec
      Start 17: globHelperTests
17/54 Test #17: globHelperTests ..........................   Passed    0.00 sec
      Start 18: hashHelperTests
18/54 Test #18: hashHelperTests ..........................   Passed    0.01 sec
      Start 19: jsonHelperTests
19/54 Test #19: jsonHelperTests ..........................   Passed    0.00 sec
      Start 20: linuxHelperTests
20/54 Test #20: linuxHelperTests .........................   Passed    0.02 sec
      Start 21: LoggerTest
21/54 Test #21: LoggerTest ...............................   Passed    0.00 sec
      Start 22: mapWrapperTests
22/54 Test #22: mapWrapperTests ..........................   Passed    0.00 sec
      Start 23: pipelineHelperTests
23/54 Test #23: pipelineHelperTests ......................   Passed    0.00 sec
      Start 24: sqliteWrapperTests
24/54 Test #24: sqliteWrapperTests .......................   Passed    0.02 sec
      Start 25: stringHelperTests
25/54 Test #25: stringHelperTests ........................   Passed    0.00 sec
      Start 26: threadDispatcherTests
26/54 Test #26: threadDispatcherTests ....................   Passed    0.00 sec
      Start 27: timeHelperTests
27/54 Test #27: timeHelperTests ..........................   Passed    0.00 sec
      Start 28: InventoryTest
28/54 Test #28: InventoryTest ............................   Passed    0.00 sec
      Start 29: InventoryImpTest
29/54 Test #29: InventoryImpTest .........................   Passed   28.02 sec
      Start 30: InvNormalizerTest
30/54 Test #30: InvNormalizerTest ........................   Passed    0.00 sec
      Start 31: StatelessEventUnitTest
31/54 Test #31: StatelessEventUnitTest ...................   Passed    0.00 sec
      Start 32: LogcollectorUnitTests
32/54 Test #32: LogcollectorUnitTests ....................   Passed    0.00 sec
      Start 33: ModuleManagerTest
33/54 Test #33: ModuleManagerTest ........................   Passed    0.03 sec
      Start 34: AgentInfoTest
34/54 Test #34: AgentInfoTest ............................   Passed    0.00 sec
      Start 35: AgentInfoPersistenceTest
35/54 Test #35: AgentInfoPersistenceTest .................   Passed    0.00 sec
      Start 36: CentralizedConfiguration
36/54 Test #36: CentralizedConfiguration .................   Passed    0.00 sec
      Start 37: CommandHandlerTest
37/54 Test #37: CommandHandlerTest .......................   Passed    2.01 sec
      Start 38: CommandStoreTest
38/54 Test #38: CommandStoreTest .........................   Passed    0.00 sec
      Start 39: CommunicatorTest
39/54 Test #39: CommunicatorTest .........................   Passed    8.01 sec
      Start 40: ConfigParserTest
40/54 Test #40: ConfigParserTest .........................   Passed    0.01 sec
      Start 41: ConfigParserUtilsTest
41/54 Test #41: ConfigParserUtilsTest ....................   Passed    0.00 sec
      Start 42: HttpClientTest
42/54 Test #42: HttpClientTest ...........................   Passed    0.00 sec
      Start 43: HttpSocketTest
43/54 Test #43: HttpSocketTest ...........................   Passed    0.00 sec
      Start 44: HttpsSocketTest
44/54 Test #44: HttpsSocketTest ..........................   Passed    0.01 sec
      Start 45: MultiTypeQueueTest
45/54 Test #45: MultiTypeQueueTest .......................   Passed    0.00 sec
      Start 46: StorageTest
46/54 Test #46: StorageTest ..............................   Passed    0.00 sec
      Start 47: SQLiteManager_test
47/54 Test #47: SQLiteManager_test .......................   Passed    0.05 sec
      Start 48: TaskManagerTest
48/54 Test #48: TaskManagerTest ..........................   Passed    0.00 sec
      Start 49: RestartHandler
49/54 Test #49: RestartHandler ...........................   Passed   11.01 sec
      Start 50: AgentTest
50/54 Test #50: AgentTest ................................   Passed    0.01 sec
      Start 51: AgentEnrollmentTest
51/54 Test #51: AgentEnrollmentTest ......................   Passed    0.00 sec
      Start 52: SignalHandlerTest
52/54 Test #52: SignalHandlerTest ........................   Passed    0.00 sec
      Start 53: MessageQueueUtilsTest
53/54 Test #53: MessageQueueUtilsTest ....................   Passed    0.00 sec
      Start 54: InstanceHandlerTest
54/54 Test #54: InstanceHandlerTest ......................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 54

Total Test time (real) =  49.65 sec
```
<!--
Provide evidence of the changes made, such as:
- Logs
- Screenshots
- Before/after comparisons
-->

### Artifacts Affected

All executables

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Documentation Updates

<!--
If applicable, list the sections of documentation that have been updated as part of this pull request.
-->

### Tests Introduced

Modifies instance_handler_test.cpp

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
