### PR TITLE
Improve windows scaffolding

### DIFF
--- a/.github/actions/5_testintegration_compile/action.yml
+++ b/.github/actions/5_testintegration_compile/action.yml
@@ -19,8 +19,13 @@ runs:
         mkdir -p ${{ inputs.build_path }} && cd ${{ inputs.build_path }}
         if [[ "$RUNNER_OS" == "Windows" ]]; then
           cmake ${SRC_FOLDER} -DBUILD_TESTS=1 -G "Visual Studio 17 2022" -A x64
-        else
+        elif [[ "$RUNNER_OS" == "Linux" ]]; then
           cmake ${SRC_FOLDER} -DBUILD_TESTS=1 -G "Unix Makefiles"
+        elif [[ "$RUNNER_OS" == "macOS" ]]; then
+          cmake ${SRC_FOLDER} -DBUILD_TESTS=1 -DENABLE_CLANG_TIDY=NO -G "Unix Makefiles"
+        else
+          echo "Unsupported OS: $RUNNER_OS"
+          exit 1
         fi
         echo "CMake project generated in $(pwd)"
       shell: bash

--- a/packages/windows/cleanup.ps1
+++ b/packages/windows/cleanup.ps1
@@ -45,7 +45,6 @@ if (-not (Get-ChildItem -Path $CleanPath -Recurse)) {
     }
 }
 
-
 # Remove Wazuh service
 $serviceName = "Wazuh Agent"
 $wazuhagent = "$PSScriptRoot\wazuh-agent.exe"

--- a/packages/windows/generate_wazuh_msi.ps1
+++ b/packages/windows/generate_wazuh_msi.ps1
@@ -55,17 +55,16 @@ function BuildWazuhMsi(){
 
         $exeFiles = @()
 
-        # Every .exe and .dll
+        # Every .exe
         $exeFiles += Get-ChildItem -Filter "*.exe"
-        $exeFiles += Get-ChildItem -Filter "*.dll"
 
         # Extract symbols
         foreach ($file in $exeFiles)
         {
             Write-Host "Extracting dbg symbols from" $file.FullName
-            $args = $file.FullName # Source (exe/dll with debug symbols)
+            $args = $file.FullName # Source (exe with debug symbols)
             $args += " "
-            $args += $file.FullName  # Destination (same as source - exe/dll is stripped of debug symbols)
+            $args += $file.FullName  # Destination (same as source - exe is stripped of debug symbols)
             $args += " "
             $args += $file.BaseName
             $args += ".pdb"
@@ -111,7 +110,6 @@ function BuildWazuhMsi(){
         # Define files to sign
         $filesToSign = @(
             "$PSScriptRoot\..\..\build\$CMAKE_CONFIG\*.exe",
-            "$PSScriptRoot\..\..\build\$CMAKE_CONFIG\*.dll",
             "$PSScriptRoot\postinstall.ps1",
             "$PSScriptRoot\cleanup.ps1"
         )

--- a/packages/windows/postinstall.ps1
+++ b/packages/windows/postinstall.ps1
@@ -18,7 +18,6 @@ foreach ($dir in $directoriesToCreate) {
 }
 Write-Host "Directories created successfully."
 
-
 # Handle Wazuh config file
 $destinationDir = Join-Path -Path $programData -ChildPath "wazuh-agent\config"
 $sourcePath = "$PSScriptRoot\wazuh-agent.yml"
@@ -56,7 +55,6 @@ if (Test-Path $sourcePath) {
     Write-Host "Source file not found: $sourcePath"
 }
 
-
 # Install Wazuh service
 $serviceName = "Wazuh Agent"
 $wazuhagent = "$PSScriptRoot\wazuh-agent.exe"
@@ -74,3 +72,8 @@ if (-not (Get-Service -Name $serviceName -ErrorAction SilentlyContinue)) {
 }
 
 Write-Host "postinstall.ps1 script completed."
+
+# Delete script after execution
+$scriptPath = "$PSScriptRoot\postinstall.ps1"
+Write-Host "Deleting script: $scriptPath"
+Remove-Item -Path $scriptPath -Force

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,14 +17,19 @@ else()
     set(CMAKE_TOOLCHAIN_FILE "${vcpkg_SOURCE_DIR}/scripts/buildsystems/vcpkg.cmake" CACHE FILEPATH "")
 endif()
 
+if(WIN32)
+    set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "Vcpkg target triplet" FORCE)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
 get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
 get_filename_component(CONFIG_FOLDER ${CMAKE_SOURCE_DIR}/../etc/config/ ABSOLUTE)
 get_filename_component(WINDOWS_FOLDER ${CMAKE_SOURCE_DIR}/../packages/windows/ ABSOLUTE)
 
 project(wazuh-agent)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++")
+if(UNIX AND NOT APPLE)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
 endif()
 
 find_package(OpenSSL REQUIRED)

--- a/src/agent/agent_info/CMakeLists.txt
+++ b/src/agent/agent_info/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(AgentInfo PUBLIC
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(AgentInfo PUBLIC nlohmann_json::nlohmann_json PRIVATE Config Persistence Boost::uuid Logger)
 
-if(MSVC)
+if(WIN32)
     target_link_libraries(AgentInfo PRIVATE bcrypt)
 endif()
 

--- a/src/cmake/CommonSettings.cmake
+++ b/src/cmake/CommonSettings.cmake
@@ -93,6 +93,10 @@ function(set_common_settings)
         set(CMAKE_CXX_FLAGS "-g3" PARENT_SCOPE)
     endif()
 
+    if(APPLE)
+        add_link_options("-Wl,-no_warn_duplicate_libraries")
+    endif()
+
     if(ENABLE_INVENTORY)
         add_definitions(-DENABLE_INVENTORY)
     endif()

--- a/src/common/data_provider/CMakeLists.txt
+++ b/src/common/data_provider/CMakeLists.txt
@@ -5,39 +5,26 @@ project(sysinfo)
 include(../../cmake/CommonSettings.cmake)
 set_common_settings()
 
-get_filename_component(SRC_FOLDER     ${CMAKE_CURRENT_SOURCE_DIR}/../../ ABSOLUTE)
-get_filename_component(COMMON_FOLDER  ${CMAKE_CURRENT_SOURCE_DIR}/../ ABSOLUTE)
-
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-if(WIN32)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-else()
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-endif()
-
-if(UNIX AND NOT APPLE)
-    find_package(Lua REQUIRED)
-    include_directories(${LUA_INCLUDE_DIR})
-endif()
-
-if(APPLE)
-    find_package(unofficial-libplist CONFIG REQUIRED)
+if(UNIX)
+    find_package(LibArchive REQUIRED)
+    if (APPLE)
+        find_package(unofficial-libplist CONFIG REQUIRED)
+        find_library(iokit_lib IOKit REQUIRED)
+        find_library(corefoundation_lib CoreFoundation REQUIRED)
+    else()
+        find_package(Lua REQUIRED)
+        find_path(POPT_INCLUDE_DIR include/popt.h)
+        find_library(POPT_LIBRARY libpopt.a)
+        find_library(PROC_NG_LIBRARY NAMES proc-ng REQUIRED)
+        find_library(LIBDB_LIBRARY NAMES db REQUIRED)
+        find_library(LIBRPM_LIBRARY NAMES rpm REQUIRED)
+        find_library(LIBRPMIO_LIBRARY NAMES rpmio REQUIRED)
+    endif()
 endif()
 
 find_package(cJSON CONFIG REQUIRED)
-find_package(LibArchive REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(unofficial-sqlite3 CONFIG REQUIRED)
-
-find_path(POPT_INCLUDE_DIR include/popt.h)
-include_directories(${POPT_INCLUDE_DIR})
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/)
-include_directories(${COMMON_FOLDER})
-
-link_directories(${SRC_FOLDER})
 
 if(WIN32)
     file(GLOB SYSINFO_SRC
@@ -75,10 +62,17 @@ endif()
 add_library(sysinfo STATIC
     ${SYSINFO_SRC}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/sysInfo.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/utilsWrapper.cpp
-    ${SRC_FOLDER}/${RESOURCE_OBJ})
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/utilsWrapper.cpp)
 
-target_include_directories(sysinfo PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/)
+target_include_directories(sysinfo
+    PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/../
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/
+    $<$<PLATFORM_ID:Linux>:${LUA_INCLUDE_DIR}>
+    $<$<PLATFORM_ID:Linux>:${POPT_INCLUDE_DIR}>
+)
 
 target_link_libraries(sysinfo
     PUBLIC
@@ -92,54 +86,25 @@ target_link_libraries(sysinfo
     sqlite_wrapper
     string_helper
     time_helper
-)
-
-if(WIN32)
-    target_link_libraries(sysinfo PUBLIC encoding_helper registry_helper windows_helper)
-elseif(NOT APPLE)
-    target_link_libraries(sysinfo PUBLIC linux_helper)
-endif()
-
-if(WIN32)
-    target_link_libraries(sysinfo
-        PUBLIC
-        psapi
-        iphlpapi
-        ws2_32
-    )
-elseif(APPLE)
-    find_library(iokit_lib IOKit REQUIRED)
-    find_library(corefoundation_lib CoreFoundation REQUIRED)
-
-    target_link_libraries(sysinfo
-        PUBLIC
-        unofficial::libplist::libplist
-        unofficial::libplist::libplist++
-        ${iokit_lib}
-        ${corefoundation_lib}
-        LibArchive::LibArchive
-    )
-else()
-    find_library(POPT_LIBRARY libpopt.a)
-    find_library(PROC_NG_LIBRARY NAMES proc-ng REQUIRED)
-    find_library(LIBDB_LIBRARY NAMES db REQUIRED)
-    find_library(LIBRPM_LIBRARY NAMES rpm REQUIRED)
-    find_library(LIBRPMIO_LIBRARY NAMES rpmio REQUIRED)
-
-    target_link_libraries(sysinfo
-        PUBLIC
-        ${LIBDB_LIBRARY}
-        ${PROC_NG_LIBRARY}
-        ${LIBRPM_LIBRARY}
-        ${LIBRPMIO_LIBRARY}
-        LibArchive::LibArchive
-        ${POPT_LIBRARY}
-        ${LUA_LIBRARIES}
-    )
-endif()
-
-target_link_libraries(sysinfo
-    PUBLIC
+    $<$<PLATFORM_ID:Windows>:encoding_helper>
+    $<$<PLATFORM_ID:Windows>:registry_helper>
+    $<$<PLATFORM_ID:Windows>:windows_helper>
+    $<$<PLATFORM_ID:Windows>:psapi>
+    $<$<PLATFORM_ID:Windows>:iphlpapi>
+    $<$<PLATFORM_ID:Windows>:ws2_32>
+    $<$<PLATFORM_ID:Darwin>:unofficial::libplist::libplist>
+    $<$<PLATFORM_ID:Darwin>:unofficial::libplist::libplist++>
+    $<$<PLATFORM_ID:Darwin>:${iokit_lib}>
+    $<$<PLATFORM_ID:Darwin>:${corefoundation_lib}>
+    $<$<PLATFORM_ID:Darwin>:LibArchive::LibArchive>
+    $<$<PLATFORM_ID:Linux>:linux_helper>
+    $<$<PLATFORM_ID:Linux>:${LIBDB_LIBRARY}>
+    $<$<PLATFORM_ID:Linux>:${PROC_NG_LIBRARY}>
+    $<$<PLATFORM_ID:Linux>:${LIBRPM_LIBRARY}>
+    $<$<PLATFORM_ID:Linux>:${LIBRPMIO_LIBRARY}>
+    $<$<PLATFORM_ID:Linux>:LibArchive::LibArchive>
+    $<$<PLATFORM_ID:Linux>:${POPT_LIBRARY}>
+    $<$<PLATFORM_ID:Linux>:${LUA_LIBRARIES}>
     nlohmann_json::nlohmann_json
     cjson
     PRIVATE

--- a/src/common/data_provider/tests/sysInfo/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfo/CMakeLists.txt
@@ -5,13 +5,13 @@ project(sysinfo_unit_test)
 file(GLOB sysinfo_UNIT_TEST_SRC
     "*.cpp")
 
-file(GLOB SYSINFO_SRC
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/sysInfo.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/osinfo/sysOsParsers.cpp")
-
 add_executable(sysinfo_unit_test
-    ${sysinfo_UNIT_TEST_SRC}
-    ${SYSINFO_SRC})
+    ${sysinfo_UNIT_TEST_SRC})
+
+target_include_directories(sysinfo_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/osinfo
+)
 
 configure_target(sysinfo_unit_test)
 

--- a/src/common/data_provider/tests/sysInfo/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfo/CMakeLists.txt
@@ -3,7 +3,16 @@ cmake_minimum_required(VERSION 3.22)
 project(sysinfo_unit_test)
 
 file(GLOB sysinfo_UNIT_TEST_SRC
-    "*.cpp")
+    "sysInfo_test.cpp"
+    "main.cpp")
+
+if(WIN32)
+    list(APPEND sysinfo_UNIT_TEST_SRC
+    "sysOsInfo_test.cpp")
+else()
+    list(APPEND sysinfo_UNIT_TEST_SRC
+    "sysInfoParsers_test.cpp")
+endif()
 
 add_executable(sysinfo_unit_test
     ${sysinfo_UNIT_TEST_SRC})

--- a/src/common/data_provider/tests/sysInfo/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfo/CMakeLists.txt
@@ -15,27 +15,14 @@ target_include_directories(sysinfo_unit_test PRIVATE
 
 configure_target(sysinfo_unit_test)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    target_link_libraries(sysinfo_unit_test PRIVATE
-        sysinfo
-        GTest::gtest
-        GTest::gmock
-        GTest::gtest_main
-        GTest::gmock_main
-        cjson
-    )
-else()
-    target_link_libraries(sysinfo_unit_test PRIVATE
-        sysinfo
-        GTest::gtest
-        GTest::gmock
-        GTest::gtest_main
-        GTest::gmock_main
-        pthread
-        cjson
-        dl
-    )
-endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+target_link_libraries(sysinfo_unit_test PRIVATE
+    sysinfo
+    GTest::gtest
+    GTest::gmock
+    GTest::gtest_main
+    GTest::gmock_main
+    cjson
+)
 
 add_test(NAME sysinfo_unit_test
          COMMAND sysinfo_unit_test)

--- a/src/common/data_provider/tests/sysInfoHardwareMac/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoHardwareMac/CMakeLists.txt
@@ -3,13 +3,17 @@ cmake_minimum_required(VERSION 3.22)
 project(sysInfoHardwareMac_unit_test)
 
 file(GLOB sysinfo_UNIT_TEST_SRC
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/hardware/*X86_64Mac.cpp"
     "sysInfoHardwareMac_test.cpp"
     "sysInfoHardwareWrapperMac_test.cpp"
     "main.cpp")
 
 add_executable(sysInfoHardwareMac_unit_test
     ${sysinfo_UNIT_TEST_SRC})
+
+target_include_directories(sysInfoHardwareMac_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/hardware
+)
 
 configure_target(sysInfoHardwareMac_unit_test)
 
@@ -26,23 +30,18 @@ add_test(NAME sysInfoHardwareMac_unit_test
 
 if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "arm64.*|ARM64.*")
     file(GLOB sysinfo_ARM_UNIT_TEST_SRC
-        "${CMAKE_CURRENT_SOURCE_DIR}/../../src/hardware/*ARMMac.cpp"
         "sysInfoHardwareWrapperARMMac_test.cpp"
         "main.cpp")
 
     add_executable(sysInfoHardwareARMMac_unit_test
         ${sysinfo_ARM_UNIT_TEST_SRC})
 
-    configure_target(sysInfoHardwareARMMac_unit_test)
+    target_include_directories(sysInfoHardwareARMMac_unit_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../src/hardware
+    )
 
-    find_library(iokit_lib IOKit)
-    if(NOT iokit_lib)
-        message(FATAL_ERROR "IOKit library not found! Aborting...")
-    endif()
-    find_library(corefoundation_lib CoreFoundation)
-    if(NOT corefoundation_lib)
-        message(FATAL_ERROR "CoreFoundation library not found! Aborting...")
-    endif()
+    configure_target(sysInfoHardwareARMMac_unit_test)
 
     target_link_libraries(sysInfoHardwareARMMac_unit_test PRIVATE
         sysinfo
@@ -54,4 +53,30 @@ if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "arm64.*|ARM64.*")
 
     add_test(NAME sysInfoHardwareARMMac_unit_test
             COMMAND sysInfoHardwareARMMac_unit_test)
+
+else()
+    file(GLOB sysinfo_X86_64_UNIT_TEST_SRC
+        "sysInfoHardwareWrapperX86_64Mac_test.cpp"
+        "main.cpp")
+
+    add_executable(sysInfoHardwareX86_64Mac_unit_test
+        ${sysinfo_X86_64_UNIT_TEST_SRC})
+
+    target_include_directories(sysInfoHardwareX86_64Mac_unit_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../src/hardware
+    )
+
+    configure_target(sysInfoHardwareX86_64Mac_unit_test)
+
+    target_link_libraries(sysInfoHardwareX86_64Mac_unit_test PRIVATE
+        sysinfo
+        GTest::gtest
+        GTest::gmock
+        GTest::gtest_main
+        GTest::gmock_main
+    )
+
+    add_test(NAME sysInfoHardwareX86_64Mac_unit_test
+            COMMAND sysInfoHardwareX86_64Mac_unit_test)
 endif()

--- a/src/common/data_provider/tests/sysInfoHardwareMac/sysInfoHardwareWrapperARMMac_test.cpp
+++ b/src/common/data_provider/tests/sysInfoHardwareMac/sysInfoHardwareWrapperARMMac_test.cpp
@@ -1,6 +1,4 @@
 #include "sysInfoHardwareWrapperARMMac_test.hpp"
-#include "CoreFoundation/CFBase.h"
-#include "IOKit/IOKitLib.h"
 #include "hardware/hardwareWrapperImplMac.h"
 #include "osPrimitivesInterfaceMac.h"
 #include "osPrimitives_mock.hpp"

--- a/src/common/data_provider/tests/sysInfoHardwareMac/sysInfoHardwareWrapperMac_test.cpp
+++ b/src/common/data_provider/tests/sysInfoHardwareMac/sysInfoHardwareWrapperMac_test.cpp
@@ -122,43 +122,6 @@ TEST_F(SysInfoHardwareWrapperMacTest, Test_CpuCores_Failed_Sysctl)
     EXPECT_THROW(wrapper->cpuCores(), std::system_error);
 }
 
-TEST_F(SysInfoHardwareWrapperMacTest, Test_CpuMhz_WithCpuFrequency_Succeed)
-{
-    auto wrapper {std::make_shared<OSHardwareWrapperMac<OsPrimitivesMacMock>>()};
-    EXPECT_CALL(*wrapper, sysctlbyname("hw.cpufrequency", _, _, _, _))
-        .WillOnce(
-            [](const char* name, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
-            {
-                (void)name;
-                (void)oldlenp;
-                (void)newp;
-                (void)newlen;
-                *static_cast<uint64_t*>(oldp) = 3280896;
-                return 0;
-            });
-    int ret = 0;
-    EXPECT_NO_THROW(ret = wrapper->cpuMhz());
-    EXPECT_EQ(ret, 3280896 / 1000000);
-}
-
-TEST_F(SysInfoHardwareWrapperMacTest, Test_CpuMhz_WithoutCpuFrequency_Failed_Sysctlbyname)
-{
-    auto wrapper {std::make_shared<OSHardwareWrapperMac<OsPrimitivesMacMock>>()};
-    EXPECT_CALL(*wrapper, sysctlbyname("hw.cpufrequency", _, _, _, _))
-        .WillOnce(
-            [](const char* name, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
-            {
-                (void)name;
-                (void)oldlenp;
-                (void)newp;
-                (void)newlen;
-                *static_cast<uint64_t*>(oldp) = 0;
-                return -1;
-            });
-
-    EXPECT_THROW(wrapper->cpuMhz(), std::system_error);
-}
-
 TEST_F(SysInfoHardwareWrapperMacTest, Test_RamTotal_Succeed)
 {
     auto wrapper {std::make_shared<OSHardwareWrapperMac<OsPrimitivesMacMock>>()};

--- a/src/common/data_provider/tests/sysInfoHardwareMac/sysInfoHardwareWrapperX86_64Mac_test.cpp
+++ b/src/common/data_provider/tests/sysInfoHardwareMac/sysInfoHardwareWrapperX86_64Mac_test.cpp
@@ -1,0 +1,48 @@
+#include "sysInfoHardwareWrapperX86_64Mac_test.hpp"
+#include "hardware/hardwareWrapperImplMac.h"
+#include "osPrimitivesInterfaceMac.h"
+#include "osPrimitives_mock.hpp"
+
+void SysInfoHardwareWrapperX86_64MacTest::SetUp() {};
+
+void SysInfoHardwareWrapperX86_64MacTest::TearDown() {};
+
+using ::testing::_; // NOLINT(bugprone-reserved-identifier)
+using ::testing::Return;
+
+TEST_F(SysInfoHardwareWrapperX86_64MacTest, Test_CpuMhz_WithCpuFrequency_Succeed)
+{
+    auto wrapper {std::make_shared<OSHardwareWrapperMac<OsPrimitivesMacMock>>()};
+    EXPECT_CALL(*wrapper, sysctlbyname("hw.cpufrequency", _, _, _, _))
+        .WillOnce(
+            [](const char* name, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
+            {
+                (void)name;
+                (void)oldlenp;
+                (void)newp;
+                (void)newlen;
+                *static_cast<uint64_t*>(oldp) = 3280896;
+                return 0;
+            });
+    int ret = 0;
+    EXPECT_NO_THROW(ret = wrapper->cpuMhz());
+    EXPECT_EQ(ret, 3280896 / 1000000);
+}
+
+TEST_F(SysInfoHardwareWrapperX86_64MacTest, Test_CpuMhz_WithoutCpuFrequency_Failed_Sysctlbyname)
+{
+    auto wrapper {std::make_shared<OSHardwareWrapperMac<OsPrimitivesMacMock>>()};
+    EXPECT_CALL(*wrapper, sysctlbyname("hw.cpufrequency", _, _, _, _))
+        .WillOnce(
+            [](const char* name, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
+            {
+                (void)name;
+                (void)oldlenp;
+                (void)newp;
+                (void)newlen;
+                *static_cast<uint64_t*>(oldp) = 0;
+                return -1;
+            });
+
+    EXPECT_THROW(wrapper->cpuMhz(), std::system_error);
+}

--- a/src/common/data_provider/tests/sysInfoHardwareMac/sysInfoHardwareWrapperX86_64Mac_test.hpp
+++ b/src/common/data_provider/tests/sysInfoHardwareMac/sysInfoHardwareWrapperX86_64Mac_test.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+class SysInfoHardwareWrapperX86_64MacTest : public ::testing::Test
+{
+protected:
+    SysInfoHardwareWrapperX86_64MacTest() = default;
+    virtual ~SysInfoHardwareWrapperX86_64MacTest() = default;
+
+    void SetUp() override;
+    void TearDown() override;
+};

--- a/src/common/data_provider/tests/sysInfoNetworkBSD/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoNetworkBSD/CMakeLists.txt
@@ -5,12 +5,13 @@ project(sysInfoNetworkBSD_unit_test)
 file(GLOB sysinfo_UNIT_TEST_SRC
     "*.cpp")
 
-file(GLOB SYSINFO_SRC
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/network/networkInterfaceBSD.cpp")
-
 add_executable(sysInfoNetworkBSD_unit_test
-    ${sysinfo_UNIT_TEST_SRC}
-    ${SYSINFO_SRC})
+    ${sysinfo_UNIT_TEST_SRC})
+
+target_include_directories(sysInfoNetworkBSD_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/network
+)
 
 configure_target(sysInfoNetworkBSD_unit_test)
 

--- a/src/common/data_provider/tests/sysInfoNetworkLinux/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoNetworkLinux/CMakeLists.txt
@@ -5,12 +5,13 @@ project(sysInfoNetworkLinux_unit_test)
 file(GLOB sysinfo_UNIT_TEST_SRC
     "*.cpp")
 
-file(GLOB SYSINFO_SRC
-    "${CMAKE_SOURCE_DIR}/src/network/networkInterfaceLinux.cpp")
-
 add_executable(sysInfoNetworkLinux_unit_test
-    ${sysinfo_UNIT_TEST_SRC}
-    ${SYSINFO_SRC})
+    ${sysinfo_UNIT_TEST_SRC})
+
+target_include_directories(sysInfoNetworkLinux_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/network
+)
 
 configure_target(sysInfoNetworkLinux_unit_test)
 

--- a/src/common/data_provider/tests/sysInfoNetworkWindows/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoNetworkWindows/CMakeLists.txt
@@ -5,14 +5,13 @@ project(sysInfoNetworkWindows_unit_test)
 file(GLOB sysinfo_UNIT_TEST_SRC
     "*.cpp")
 
-file(GLOB SYSINFO_SRC
-    "${CMAKE_SOURCE_DIR}/src/network/networkInterfaceWindows.cpp")
-
-find_package(GTest CONFIG REQUIRED)
-
 add_executable(sysInfoNetworkWindows_unit_test
-    ${sysinfo_UNIT_TEST_SRC}
-    ${SYSINFO_SRC})
+    ${sysinfo_UNIT_TEST_SRC})
+
+target_include_directories(sysInfoNetworkWindows_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/network
+)
 
 configure_target(sysInfoNetworkWindows_unit_test)
 

--- a/src/common/data_provider/tests/sysInfoNetworkWindows/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoNetworkWindows/CMakeLists.txt
@@ -15,13 +15,12 @@ target_include_directories(sysInfoNetworkWindows_unit_test PRIVATE
 
 configure_target(sysInfoNetworkWindows_unit_test)
 
-target_link_libraries(sysInfoNetworkWindows_unit_test
+target_link_libraries(sysInfoNetworkWindows_unit_test PRIVATE
     sysinfo
     GTest::gtest
-    GTest::gtest_main
     GTest::gmock
+    GTest::gtest_main
     GTest::gmock_main
-    cjson
 )
 
 add_test(NAME sysInfoNetworkWindows_unit_test

--- a/src/common/data_provider/tests/sysInfoPackageLinuxParserRpm/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoPackageLinuxParserRpm/CMakeLists.txt
@@ -2,18 +2,19 @@ cmake_minimum_required(VERSION 3.22)
 
 project(sysInfoPackageLinuxParserRPM_unit_test)
 
-file(GLOB sysinfo_UNIT_TEST_SRC "*.cpp")
-file(GLOB PARSER_SRC "${CMAKE_SOURCE_DIR}/src/packages/packageLinuxParserRpm.hpp")
-file(GLOB RPM_SRC "${CMAKE_SOURCE_DIR}/src/packages/rpm*.cpp")
+file(GLOB sysinfo_UNIT_TEST_SRC
+    "*.cpp")
 
 add_executable(sysInfoPackageLinuxParserRPM_unit_test
-    ${sysinfo_UNIT_TEST_SRC}
-    ${RPM_SRC}
-    ${PARSER_SRC})
+    ${sysinfo_UNIT_TEST_SRC})
+
+target_include_directories(sysInfoPackageLinuxParserRPM_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/packages
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../file_helper/filesystem/tests/mocks
+)
 
 configure_target(sysInfoPackageLinuxParserRPM_unit_test)
-
-target_include_directories(sysInfoPackageLinuxParserRPM_unit_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../file_helper/filesystem/tests/mocks)
 
 target_link_libraries(sysInfoPackageLinuxParserRPM_unit_test PRIVATE
     sysinfo

--- a/src/common/data_provider/tests/sysInfoPackages/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoPackages/CMakeLists.txt
@@ -2,16 +2,19 @@ cmake_minimum_required(VERSION 3.22)
 
 project(sysInfoPackages_unit_test)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../src/packages)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../file_helper/filesystem/tests/mocks)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../file_helper/file_io/tests/mocks)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../jsonHelper/tests/mocks)
-
 file(GLOB sysinfo_UNIT_TEST_SRC
     "*.cpp")
 
 add_executable(sysInfoPackages_unit_test
     ${sysinfo_UNIT_TEST_SRC})
+
+target_include_directories(sysInfoPackages_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/packages
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../file_helper/filesystem/tests/mocks
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../file_helper/file_io/tests/mocks
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../jsonHelper/tests/mocks
+)
 
 configure_target(sysInfoPackages_unit_test)
 

--- a/src/common/data_provider/tests/sysInfoPackagesBerkeleyDB/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoPackagesBerkeleyDB/CMakeLists.txt
@@ -8,6 +8,11 @@ file(GLOB sysinfo_UNIT_TEST_SRC
 add_executable(sysInfoPackagesBerkeleyDB_unit_test
     ${sysinfo_UNIT_TEST_SRC})
 
+target_include_directories(sysInfoPackagesBerkeleyDB_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/packages
+)
+
 configure_target(sysInfoPackagesBerkeleyDB_unit_test)
 
 target_link_libraries(sysInfoPackagesBerkeleyDB_unit_test PRIVATE

--- a/src/common/data_provider/tests/sysInfoPackagesLinuxHelper/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoPackagesLinuxHelper/CMakeLists.txt
@@ -8,6 +8,11 @@ file(GLOB sysinfo_UNIT_TEST_SRC
 add_executable(sysInfoPackagesLinuxHelper_unit_test
     ${sysinfo_UNIT_TEST_SRC})
 
+target_include_directories(sysInfoPackagesLinuxHelper_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/packages
+)
+
 configure_target(sysInfoPackagesLinuxHelper_unit_test)
 
 target_link_libraries(sysInfoPackagesLinuxHelper_unit_test PRIVATE

--- a/src/common/data_provider/tests/sysInfoPackagesMAC/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoPackagesMAC/CMakeLists.txt
@@ -4,17 +4,17 @@ project(sysInfoMacPackage_unit_test)
 
 file(COPY input_files DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../sqliteWrapper/tests/mocks)
-
 file(GLOB sysinfo_UNIT_TEST_SRC
     "*.cpp")
 
-file(GLOB SYSINFO_SRC
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/packages/packageMac.cpp")
-
 add_executable(sysInfoMacPackage_unit_test
-    ${sysinfo_UNIT_TEST_SRC}
-    ${SYSINFO_SRC})
+    ${sysinfo_UNIT_TEST_SRC})
+
+target_include_directories(sysInfoMacPackage_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/packages
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../sqliteWrapper/tests/mocks
+)
 
 configure_target(sysInfoMacPackage_unit_test)
 

--- a/src/common/data_provider/tests/sysInfoPorts/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoPorts/CMakeLists.txt
@@ -5,12 +5,13 @@ project(sysInfoPort_unit_test)
 file(GLOB sysinfo_UNIT_TEST_SRC
     "*.cpp")
 
-file(GLOB SYSINFO_SRC
-    "${CMAKE_SOURCE_DIR}/ports/portImpl.h")
-
 add_executable(sysInfoPort_unit_test
-    ${sysinfo_UNIT_TEST_SRC}
-    ${SYSINFO_SRC})
+    ${sysinfo_UNIT_TEST_SRC})
+
+target_include_directories(sysInfoPort_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/ports
+)
 
 configure_target(sysInfoPort_unit_test)
 

--- a/src/common/data_provider/tests/sysInfoRpmPackageManager/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoRpmPackageManager/CMakeLists.txt
@@ -2,10 +2,15 @@ cmake_minimum_required(VERSION 3.22)
 
 project(RpmPackageManager_unit_test)
 
-file(GLOB RPM_UNIT_TEST_SRC "*.cpp")
-file(GLOB RPM_SRC "${CMAKE_SOURCE_DIR}/src/packages/rpm*.cpp")
+file(GLOB RPM_UNIT_TEST_SRC
+    "*.cpp")
 
-add_executable(sysInfoRpm_unit_test ${RPM_UNIT_TEST_SRC} ${RPM_SRC})
+add_executable(sysInfoRpm_unit_test ${RPM_UNIT_TEST_SRC})
+
+target_include_directories(sysInfoRpm_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/packages
+)
 
 configure_target(sysInfoRpm_unit_test)
 

--- a/src/common/data_provider/tests/sysInfoWin/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoWin/CMakeLists.txt
@@ -15,13 +15,12 @@ target_include_directories(sysInfoWindows_unit_test PRIVATE
 
 configure_target(sysInfoWindows_unit_test)
 
-target_link_libraries(sysInfoWindows_unit_test
+target_link_libraries(sysInfoWindows_unit_test PRIVATE
     sysinfo
     GTest::gtest
-    GTest::gtest_main
     GTest::gmock
+    GTest::gtest_main
     GTest::gmock_main
-    cjson
 )
 
 add_test(NAME sysInfoWindows_unit_test

--- a/src/common/data_provider/tests/sysInfoWin/CMakeLists.txt
+++ b/src/common/data_provider/tests/sysInfoWin/CMakeLists.txt
@@ -5,10 +5,13 @@ project(sysInfoWindows_unit_test)
 file(GLOB sysinfo_UNIT_TEST_SRC
     "*.cpp")
 
-find_package(GTest CONFIG REQUIRED)
-
 add_executable(sysInfoWindows_unit_test
     ${sysinfo_UNIT_TEST_SRC})
+
+target_include_directories(sysInfoWindows_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/osinfo
+)
 
 configure_target(sysInfoWindows_unit_test)
 

--- a/src/common/data_provider/testtool/CMakeLists.txt
+++ b/src/common/data_provider/testtool/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22)
 project(sysinfo_test_tool)
 
 add_executable(sysinfo_test_tool
-               ${sysinfo_TESTTOOL_SRC}
                ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
 target_include_directories(sysinfo_test_tool PRIVATE
@@ -11,7 +10,7 @@ target_include_directories(sysinfo_test_tool PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/
 )
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if(WIN32)
     target_link_libraries(sysinfo_test_tool
         sysinfo
         psapi
@@ -21,10 +20,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 else()
     target_link_libraries(sysinfo_test_tool
         sysinfo
-        dl
-        pthread
     )
-endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+endif()
 
 include(../../../cmake/ConfigureTarget.cmake)
 configure_target(sysinfo_test_tool)

--- a/src/common/data_provider/testtool/CMakeLists.txt
+++ b/src/common/data_provider/testtool/CMakeLists.txt
@@ -2,12 +2,14 @@ cmake_minimum_required(VERSION 3.22)
 
 project(sysinfo_test_tool)
 
-include_directories(${CMAKE_SOURCE_DIR}/include/)
-include_directories(${CMAKE_SOURCE_DIR}/src/)
-
 add_executable(sysinfo_test_tool
                ${sysinfo_TESTTOOL_SRC}
                ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+
+target_include_directories(sysinfo_test_tool PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/
+)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_link_libraries(sysinfo_test_tool

--- a/src/common/dbsync/CMakeLists.txt
+++ b/src/common/dbsync/CMakeLists.txt
@@ -5,42 +5,26 @@ project(dbsync)
 include(../../cmake/CommonSettings.cmake)
 set_common_settings()
 
-get_filename_component(SRC_FOLDER     ${CMAKE_CURRENT_SOURCE_DIR}/../../ ABSOLUTE)
-get_filename_component(COMMON_FOLDER  ${CMAKE_CURRENT_SOURCE_DIR}/../ ABSOLUTE)
-
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-if(WIN32)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-else()
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-endif()
-
-if(APPLE)
-    set(CMAKE_MACOSX_RPATH 1)
-endif(APPLE)
-
 find_package(cJSON CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(unofficial-sqlite3 CONFIG REQUIRED)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/)
-include_directories(${COMMON_FOLDER})
-
 add_definitions(-DPROMISE_TYPE=PromiseType::NORMAL)
-
-link_directories(${SRC_FOLDER})
 
 file(GLOB DBSYNC_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/sqlite/*.cpp")
 
 add_library(dbsync STATIC
-    ${DBSYNC_SRC}
-    ${SRC_FOLDER}/${RESOURCE_OBJ})
+    ${DBSYNC_SRC})
 
-target_include_directories(dbsync PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/)
+target_include_directories(dbsync
+    PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/../
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/
+)
 
 target_link_libraries(dbsync
     PUBLIC
@@ -50,10 +34,6 @@ target_link_libraries(dbsync
     sqlite_wrapper
     string_helper
     thread_dispatcher
-)
-
-target_link_libraries(dbsync
-    PUBLIC
     nlohmann_json::nlohmann_json
     cjson
     PRIVATE

--- a/src/common/dbsync/example/CMakeLists.txt
+++ b/src/common/dbsync/example/CMakeLists.txt
@@ -2,23 +2,17 @@ cmake_minimum_required(VERSION 3.22)
 
 project(dbsync_example)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/)
-link_directories(${CMAKE_BINARY_DIR}/lib)
-
 add_executable(dbsync_example
-    "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp" )
+               ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    target_link_libraries(dbsync_example
-        dbsync
-    )
-else()
-    target_link_libraries(dbsync_example
-        dbsync
-        pthread
-        dl
-    )
-endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+target_include_directories(dbsync_example PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/
+)
+
+target_link_libraries(dbsync_example
+    dbsync
+)
 
 include(../../../cmake/ConfigureTarget.cmake)
 configure_target(dbsync_example)

--- a/src/common/dbsync/integrationTests/CMakeLists.txt
+++ b/src/common/dbsync/integrationTests/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.22)
 
 project(integration_tests)
 
-include_directories(${CMAKE_SOURCE_DIR}/include/)
-
 find_package(GTest CONFIG REQUIRED)
 
 add_subdirectory(fim)

--- a/src/common/dbsync/integrationTests/fim/CMakeLists.txt
+++ b/src/common/dbsync/integrationTests/fim/CMakeLists.txt
@@ -4,42 +4,27 @@ project(fim_integration_test)
 
 add_definitions(-DTEST_DB_INPUTS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../include/)
-link_directories(${CMAKE_BINARY_DIR}/lib)
-
 file(GLOB INTERFACE_UNITTEST_SRC
     "*.cpp")
 
-file(GLOB DBSYNC_IMP_SRC
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/*.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/sqlite/*.cpp")
-
 add_executable(fim_integration_test
-    ${INTERFACE_UNITTEST_SRC}
-    ${DBSYNC_IMP_SRC})
+    ${INTERFACE_UNITTEST_SRC})
+
+target_include_directories(fim_integration_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/sqlite
+)
 
 configure_target(fim_integration_test)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    target_link_libraries(fim_integration_test
-        dbsync
-        GTest::gtest
-        GTest::gmock
-        GTest::gtest_main
-        GTest::gmock_main
-        cjson
-    )
-else()
-    target_link_libraries(fim_integration_test
-        dbsync
-        GTest::gtest
-        GTest::gmock
-        GTest::gtest_main
-        GTest::gmock_main
-        cjson
-        pthread
-        dl
-    )
-endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+target_link_libraries(fim_integration_test
+    dbsync
+    GTest::gtest
+    GTest::gmock
+    GTest::gtest_main
+    GTest::gmock_main
+    cjson
+)
+
 add_test(NAME fim_integration_test
          COMMAND fim_integration_test)

--- a/src/common/dbsync/tests/CMakeLists.txt
+++ b/src/common/dbsync/tests/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.22)
 
 project(unit_tests)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src/)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src/sqlite/)
-
 find_package(GTest CONFIG REQUIRED)
 
 add_subdirectory(interface)

--- a/src/common/dbsync/tests/dbengine/CMakeLists.txt
+++ b/src/common/dbsync/tests/dbengine/CMakeLists.txt
@@ -2,43 +2,27 @@ cmake_minimum_required(VERSION 3.22)
 
 project(dbengine_unit_test)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../include/ ${CMAKE_CURRENT_SOURCE_DIR}/../../../sqliteWrapper/tests/mocks)
-link_directories(${CMAKE_BINARY_DIR}/lib)
-
 file(GLOB DBENGINE_UNITTEST_SRC
     "*.cpp")
 
-file(GLOB SQLITE_ENGINE_SRC
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/*.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/sqlite/*.cpp")
-
 add_executable(dbengine_unit_test
-    ${DBENGINE_UNITTEST_SRC}
-    ${SQLITE_ENGINE_SRC})
+    ${DBENGINE_UNITTEST_SRC})
+
+target_include_directories(dbengine_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/sqlite
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../sqliteWrapper/tests/mocks
+)
 
 configure_target(dbengine_unit_test)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    target_link_libraries(dbengine_unit_test
-        dbsync
-        GTest::gtest
-        GTest::gmock
-        GTest::gtest_main
-        GTest::gmock_main
-        cjson
-    )
-else()
-    target_link_libraries(dbengine_unit_test
-        dbsync
-        GTest::gtest
-        GTest::gmock
-        GTest::gtest_main
-        GTest::gmock_main
-        cjson
-        pthread
-        dl
-    )
-endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+target_link_libraries(dbengine_unit_test
+    dbsync
+    GTest::gtest
+    GTest::gmock
+    GTest::gtest_main
+    GTest::gmock_main
+)
 
 add_test(NAME dbengine_unit_test
          COMMAND dbengine_unit_test)

--- a/src/common/dbsync/tests/interface/CMakeLists.txt
+++ b/src/common/dbsync/tests/interface/CMakeLists.txt
@@ -4,40 +4,27 @@ project(dbsync_unit_test)
 
 add_definitions(-DTEST_INPUTS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../include/)
-link_directories(${CMAKE_BINARY_DIR}/lib)
-
 file(GLOB INTERFACE_UNITTEST_SRC
-    "*.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/*.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/sqlite/*.cpp")
+    "*.cpp")
 
 add_executable(dbsync_unit_test
     ${INTERFACE_UNITTEST_SRC})
 
+target_include_directories(dbsync_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/sqlite
+)
+
 configure_target(dbsync_unit_test)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    target_link_libraries(dbsync_unit_test
-        dbsync
-        GTest::gtest
-        GTest::gmock
-        GTest::gtest_main
-        GTest::gmock_main
-        cjson
-    )
-else()
-    target_link_libraries(dbsync_unit_test
-        dbsync
-        GTest::gtest
-        GTest::gmock
-        GTest::gtest_main
-        GTest::gmock_main
-        cjson
-        pthread
-        dl
-    )
-endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+target_link_libraries(dbsync_unit_test
+    dbsync
+    GTest::gtest
+    GTest::gmock
+    GTest::gtest_main
+    GTest::gmock_main
+    cjson
+)
 
 add_test(NAME dbsync_unit_test
          COMMAND dbsync_unit_test)

--- a/src/common/dbsync/tests/pipelineFactory/CMakeLists.txt
+++ b/src/common/dbsync/tests/pipelineFactory/CMakeLists.txt
@@ -2,46 +2,26 @@ cmake_minimum_required(VERSION 3.22)
 
 project(dbsyncPipelineFactory_unit_test)
 
-include_directories(${CMAKE_SOURCE_DIR}/src/)
-link_directories(${CMAKE_BINARY_DIR}/lib)
-
 file(GLOB PIPELINE_FACTORY_UNITTEST_SRC
     "*.cpp")
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../include/)
-link_directories(${CMAKE_BINARY_DIR}/lib)
-
-file(GLOB PIPELINE_FACTORY_SRC
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/*.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/sqlite/*.cpp")
-
 add_executable(dbsyncPipelineFactory_unit_test
-    ${PIPELINE_FACTORY_UNITTEST_SRC}
-    ${PIPELINE_FACTORY_SRC})
+    ${PIPELINE_FACTORY_UNITTEST_SRC})
+
+target_include_directories(dbsyncPipelineFactory_unit_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/sqlite
+)
 
 configure_target(dbsyncPipelineFactory_unit_test)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    target_link_libraries(dbsyncPipelineFactory_unit_test
-        dbsync
-        GTest::gtest
-        GTest::gmock
-        GTest::gtest_main
-        GTest::gmock_main
-        cjson
-    )
-else()
-    target_link_libraries(dbsyncPipelineFactory_unit_test
-        dbsync
-        GTest::gtest
-        GTest::gmock
-        GTest::gtest_main
-        GTest::gmock_main
-        pthread
-        cjson
-        dl
-    )
-endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+target_link_libraries(dbsyncPipelineFactory_unit_test
+    dbsync
+    GTest::gtest
+    GTest::gmock
+    GTest::gtest_main
+    GTest::gmock_main
+)
 
 add_test(NAME dbsyncPipelineFactory_unit_test
          COMMAND dbsyncPipelineFactory_unit_test)

--- a/src/common/dbsync/testtool/CMakeLists.txt
+++ b/src/common/dbsync/testtool/CMakeLists.txt
@@ -2,24 +2,17 @@ cmake_minimum_required(VERSION 3.22)
 
 project(dbsync_test_tool)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/testtool/)
-link_directories(${CMAKE_BINARY_DIR}/lib)
-
 add_executable(dbsync_test_tool
-               ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp )
+               ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-	target_link_libraries(dbsync_test_tool
-	    dbsync
-	)
-else()
-	target_link_libraries(dbsync_test_tool
-	    dbsync
-	    pthread
-	    dl
-	)
-endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+target_include_directories(dbsync_test_tool PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/
+	${CMAKE_CURRENT_SOURCE_DIR}/../src/
+)
+
+target_link_libraries(dbsync_test_tool
+	dbsync
+)
 
 include(../../../cmake/ConfigureTarget.cmake)
 configure_target(dbsync_test_tool)

--- a/src/common/hashHelper/tests/CMakeLists.txt
+++ b/src/common/hashHelper/tests/CMakeLists.txt
@@ -17,6 +17,6 @@ target_include_directories(hash_helper_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../include
 )
 
-target_link_libraries(hash_helper_tests PRIVATE hash_helper GTest::gtest OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(hash_helper_tests PRIVATE hash_helper GTest::gtest)
 
 add_test(NAME hashHelperTests COMMAND hash_helper_tests)

--- a/src/modules/inventory/CMakeLists.txt
+++ b/src/modules/inventory/CMakeLists.txt
@@ -16,7 +16,10 @@ add_library(Inventory
     src/inventoryNormalizer.cpp
     src/statelessEvent.cpp)
 
-target_include_directories(Inventory PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(Inventory
+    PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
 
 target_link_libraries(Inventory
     PUBLIC
@@ -39,10 +42,10 @@ target_link_libraries(Inventory
     cjson
 )
 
+add_subdirectory(testtool)
+
 include(../../cmake/ConfigureTarget.cmake)
 configure_target(Inventory)
-
-add_subdirectory(testtool)
 
 if(BUILD_TESTS)
     enable_testing()

--- a/src/modules/inventory/CMakeLists.txt
+++ b/src/modules/inventory/CMakeLists.txt
@@ -5,9 +5,6 @@ project(Inventory)
 include(../../cmake/CommonSettings.cmake)
 set_common_settings()
 
-get_filename_component(SRC_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/../../ ABSOLUTE)
-get_filename_component(COMMON_FOLDER ${SRC_FOLDER}/common/ ABSOLUTE)
-
 find_package(cJSON CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(OpenSSL REQUIRED)
@@ -18,10 +15,6 @@ add_library(Inventory
     src/inventoryImp.cpp
     src/inventoryNormalizer.cpp
     src/statelessEvent.cpp)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    target_compile_options(Inventory PRIVATE /WX-)
-endif()
 
 target_include_directories(Inventory PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 

--- a/src/modules/inventory/tests/CMakeLists.txt
+++ b/src/modules/inventory/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.22)
 
 project(unit_tests)
 
+find_package(GTest CONFIG REQUIRED)
+
 add_subdirectory(inventory)
 add_subdirectory(inventoryImp)
 add_subdirectory(invNormalizer)

--- a/src/modules/inventory/tests/invNormalizer/CMakeLists.txt
+++ b/src/modules/inventory/tests/invNormalizer/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(GTest CONFIG REQUIRED)
-
 add_executable(inv_normalizer_unit_test invNormalizer_test.cpp)
 configure_target(inv_normalizer_unit_test)
 target_include_directories(inv_normalizer_unit_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)

--- a/src/modules/inventory/tests/inventory/CMakeLists.txt
+++ b/src/modules/inventory/tests/inventory/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(GTest CONFIG REQUIRED)
-
 add_executable(inventory_unit_test inventory_test.cpp)
 configure_target(inventory_unit_test)
 target_include_directories(inventory_unit_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)

--- a/src/modules/inventory/tests/inventoryImp/CMakeLists.txt
+++ b/src/modules/inventory/tests/inventoryImp/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(GTest CONFIG REQUIRED)
-
 add_executable(inventoryimp_unit_test inventoryImp_test.cpp)
 configure_target(inventoryimp_unit_test)
 target_include_directories(inventoryimp_unit_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)

--- a/src/modules/inventory/tests/statelessEvent/CMakeLists.txt
+++ b/src/modules/inventory/tests/statelessEvent/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(GTest CONFIG REQUIRED)
-
 add_executable(statelessEvent_unit_test statelessEvent_test.cpp)
 configure_target(statelessEvent_unit_test)
 
@@ -8,19 +6,10 @@ target_include_directories(statelessEvent_unit_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/inventory/events
 )
 
-if(NOT WIN32)
-    target_link_libraries(statelessEvent_unit_test PRIVATE
-        Inventory
-        GTest::gtest
-        GTest::gtest_main
-        pthread
-    )
-else()
-    target_link_libraries(statelessEvent_unit_test PRIVATE
-        Inventory
-        GTest::gtest
-        GTest::gtest_main
-    )
-endif()
+target_link_libraries(statelessEvent_unit_test PRIVATE
+    Inventory
+    GTest::gtest
+    GTest::gtest_main
+)
 
 add_test(NAME StatelessEventUnitTest COMMAND statelessEvent_unit_test)

--- a/src/modules/inventory/testtool/CMakeLists.txt
+++ b/src/modules/inventory/testtool/CMakeLists.txt
@@ -2,15 +2,15 @@ cmake_minimum_required(VERSION 3.22)
 
 project(inventory_test_tool)
 
-file(GLOB INVENTORY_TESTTOOL_SRC
-        "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
-        )
-
 add_executable(inventory_test_tool
-               ${INVENTORY_TESTTOOL_SRC}
-               )
+               ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+target_include_directories(inventory_test_tool PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/
+)
+
+if(WIN32)
     target_link_libraries(inventory_test_tool
         dbsync
         sysinfo
@@ -25,10 +25,8 @@ else()
         dbsync
         sysinfo
         Inventory
-        pthread
-        dl
     )
-endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+endif()
 
 include(../../../cmake/ConfigureTarget.cmake)
 configure_target(inventory_test_tool)

--- a/src/modules/logcollector/CMakeLists.txt
+++ b/src/modules/logcollector/CMakeLists.txt
@@ -7,9 +7,6 @@ set_common_settings()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-get_filename_component(SRC_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/../../ ABSOLUTE)
-get_filename_component(COMMON_FOLDER ${SRC_FOLDER}/common/ ABSOLUTE)
-
 if(APPLE)
     find_package(fmt REQUIRED)
     add_subdirectory(src/macos_reader/oslogstore)

--- a/src/modules/logcollector/CMakeLists.txt
+++ b/src/modules/logcollector/CMakeLists.txt
@@ -14,7 +14,6 @@ endif()
 
 find_package(cJSON CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
-find_package(OpenSSL REQUIRED)
 find_package(Boost REQUIRED COMPONENTS asio)
 
 FILE(GLOB LOGCOLLECTOR_SOURCES src/*.cpp src/file_reader/src/*.cpp)

--- a/src/modules/logcollector/tests/CMakeLists.txt
+++ b/src/modules/logcollector/tests/CMakeLists.txt
@@ -2,4 +2,6 @@ cmake_minimum_required(VERSION 3.22)
 
 project(LogcollectorTests)
 
+find_package(GTest CONFIG REQUIRED)
+
 add_subdirectory(unit)

--- a/src/modules/logcollector/tests/unit/CMakeLists.txt
+++ b/src/modules/logcollector/tests/unit/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(GTest CONFIG REQUIRED)
-
 if(UNIX AND NOT APPLE)
 	find_package(PkgConfig REQUIRED)
 	pkg_check_modules(SYSTEMD REQUIRED libsystemd)


### PR DESCRIPTION
## Description

This PR adds several improvements to the Windows scaffolding, as reported by https://github.com/wazuh/wazuh-agent/issues/692. These changes also significantly reduce the MSI and installation size.

## Proposed Changes

- Fix UT location so they are not included in the MSI.
  - `data_provider` and `dbsync` cmake improvements.
- Improve some UT, run them on the correct OSs.
- Link `vcpkg` dependencies statically.
  - Several changes/improvements in Windows scaffolding and package sizes.
- Remove some unused target links.
- Suppress some inoffensive macOS compilation warnings.

### Results and Evidence

Linux:

```
# ldd wazuh-agent
        linux-vdso.so.1 (0x0000e8cf367a7000)
        libsystemd.so.0 => /lib/aarch64-linux-gnu/libsystemd.so.0 (0x0000e8cf35500000)
        libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000e8cf35450000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000e8cf35290000)
        /lib/ld-linux-aarch64.so.1 (0x0000e8cf3676a000)
        libcap.so.2 => /lib/aarch64-linux-gnu/libcap.so.2 (0x0000e8cf36740000)
        libgcrypt.so.20 => /lib/aarch64-linux-gnu/libgcrypt.so.20 (0x0000e8cf35180000)
        liblz4.so.1 => /lib/aarch64-linux-gnu/liblz4.so.1 (0x0000e8cf36700000)
        liblzma.so.5 => /lib/aarch64-linux-gnu/liblzma.so.5 (0x0000e8cf35130000)
        libzstd.so.1 => /lib/aarch64-linux-gnu/libzstd.so.1 (0x0000e8cf35070000)
        libgpg-error.so.0 => /lib/aarch64-linux-gnu/libgpg-error.so.0 (0x0000e8cf35020000)
```

macOS:

```
% otool -L wazuh-agent 
wazuh-agent:
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 61439.60.117)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 3208.0.0)
        /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 3208.0.0)
        /System/Library/Frameworks/OSLog.framework/Versions/A/OSLog (compatibility version 1.0.0, current version 1612.60.27)
        /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
        /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
        /usr/lib/libcharset.1.dylib (compatibility version 1.0.0, current version 1.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1800.105.0)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```

Windows

```
>dumpbin /dependents wazuh-agent.exe
Microsoft (R) COFF/PE Dumper Version 14.40.33811.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file wazuh-agent.exe

File Type: EXECUTABLE IMAGE

  Image has the following dependencies:

    bcrypt.dll
    CRYPT32.dll
    IPHLPAPI.DLL
    WS2_32.dll
    KERNEL32.dll
    USER32.dll
    SHELL32.dll
    ole32.dll
    ADVAPI32.dll
    wevtapi.dll
```

![image](https://github.com/user-attachments/assets/cb154de0-724f-4b48-bac2-44bdfe33270e)

Old sizes:
- MSI : 47.4 MB
- Install size: 62.0 MB

New sizes:
- MSI: 38.8 MB
- Install size: 47.9 MB

### Artifacts Affected

- MSI

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

N/A

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
