### PR TITLE
Correct action path for Linux package testing

### DIFF
--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -225,7 +225,7 @@ jobs:
           persist-credentials: false
 
       - name: Test package on ${{ matrix.distro_name }}
-        uses: .github/actions/5_testcomponent_install_linux
+        uses: ./.github/actions/5_testcomponent_install_linux
         with:
           system: rpm
           tested_image: ${{ matrix.distro_name }}


### PR DESCRIPTION
Closes https://github.com/wazuh/wazuh-agent/issues/696

## Description

This PR fixes the path for a workflow action that was causing workflows to fail.

## Proposed Changes

Fix path of action for `Test package...` step in `5_builderpackage_agent-linux.yml`.

## Evidence

Previously the workflow failed without even starting, now it ran past beyond that point:
https://github.com/wazuh/wazuh-agent/actions/runs/14062272189

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

