### PR TITLE
Define a default configuration per platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ __pycache__
 venv
 
 doxygen/
+
+# config result
+etc/config/wazuh-agent.yml

--- a/etc/config/wazuh_agent_linux.yml
+++ b/etc/config/wazuh_agent_linux.yml
@@ -1,0 +1,26 @@
+agent:
+  thread_count: 4
+  server_url: https://localhost:27000
+  retry_interval: 30s
+  verification_mode: none
+  queue_size: 10000
+events:
+  batch_interval: 10s
+  batch_size: 1MB
+inventory:
+  enabled: true
+  interval: 1h
+  scan_on_start: true
+  hardware: true
+  system: true
+  networks: true
+  packages: true
+  ports: true
+  ports_all: false
+  processes: false
+logcollector:
+  enabled: true
+  localfiles:
+    - /var/log/auth.log
+  reload_interval: 1m
+  read_interval: 500ms

--- a/etc/config/wazuh_agent_linux.yml
+++ b/etc/config/wazuh_agent_linux.yml
@@ -24,3 +24,8 @@ logcollector:
     - /var/log/auth.log
   reload_interval: 1m
   read_interval: 500ms
+  journald:
+    - field: "SYSLOG_IDENTIFIER"
+      value: "systemd"
+      exact_match: false
+      ignore_if_missing: true

--- a/etc/config/wazuh_agent_macos.yml
+++ b/etc/config/wazuh_agent_macos.yml
@@ -22,8 +22,6 @@ logcollector:
   enabled: true
   reload_interval: 1m
   read_interval: 500ms
-  localfiles:
-    - /var/log/secure.log #TODO: double check if this has sense
   macos:
     - query: process == "sshd" OR message CONTAINS "invalid"
       level: info

--- a/etc/config/wazuh_agent_macos.yml
+++ b/etc/config/wazuh_agent_macos.yml
@@ -18,10 +18,13 @@ inventory:
   ports: true
   ports_all: false
   processes: false
-  hotfixes: true
 logcollector:
   enabled: true
-  localfiles:
-    - /var/log/auth.log
   reload_interval: 1m
   read_interval: 500ms
+  localfiles:
+    - /var/log/secure.log #TODO: double check if this has sense
+  macos:
+    - query: process == "sshd" OR message CONTAINS "invalid"
+      level: info
+      type: trace,activity,log

--- a/etc/config/wazuh_agent_windows.yml
+++ b/etc/config/wazuh_agent_windows.yml
@@ -24,14 +24,11 @@ logcollector:
   reload_interval: 1m
   read_interval: 500ms
   windows:
-    - channel: Application
-      query: "*"
-    - channel: Security
-      query: Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and
-      EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and
-      EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907 and
-      EventID != 5152 and EventID != 5157]
     - channel: System
-      query: "*"
+      query: Event[System/EventID != 1000]
+    - channel: Application
+      query: Event[System/EventID = 1000]
+    - channel: Security
+      query: Event[System/EventID != 5145 and System/EventID != 5156 and System/EventID != 5447 and System/EventID != 4656 and System/EventID != 4658 and System/EventID != 4663 and System/EventID != 4660 and System/EventID != 4670 and System/EventID != 4690 and System/EventID != 4703 and System/EventID != 4907 and System/EventID != 5152 and System/EventID != 5157]
 
 

--- a/etc/config/wazuh_agent_windows.yml
+++ b/etc/config/wazuh_agent_windows.yml
@@ -1,0 +1,37 @@
+agent:
+  thread_count: 4
+  server_url: https://localhost:27000
+  retry_interval: 30s
+  verification_mode: none
+  queue_size: 10000
+events:
+  batch_interval: 10s
+  batch_size: 1MB
+inventory:
+  enabled: true
+  interval: 1h
+  scan_on_start: true
+  hardware: true
+  system: true
+  networks: true
+  packages: true
+  ports: true
+  ports_all: false
+  processes: false
+  hotfixes: true
+logcollector:
+  enabled: true
+  reload_interval: 1m
+  read_interval: 500ms
+  windows:
+    - channel: Application
+      query: "*"
+    - channel: Security
+      query: Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and
+      EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and
+      EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907 and
+      EventID != 5152 and EventID != 5157]
+    - channel: System
+      query: "*"
+
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,8 +70,15 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     install(DIRECTORY DESTINATION "${DATA_INSTALL_DIR}")
 
     install(CODE "file(MAKE_DIRECTORY \"${CONFIG_INSTALL_DIR}\")")
-    install(FILES ${CONFIG_FOLDER}/wazuh-agent.yml
-            DESTINATION ${CONFIG_INSTALL_DIR})
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        install(FILES ${CONFIG_FOLDER}/wazuh_agent_linux.yml
+                DESTINATION ${CONFIG_INSTALL_DIR})
+        file(COPY_FILE ${CONFIG_FOLDER}/wazuh_agent_linux.yml ${CONFIG_FOLDER}/wazuh-agent.yml)
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        install(FILES ${CONFIG_FOLDER}/wazuh_agent_macos.yml
+                DESTINATION ${CONFIG_INSTALL_DIR})
+        file(COPY_FILE ${CONFIG_FOLDER}/wazuh_agent_macos.yml ${CONFIG_FOLDER}/wazuh-agent.yml)
+    endif()
     install(FILES "${CMAKE_BINARY_DIR}/VERSION.json" DESTINATION ${PARENT_DIR})
     install(TARGETS wazuh-agent
             DESTINATION ${BIN_INSTALL_DIR})
@@ -92,7 +99,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION .)
     include(InstallRequiredSystemLibraries)
     install(DIRECTORY ${CMAKE_BINARY_DIR}/$ENV{CUSTOM_CMAKE_CONFIG}/ DESTINATION .)
-    install(FILES ${CONFIG_FOLDER}/wazuh-agent.yml DESTINATION .)
+    install(FILES ${CONFIG_FOLDER}/wazuh_agent_windows.yml DESTINATION .)
+    file(COPY_FILE ${CONFIG_FOLDER}/wazuh_agent_windows.yml ${CONFIG_FOLDER}/wazuh-agent.yml)
     install(FILES ${WINDOWS_FOLDER}/postinstall.ps1 DESTINATION .)
     install(FILES ${WINDOWS_FOLDER}/cleanup.ps1 DESTINATION .)
     install(FILES "${CMAKE_BINARY_DIR}/VERSION.json" DESTINATION .)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,21 +64,32 @@ configure_target(wazuh-agent)
 include(cmake/config.cmake)
 include(cmake/PrepareVersionFileForInstallation.cmake)
 
+set(OUTPUT_CONFIG ${CONFIG_FOLDER}/wazuh-agent.yml)
+
+# Platform specific config file
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(SOURCE_CONFIG ${CONFIG_FOLDER}/wazuh_agent_linux.yml)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(SOURCE_CONFIG ${CONFIG_FOLDER}/wazuh_agent_macos.yml)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(SOURCE_CONFIG ${CONFIG_FOLDER}/wazuh_agent_windows.yml)
+endif()
+
+# Replace propper config in the generic placement
+add_custom_command(OUTPUT ${OUTPUT_CONFIG}
+    COMMAND ${CMAKE_COMMAND} -E copy ${SOURCE_CONFIG} ${OUTPUT_CONFIG}
+    DEPENDS ${SOURCE_CONFIG}
+    COMMENT "Creating ${OUTPUT_CONFIG} from ${SOURCE_CONFIG}")
+
+add_custom_target(generate_config ALL DEPENDS ${OUTPUT_CONFIG})
+
 # Installation
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 
     install(DIRECTORY DESTINATION "${DATA_INSTALL_DIR}")
 
     install(CODE "file(MAKE_DIRECTORY \"${CONFIG_INSTALL_DIR}\")")
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        install(FILES ${CONFIG_FOLDER}/wazuh_agent_linux.yml
-                DESTINATION ${CONFIG_INSTALL_DIR})
-        file(COPY_FILE ${CONFIG_FOLDER}/wazuh_agent_linux.yml ${CONFIG_FOLDER}/wazuh-agent.yml)
-    elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-        install(FILES ${CONFIG_FOLDER}/wazuh_agent_macos.yml
-                DESTINATION ${CONFIG_INSTALL_DIR})
-        file(COPY_FILE ${CONFIG_FOLDER}/wazuh_agent_macos.yml ${CONFIG_FOLDER}/wazuh-agent.yml)
-    endif()
+    install(FILES ${OUTPUT_CONFIG} DESTINATION ${CONFIG_INSTALL_DIR})
     install(FILES "${CMAKE_BINARY_DIR}/VERSION.json" DESTINATION ${PARENT_DIR})
     install(TARGETS wazuh-agent
             DESTINATION ${BIN_INSTALL_DIR})
@@ -99,8 +110,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION .)
     include(InstallRequiredSystemLibraries)
     install(DIRECTORY ${CMAKE_BINARY_DIR}/$ENV{CUSTOM_CMAKE_CONFIG}/ DESTINATION .)
-    install(FILES ${CONFIG_FOLDER}/wazuh_agent_windows.yml DESTINATION .)
-    file(COPY_FILE ${CONFIG_FOLDER}/wazuh_agent_windows.yml ${CONFIG_FOLDER}/wazuh-agent.yml)
+    install(FILES ${OUTPUT_CONFIG} DESTINATION .)
     install(FILES ${WINDOWS_FOLDER}/postinstall.ps1 DESTINATION .)
     install(FILES ${WINDOWS_FOLDER}/cleanup.ps1 DESTINATION .)
     install(FILES "${CMAKE_BINARY_DIR}/VERSION.json" DESTINATION .)

--- a/src/cmake/config.cmake
+++ b/src/cmake/config.cmake
@@ -69,7 +69,11 @@ set(DEFAULT_PORTS_ALL false CACHE BOOL "Default inventory ports all")
 
 set(DEFAULT_PROCESSES false CACHE BOOL "Default inventory processes")
 
-set(DEFAULT_HOTFIXES true CACHE BOOL "Default inventory hotfixes")
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(DEFAULT_HOTFIXES true CACHE BOOL "Default inventory hotfixes")
+else()
+    set(DEFAULT_HOTFIXES false CACHE BOOL "Default inventory hotfixes")
+endif()
 
 set(QUEUE_STATUS_REFRESH_TIMER 100 CACHE STRING "Default Agent's queue refresh timer (100ms)")
 

--- a/src/modules/inventory/tests/inventoryImp/inventoryImp_test.cpp
+++ b/src/modules/inventory/tests/inventoryImp/inventoryImp_test.cpp
@@ -77,9 +77,6 @@ TEST_F(InventoryImpTest, defaultCtor)
         .WillOnce(::testing::InvokeArgument<0>(
             R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
 
-    EXPECT_CALL(*spInfoWrapper, hotfixes())
-        .WillRepeatedly(Return(nlohmann::json::parse(R"([{"hotfix":"KB12345678"}])")));
-
     EXPECT_CALL(*spInfoWrapper, networks())
         .WillRepeatedly(Return(nlohmann::json::parse(
             R"({"iface":[{"IPv4":[{"address":"172.17.0.1","broadcast":"172.17.255.255","dhcp":"unknown","metric":"0","netmask":"255.255.0.0"}],"adapter":"","gateway":"","mac":"02:42:1c:26:13:65","mtu":1500,"name":"docker0","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"state":"down","tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0,"type":"ethernet"}]})")));
@@ -100,19 +97,16 @@ TEST_F(InventoryImpTest, defaultCtor)
         R"({"data":{"host":{"architecture":"x86_64","hostname":"UBUNTU","os":{"full":null,"kernel":"7601","name":"Microsoft Windows 7","platform":null,"type":null,"version":"6.1.7601"}}},"metadata":{"collector":"system","module":"inventory","operation":"create"}})"};
     const auto expectedResult3 {
         R"({"data":{"package":{"architecture":"amd64","description":null,"installed":null,"name":"xserver-xorg","path":" ","size":4111222333,"type":"deb","version":"1:7.7+19ubuntu14"}},"metadata":{"collector":"packages","module":"inventory","operation":"create"}})"};
-    const auto expectedResult5 {
-        R"({"data":{"package":{"hotfix":{"name":"KB12345678"}}},"metadata":{"collector":"hotfixes","module":"inventory","operation":"create"}})"};
-    const auto expectedResult6 {
+    const auto expectedResult4 {
         R"({"data":{"destination":{"ip":["0.0.0.0"],"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":0},"ingress":{"queue":0}}},"interface":{"state":"listening"},"network":{"protocol":"tcp"},"process":{"name":null,"pid":0},"source":{"ip":["127.0.0.1"],"port":631}},"metadata":{"collector":"ports","module":"inventory","operation":"create"}})"};
-    const auto expectedResult7 {
+    const auto expectedResult5 {
         R"({"data":{"host":{"ip":["172.17.0.1"],"mac":"02:42:1c:26:13:65","network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"mtu":1500,"state":"down","type":"ethernet"},"network":{"broadcast":["172.17.255.255"],"dhcp":"unknown","gateway":[],"metric":"0","netmask":["255.255.0.0"],"type":"ipv4"},"observer":{"ingress":{"interface":{"alias":null,"name":"docker0"}}}},"metadata":{"collector":"networks","module":"inventory","operation":"create"}})"};
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(testing::AtLeast(1));
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(testing::AtLeast(1));
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(testing::AtLeast(1));
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(testing::AtLeast(1));
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult5)).Times(testing::AtLeast(1));
-    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult6)).Times(testing::AtLeast(1));
-    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult7)).Times(testing::AtLeast(1));
 
     auto configurationParser = std::make_shared<configuration::ConfigurationParser>();
     Inventory::Instance().Setup(configurationParser);


### PR DESCRIPTION
## Description
Closes #694 

The installer provides a default configuration file, _wazuh-agent.yml_. This file contains numerous settings but is specifically tailored for Linux.

The final version of the agent will likely have a minimal configuration. The manager will transmit a more complete configuration, adapted to its platform and configuration group.

However, to facilitate testing, we should provide a default configuration file that is more suitable for each platform (Linux, Windows, and macOS), allowing the agent to be tested without requiring any configuration.

## Tasks

- Split the configuration into three files:
   - wazuh_agent_linux.yml
   - wazuh_agent_windows.yml
   - wazuh_agent_macos.yml
- Propose a suitable default configuration for each platform.
- Adapt the installer to copy the appropriate configuration file for the platform.

## Acceptance Criteria

- The installer copies the appropriate configuration file for the platform.
## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Configuration Changes

* In windows platforms hotfixes will be set to true by default, false in other cases.


## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
