### PR TITLE
Gracefully shutdown sockets

### DIFF
--- a/src/agent/http_client/src/http_client.cpp
+++ b/src/agent/http_client/src/http_client.cpp
@@ -161,6 +161,12 @@ namespace http_client
 
             LogDebug("Request {}: Status {}", params.Endpoint, res.result_int());
             LogTrace("{}", ResponseToString(params.Endpoint, res));
+
+            socket->Shutdown(ec);
+            if (ec)
+            {
+                throw std::runtime_error("Error shutting down socket: " + ec.message());
+            }
         }
         catch (const std::exception& e)
         {
@@ -232,6 +238,12 @@ namespace http_client
 
             LogDebug("Request {}: Status {}", params.Endpoint, res.result_int());
             LogTrace("{}", ResponseToString(params.Endpoint, res));
+
+            socket->Shutdown(ec);
+            if (ec)
+            {
+                throw std::runtime_error("Error shutting down socket: " + ec.message());
+            }
         }
         catch (const std::exception& e)
         {

--- a/src/agent/http_client/src/http_socket.cpp
+++ b/src/agent/http_client/src/http_socket.cpp
@@ -116,15 +116,15 @@ namespace http_client
         }
     }
 
-    void HttpSocket::Close()
+    void HttpSocket::Shutdown(boost::system::error_code& ec)
     {
         try
         {
-            m_socket->close();
+            m_socket->shutdown(ec);
         }
         catch (const std::exception& e)
         {
-            LogDebug("Exception thrown on socket closing: {}", e.what());
+            LogDebug("Exception thrown on socket shutdown: {}", e.what());
         }
     }
 } // namespace http_client

--- a/src/agent/http_client/src/http_socket.hpp
+++ b/src/agent/http_client/src/http_socket.hpp
@@ -52,8 +52,8 @@ namespace http_client
         boost::asio::awaitable<void> AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
                                                boost::system::error_code& ec) override;
 
-        /// @copydoc IHttpSocket::Close
-        void Close() override;
+        /// @copydoc IHttpSocket::Shutdown
+        void Shutdown(boost::system::error_code& ec) override;
 
     private:
         /// @brief The socket to use for the HTTP connection

--- a/src/agent/http_client/src/http_socket_wrapper.hpp
+++ b/src/agent/http_client/src/http_socket_wrapper.hpp
@@ -73,9 +73,9 @@ namespace http_client
                 m_socket, buffer, res, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         }
 
-        void close() override
+        void shutdown(boost::system::error_code& ec) override
         {
-            m_socket.close();
+            m_socket.socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_both, ec);
         }
 
     private:

--- a/src/agent/http_client/src/https_socket.cpp
+++ b/src/agent/http_client/src/https_socket.cpp
@@ -141,15 +141,15 @@ namespace http_client
         }
     }
 
-    void HttpsSocket::Close()
+    void HttpsSocket::Shutdown(boost::system::error_code& ec)
     {
         try
         {
-            m_ssl_socket->close();
+            m_ssl_socket->shutdown(ec);
         }
         catch (const std::exception& e)
         {
-            LogDebug("Exception thrown on socket closing: {}", e.what());
+            LogDebug("Exception thrown on socket shutdown: {}", e.what());
         }
     }
 

--- a/src/agent/http_client/src/https_socket.hpp
+++ b/src/agent/http_client/src/https_socket.hpp
@@ -54,8 +54,8 @@ namespace http_client
         boost::asio::awaitable<void> AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
                                                boost::system::error_code& ec) override;
 
-        /// @copydoc IHttpSocket::Close
-        void Close() override;
+        /// @copydoc IHttpSocket::Shutdown
+        void Shutdown(boost::system::error_code& ec) override;
 
     private:
         /// @brief The SSL context to use for the socket

--- a/src/agent/http_client/src/https_socket_wrapper.hpp
+++ b/src/agent/http_client/src/https_socket_wrapper.hpp
@@ -114,9 +114,9 @@ namespace http_client
                 m_socket, buffer, res, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         }
 
-        void close() override
+        void shutdown(boost::system::error_code& ec) override
         {
-            m_socket.shutdown();
+            m_socket.next_layer().socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_both, ec);
         }
 
     private:

--- a/src/agent/http_client/src/ihttp_socket.hpp
+++ b/src/agent/http_client/src/ihttp_socket.hpp
@@ -71,7 +71,7 @@ namespace http_client
         AsyncRead(boost::beast::http::response<boost::beast::http::dynamic_body>& res,
                   boost::system::error_code& ec) = 0;
 
-        /// @brief Closes the socket
-        virtual void Close() = 0;
+        /// @brief Shuts down the socket
+        virtual void Shutdown(boost::system::error_code& ec) = 0;
     };
 } // namespace http_client

--- a/src/agent/http_client/src/ihttp_socket_wrapper.hpp
+++ b/src/agent/http_client/src/ihttp_socket_wrapper.hpp
@@ -45,7 +45,7 @@ namespace http_client
                    boost::beast::http::response<boost::beast::http::dynamic_body>& res,
                    boost::system::error_code& ec) = 0;
 
-        virtual void close() = 0;
+        virtual void shutdown(boost::system::error_code& ec) = 0;
     };
 
 } // namespace http_client

--- a/src/agent/http_client/tests/http_socket_test.cpp
+++ b/src/agent/http_client/tests/http_socket_test.cpp
@@ -406,11 +406,11 @@ TEST_F(HttpSocketTest, CloseSocket)
 {
     EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _)).Times(1);
-    EXPECT_CALL(*m_mockHelper, close()).Times(1);
+    EXPECT_CALL(*m_mockHelper, shutdown(_)).Times(1);
 
     boost::system::error_code ec;
     m_socket->Connect(dummyResults, ec);
-    EXPECT_NO_THROW(m_socket->Close());
+    EXPECT_NO_THROW(m_socket->Shutdown(ec));
 }
 
 int main(int argc, char** argv)

--- a/src/agent/http_client/tests/https_socket_test.cpp
+++ b/src/agent/http_client/tests/https_socket_test.cpp
@@ -406,11 +406,11 @@ TEST_F(HttpsSocketTest, CloseSocket)
 {
     EXPECT_CALL(*m_mockHelper, expires_after(_)).Times(1);
     EXPECT_CALL(*m_mockHelper, connect(_, _)).Times(1);
-    EXPECT_CALL(*m_mockHelper, close()).Times(1);
+    EXPECT_CALL(*m_mockHelper, shutdown(_)).Times(1);
 
     boost::system::error_code ec;
     m_socket->Connect(dummyResults, ec);
-    EXPECT_NO_THROW(m_socket->Close());
+    EXPECT_NO_THROW(m_socket->Shutdown(ec));
 }
 
 int main(int argc, char** argv)

--- a/src/agent/http_client/tests/mocks/mock_http_socket.hpp
+++ b/src/agent/http_client/tests/mocks/mock_http_socket.hpp
@@ -39,5 +39,5 @@ public:
                 (boost::beast::http::response<boost::beast::http::dynamic_body> & res, boost::system::error_code& ec),
                 (override));
 
-    MOCK_METHOD(void, ShutDown, (boost::beast::error_code & ec), (override));
+    MOCK_METHOD(void, Shutdown, (boost::system::error_code & ec), (override));
 };

--- a/src/agent/http_client/tests/mocks/mock_http_socket.hpp
+++ b/src/agent/http_client/tests/mocks/mock_http_socket.hpp
@@ -39,5 +39,5 @@ public:
                 (boost::beast::http::response<boost::beast::http::dynamic_body> & res, boost::system::error_code& ec),
                 (override));
 
-    MOCK_METHOD(void, Close, (), (override));
+    MOCK_METHOD(void, ShutDown, (boost::beast::error_code & ec), (override));
 };

--- a/src/agent/http_client/tests/mocks/mock_http_wrapper.hpp
+++ b/src/agent/http_client/tests/mocks/mock_http_wrapper.hpp
@@ -38,5 +38,5 @@ public:
                  boost::beast::http::response<boost::beast::http::dynamic_body>&,
                  boost::system::error_code&),
                 (override));
-    MOCK_METHOD(void, close, (), (override));
+    MOCK_METHOD(void, shutdown, (boost::system::error_code&), (override));
 };


### PR DESCRIPTION
## Description

This PR aims to make sure the sockets are properly shutdown before closing

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

- Add shutdown() function to wrappers and utils.
- Implement the use of shutdown() function in HttpClient.
- Remove unused close() function.
- 
<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

- Tests passed:

![image](https://github.com/user-attachments/assets/4fd329f1-3c50-446d-bea1-fa566173405e)


- Agent enrollment against latest server:

![image](https://github.com/user-attachments/assets/8cd7381a-433e-4008-9056-1e353221c45c)

- Ports after agent enrollment (remain in TIME_WAIT state for MSL period and then are closed):

![image](https://github.com/user-attachments/assets/30ececfa-b229-4283-9d5e-73f4e40144a4)

- Agent running against latest server:

![image](https://github.com/user-attachments/assets/0d0a128f-a0ab-4afa-8ec8-0f305557afce)

- Ports after agent is closed (remain in TIME_WAIT state and are progressively closed):

![image](https://github.com/user-attachments/assets/2d1e4dca-c633-491c-a6c0-c3281721a98d)


### Artifacts Affected

All executables.


### Configuration Changes

None

### Documentation Updates

None

### Tests Introduced

None

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
