### PR TITLE
Standardize short commit hash length to 7 characters

### DIFF
--- a/packages/build.sh
+++ b/packages/build.sh
@@ -108,9 +108,9 @@ fi
 if [ ! -d "/wazuh-local-src" ] ; then
   git clone --branch ${WAZUH_BRANCH} --single-branch https://github.com/wazuh/wazuh-agent.git
   short_commit_hash="$(curl -s https://api.github.com/repos/wazuh/wazuh-agent/commits/${WAZUH_BRANCH} \
-                          | grep '"sha"' | head -n 1| cut -d '"' -f 4 | cut -c 1-11)"
+                          | grep '"sha"' | head -n 1| cut -d '"' -f 4 | cut -c 1-7)"
 else
-  short_commit_hash="$(cd /wazuh-local-src && git rev-parse --short HEAD)"
+  short_commit_hash="$(cd /wazuh-local-src && git rev-parse --short=7 HEAD)"
 fi
 
 # Build directories

--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -146,7 +146,7 @@ function build_package() {
         cd $WAZUH_PATH
     fi
 
-    short_commit_hash="$(cd "${WAZUH_PATH}" && git rev-parse --short HEAD)"
+    short_commit_hash="$(cd "${WAZUH_PATH}" && git rev-parse --short=7 HEAD)"
     WAZUH_PACKAGES_PATH="${WAZUH_PATH}/packages/macos"
     VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' ${WAZUH_PATH}/VERSION.json)"
 

--- a/src/cmake/PrepareVersionFileForInstallation.cmake
+++ b/src/cmake/PrepareVersionFileForInstallation.cmake
@@ -6,7 +6,7 @@
 file(READ "${CMAKE_SOURCE_DIR}/../VERSION.json" VERSION_JSON)
 
 execute_process(
-    COMMAND git rev-parse --short HEAD
+    COMMAND git rev-parse --short=7 HEAD
     OUTPUT_VARIABLE GIT_SHORT_COMMIT
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )


### PR DESCRIPTION
## Description

This PR sets the commit hash length to 7.

Note: a different length without this limit was only observed in macOS.

## Proposed Changes

Use the short option in the git command to set the length.
Change cut commands to 7 instead of 10.

### Results and Evidence

### Artifacts Affected

All Agent v5.0 artifacts should now have a commit hash length of 7 in their naming, when applicable. VERSION.json file included in the package will have this limit as well.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
