### PR TITLE
Fix msi installation failure

### DIFF
--- a/packages/windows/cleanup.ps1
+++ b/packages/windows/cleanup.ps1
@@ -11,8 +11,13 @@ $ExceptionPaths = $Exceptions | ForEach-Object { Join-Path -Path $CleanPath -Chi
 # Remove Wazuh data folder
 Get-ChildItem -Path $CleanPath -Recurse -File | ForEach-Object {
     if ($_.FullName -notin $ExceptionPaths) {
-        Write-Host "Removing file: $($_.FullName)"
-        Remove-Item -Path $_.FullName -Force
+        try {
+            Write-Host "Removing file: $($_.FullName)"
+            Remove-Item -Path $_.FullName -Force
+        } catch {
+            Write-Host "Failed to remove file: $_"
+            exit 1
+        }
     } else {
         Write-Host "Skipping file (exception): $($_.FullName)"
     }
@@ -20,14 +25,24 @@ Get-ChildItem -Path $CleanPath -Recurse -File | ForEach-Object {
 
 Get-ChildItem -Path $CleanPath -Recurse -Directory | Sort-Object -Property FullName -Descending | ForEach-Object {
     if (-not (Get-ChildItem -Path $_.FullName -Recurse)) {
-        Write-Host "Removing empty directory: $($_.FullName)"
-        Remove-Item -Path $_.FullName -Force
+        try {
+            Write-Host "Removing empty directory: $($_.FullName)"
+            Remove-Item -Path $_.FullName -Force
+        } catch {
+            Write-Host "Failed to remove empty directory: $_"
+            exit 1
+        }
     }
 }
 
 if (-not (Get-ChildItem -Path $CleanPath -Recurse)) {
-    Write-Host "Removing root directory: $CleanPath"
-    Remove-Item -Path $CleanPath -Force
+    try {
+        Write-Host "Removing root directory: $CleanPath"
+        Remove-Item -Path $CleanPath -Force
+    } catch {
+        Write-Host "Failed to remove root directory: $_"
+        exit 1
+    }
 }
 
 

--- a/packages/windows/postinstall.ps1
+++ b/packages/windows/postinstall.ps1
@@ -45,8 +45,13 @@ if (Test-Path $destinationPath) {
 
 ## Move the new configuration file
 if (Test-Path $sourcePath) {
-    Move-Item -Path $sourcePath -Destination $destinationPath -Force
-    Write-Host "Config file moved successfully."
+    try {
+        Move-Item -Path $sourcePath -Destination $destinationPath -Force
+        Write-Host "Config file moved successfully."
+    } catch {
+        Write-Host "Failed to move config file: $_"
+        exit 1
+    }
 } else {
     Write-Host "Source file not found: $sourcePath"
 }

--- a/packages/windows/wix-patch.xml
+++ b/packages/windows/wix-patch.xml
@@ -9,8 +9,8 @@
         BinaryKey="WixCA"
         DllEntry="WixQuietExec"
         Return="check"
-        Execute="immediate"
-        Impersonate="no"
+        Execute="deferred"
+        Impersonate="yes"
     />
     <CustomAction
         Id="SetCleanupCmdLine"
@@ -22,8 +22,8 @@
         BinaryKey="WixCA"
         DllEntry="WixQuietExec"
         Return="check"
-        Execute="immediate"
-        Impersonate="no"
+        Execute="deferred"
+        Impersonate="yes"
     />
     <InstallExecuteSequence>
       <Custom Action="PostInstall" After="InstallFinalize">NOT Installed</Custom>

--- a/packages/windows/wix-patch.xml
+++ b/packages/windows/wix-patch.xml
@@ -1,7 +1,9 @@
 <CPackWiXPatch>
   <CPackWiXFragment Id="#PRODUCT">
-    <Property
-        Id="WixQuietExecCmdLine"
+    <!-- PostInstall Custom Action -->
+    <CustomAction
+        Id="SetPostInstallCmdLine"
+        Property="WixQuietExecCmdLine"
         Value="&quot;powershell.exe&quot; -ExecutionPolicy Bypass -File &quot;[INSTALL_ROOT]postinstall.ps1&quot;"
     />
     <CustomAction
@@ -10,8 +12,9 @@
         DllEntry="WixQuietExec"
         Return="check"
         Execute="deferred"
-        Impersonate="yes"
+        Impersonate="no"
     />
+    <!-- CleanupScript Custom Action -->
     <CustomAction
         Id="SetCleanupCmdLine"
         Property="WixQuietExecCmdLine"
@@ -23,10 +26,12 @@
         DllEntry="WixQuietExec"
         Return="check"
         Execute="deferred"
-        Impersonate="yes"
+        Impersonate="no"
     />
+    <!-- Schedule Custom Actions -->
     <InstallExecuteSequence>
-      <Custom Action="PostInstall" After="InstallFinalize">NOT Installed</Custom>
+      <Custom Action="SetPostInstallCmdLine" Before="PostInstall">NOT Installed</Custom>
+      <Custom Action="PostInstall" Before="InstallFinalize">NOT Installed</Custom>
       <Custom Action="SetCleanupCmdLine" Before="CleanupScript">REMOVE="ALL"</Custom>
       <Custom Action="CleanupScript" Before="InstallFinalize">REMOVE="ALL"</Custom>
     </InstallExecuteSequence>

--- a/packages/windows/wix-patch.xml
+++ b/packages/windows/wix-patch.xml
@@ -1,10 +1,11 @@
 <CPackWiXPatch>
   <CPackWiXFragment Id="#PRODUCT">
     <!-- PostInstall Custom Action -->
-    <CustomAction
-        Id="SetPostInstallCmdLine"
-        Property="WixQuietExecCmdLine"
+    <SetProperty
+        Id="PostInstall"
         Value="&quot;powershell.exe&quot; -ExecutionPolicy Bypass -File &quot;[INSTALL_ROOT]postinstall.ps1&quot;"
+        Sequence="execute"
+        Before="PostInstall"
     />
     <CustomAction
         Id="PostInstall"
@@ -15,10 +16,11 @@
         Impersonate="no"
     />
     <!-- CleanupScript Custom Action -->
-    <CustomAction
-        Id="SetCleanupCmdLine"
-        Property="WixQuietExecCmdLine"
+    <SetProperty
+        Id="CleanupScript"
         Value="&quot;powershell.exe&quot; -ExecutionPolicy Bypass -File &quot;[INSTALL_ROOT]cleanup.ps1&quot;"
+        Sequence="execute"
+        Before="CleanupScript"
     />
     <CustomAction
         Id="CleanupScript"
@@ -30,10 +32,8 @@
     />
     <!-- Schedule Custom Actions -->
     <InstallExecuteSequence>
-      <Custom Action="SetPostInstallCmdLine" Before="PostInstall">NOT Installed</Custom>
       <Custom Action="PostInstall" Before="InstallFinalize">NOT Installed</Custom>
-      <Custom Action="SetCleanupCmdLine" Before="CleanupScript">REMOVE="ALL"</Custom>
-      <Custom Action="CleanupScript" Before="InstallFinalize">REMOVE="ALL"</Custom>
+      <Custom Action="CleanupScript" Before="RemoveFiles">Installed AND REMOVE~="ALL"</Custom>
     </InstallExecuteSequence>
   </CPackWiXFragment>
 </CPackWiXPatch>


### PR DESCRIPTION
## Description

This pull request resolves the privilege elevation issues during the installation of the Windows package.

## Proposed Changes

The changes made to the `wix-patch.xml` file resolve inconsistencies in the definition of the commands for executing the post-install and cleanup scripts, as the previous format was not supported in WiX3. With these changes and a minor modification to the execution sequence, the privilege issues are resolved.

### Results and Evidence

- Powershell (no admin)
  - [Install](https://github.com/user-attachments/files/19343549/installPSnoAdmin.log)
  - [Uninstall](https://github.com/user-attachments/files/19343553/uninstallPSnoAdmin.log)

- Powershell (admin)
  - [Install](https://github.com/user-attachments/files/19343569/installPSAdmin.log)
  - [Uninstall](https://github.com/user-attachments/files/19343571/uninstallPSAdmin.log)

- GUI
  - Install
  
    ![image](https://github.com/user-attachments/assets/1d5ad847-c0ec-42e0-a111-1464b35645c4)

  - Uninstall
    ![image](https://github.com/user-attachments/assets/18b37af1-bb19-4de6-ba75-0b200e54f6f3)
    ![image](https://github.com/user-attachments/assets/4956e6f2-96f2-4831-a434-48293f083c01)

The error:  

`The System Restore service is disabled. Returned status: 1058. GetLastError() returned: 1058` 

is due to system restore protection possibly being disabled in the system properties. When it is enabled as shown below, the error disappears from the log when using some of the installation methods tested above.

- Restore Settings
    ![image](https://github.com/user-attachments/assets/98fc3479-0d2e-4203-b154-7679ca647cbe)

- [Install](https://github.com/user-attachments/files/19344030/installProtectionOn.log)

```
MSI (s) (FC:74) [16:28:00:653]: Calling SRSetRestorePoint API. dwRestorePtType: 0, dwEventType: 102, llSequenceNumber: 0, szDescription: "Installed Wazuh Agent".
MSI (s) (FC:74) [16:28:07:047]: The call to SRSetRestorePoint API succeeded. Returned status: 0, llSequenceNumber: 1.
```

### Artifacts Affected

- MSI Windows packages

### Configuration Changes

None

### Documentation Updates

None

### Tests Introduced

None

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
