### PR TITLE
Rename Windows agent service

### DIFF
--- a/docs/dev/run-agent.md
+++ b/docs/dev/run-agent.md
@@ -129,8 +129,8 @@ cd build/
     The agent service can be started, stopped, or restarted from the CLI:
 
     ```bash
-    net start "Wazuh Agent"
-    net stop "Wazuh Agent"
+    net start "wazuh-agent"
+    net stop "wazuh-agent"
     ```
 
     > This can also be done using Windows SCM.

--- a/docs/ref/backup-restore.md
+++ b/docs/ref/backup-restore.md
@@ -51,7 +51,7 @@ not recommended for moving an agent from one endpoint to another.
 
 1. Stop the Wazuh Agent service:
    ```sh
-   net stop "Wazuh Agent"
+   net stop "wazuh-agent"
    ```
 
 2. Preparing the backup:
@@ -118,5 +118,5 @@ not recommended for moving an agent from one endpoint to another.
 
 3. Start the service:
    ```sh
-   net start "Wazuh Agent"
+   net start "wazuh-agent"
    ```

--- a/packages/windows/cleanup.ps1
+++ b/packages/windows/cleanup.ps1
@@ -47,7 +47,7 @@ if (-not (Get-ChildItem -Path $CleanPath -Recurse)) {
 
 
 # Remove Wazuh service
-$serviceName = "Wazuh Agent"
+$serviceName = "wazuh-agent"
 $wazuhagent = "$PSScriptRoot\wazuh-agent.exe"
 
 Write-Host "Removing service $serviceName."

--- a/packages/windows/postinstall.ps1
+++ b/packages/windows/postinstall.ps1
@@ -58,7 +58,7 @@ if (Test-Path $sourcePath) {
 
 
 # Install Wazuh service
-$serviceName = "Wazuh Agent"
+$serviceName = "wazuh-agent"
 $wazuhagent = "$PSScriptRoot\wazuh-agent.exe"
 
 Write-Host "Installing service $serviceName."

--- a/src/agent/restart_handler/src/restart_handler.cpp
+++ b/src/agent/restart_handler/src/restart_handler.cpp
@@ -6,7 +6,7 @@ namespace restart_handler
 {
     boost::asio::awaitable<module_command::CommandExecutionResult> RestartHandler::RestartAgent()
     {
-        LogInfo("Restarting Wazuh Agent");
+        LogInfo("Restarting wazuh-agent");
 
         if (RunningAsService())
         {

--- a/src/agent/restart_handler/src/restart_handler_win.cpp
+++ b/src/agent/restart_handler/src/restart_handler_win.cpp
@@ -41,7 +41,7 @@ namespace restart_handler
             CloseHandle(pi.hProcess);
             CloseHandle(pi.hThread);
         }
-        LogInfo("Exiting Wazuh Agent now");
+        LogInfo("Exiting wazuh-agent now");
         GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0);
         co_return module_command::CommandExecutionResult {module_command::Status::IN_PROGRESS,
                                                           "Pending restart execution"};
@@ -92,7 +92,7 @@ namespace restart_handler
 
         const std::string pwrShell = GetPowerShellPath();
 
-        const std::string cmd = pwrShell + " -Command \"Restart-Service -Name 'Wazuh Agent' -Force\"";
+        const std::string cmd = pwrShell + " -Command \"Restart-Service -Name 'wazuh-agent' -Force\"";
 
         if (CreateProcess(NULL,
                           (LPSTR)cmd.c_str(),

--- a/src/agent/src/windows/windows_service.cpp
+++ b/src/agent/src/windows/windows_service.cpp
@@ -14,7 +14,7 @@ namespace
     SERVICE_STATUS_HANDLE g_StatusHandle = nullptr;
     HANDLE g_ServiceStopEvent = INVALID_HANDLE_VALUE;
     SERVICE_DESCRIPTION g_serviceDescription;
-    const std::string AGENT_SERVICENAME = "Wazuh Agent";
+    const std::string AGENT_SERVICENAME = "wazuh-agent";
     const std::string AGENT_SERVICEDESCRIPTION = "Wazuh Windows Agent";
 
     struct ServiceHandleDeleter
@@ -136,7 +136,7 @@ namespace windows_service
         CloseServiceHandle(schService);
         CloseServiceHandle(schSCManager);
 
-        LogInfo("Wazuh Agent Service successfully installed.");
+        LogInfo("{} service successfully installed.", AGENT_SERVICENAME.c_str());
 
         return true;
     }
@@ -170,7 +170,7 @@ namespace windows_service
         CloseServiceHandle(schService);
         CloseServiceHandle(schSCManager);
 
-        LogInfo("Wazuh Agent Service successfully removed.");
+        LogInfo("{} service successfully removed.", AGENT_SERVICENAME.c_str());
 
         return true;
     }
@@ -231,19 +231,20 @@ namespace windows_service
 
             if (!instanceHandler.isLockAcquired())
             {
-                LogError("Wazuh Agent cannot start. Wazuh Agent is already running");
+                LogError(
+                    "{} cannot start. {} is already running", AGENT_SERVICENAME.c_str(), AGENT_SERVICENAME.c_str());
                 ReportServiceStatus(SERVICE_STOPPED, NO_ERROR, 0);
                 return;
             }
 
-            LogInfo("Starting Wazuh Agent.");
+            LogInfo("Starting {}.", AGENT_SERVICENAME.c_str());
 
             Agent agent(std::make_unique<configuration::ConfigurationParser>(std::filesystem::path(configFilePath)));
             agent.Run();
         }
         catch (const std::exception& e)
         {
-            LogError("Exception thrown in wazuh-agent: {}", e.what());
+            LogError("Exception thrown in {}: {}", AGENT_SERVICENAME.c_str(), e.what());
             error = ERROR_EXCEPTION_IN_SERVICE;
         }
 
@@ -258,7 +259,7 @@ namespace windows_service
         switch (ctrlCode)
         {
             case SERVICE_CONTROL_STOP:
-                HandleStopSignal("Wazuh Agent is stopping. Performing cleanup.", ctrlCode);
+                HandleStopSignal("wazuh-agent is stopping. Performing cleanup.", ctrlCode);
                 break;
             case SERVICE_CONTROL_SHUTDOWN:
                 HandleStopSignal("System is shutting down. Performing cleanup.", ctrlCode);

--- a/src/agent/src/windows/windows_service.hpp
+++ b/src/agent/src/windows/windows_service.hpp
@@ -9,12 +9,12 @@
 
 namespace windows_service
 {
-    /// @brief Installs the Wazuh Agent Service.
+    /// @brief Installs the wazuh-agent service.
     /// @param windowsApiFacade The Windows API facade to use.
     /// @return True if the installation is successful, false otherwise.
     bool InstallService(const windows_api_facade::IWindowsApiFacade& windowsApiFacade);
 
-    /// @brief Removes the Wazuh Agent Service.
+    /// @brief Removes the wazuh-agent service.
     /// @param windowsApiFacade The Windows API facade to use.
     /// @return True if the removal is successful, false otherwise.
     bool RemoveService(const windows_api_facade::IWindowsApiFacade& windowsApiFacade);
@@ -31,7 +31,7 @@ namespace windows_service
     /// @param ctrlCode The control code.
     void WINAPI ServiceCtrlHandler(DWORD ctrlCode);
 
-    /// @brief Starts the Wazuh Agent Service.
+    /// @brief Starts the wazuh-agent service.
     /// @param configFilePath The path to the configuration file.
     void ServiceStart(const std::string& configFilePath);
 } // namespace windows_service

--- a/src/agent/tests/windows/windows_service_test.cpp
+++ b/src/agent/tests/windows/windows_service_test.cpp
@@ -56,7 +56,7 @@ TEST_F(WindowsServiceTest, InstallService_Success)
 {
     EXPECT_CALL(mockWindowsApiFacade, OpenSCM(SC_MANAGER_CREATE_SERVICE))
         .WillOnce(testing::Return(reinterpret_cast<SC_HANDLE>(1)));
-    EXPECT_CALL(mockWindowsApiFacade, CreateSvc(testing::_, "Wazuh Agent", testing::_))
+    EXPECT_CALL(mockWindowsApiFacade, CreateSvc(testing::_, "wazuh-agent", testing::_))
         .WillOnce(testing::Return(reinterpret_cast<SC_HANDLE>(1)));
 
     bool result = windows_service::InstallService(mockWindowsApiFacade);


### PR DESCRIPTION
## Description

Closes #691

The Windows agent service is currently named "Wazuh Agent". This PR renames it to "wazuh-agent" to maintain consistency across all platforms.

## Proposed Changes

The service name is updated in:
- Installation and uninstallation by package scripts.
- Methods for installing/uninstalling and starting/restarting/stopping the service (`windows_service.cpp`).
- Related documentation

### Documentation Updates

- docs/dev/run-agent.md
- docs/ref/backup-restore.md

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

