### PR TITLE
Refactor workflow links according to the convention

### DIFF
--- a/.github/workflows/5_builderpackage_docker-upload.yml
+++ b/.github/workflows/5_builderpackage_docker-upload.yml
@@ -129,28 +129,28 @@ jobs:
       - name: Request pkg_deb_agent_builder_amd64 update
         if: steps.changes.outputs.pkg_deb_agent_builder_amd64 == 'true'
         run: |
-          gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=deb -f architecture=amd64 -f source_reference=${{ github.ref_name }}
+          gh workflow run 5_builderpackage_upload-images-linux.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=deb -f architecture=amd64 -f source_reference=${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
 
       - name: Request pkg_rpm_agent_builder_amd64 update
         if: steps.changes.outputs.pkg_rpm_agent_builder_amd64 == 'true'
         run: |
-          gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=amd64 -f source_reference=${{ github.ref_name }}
+          gh workflow run 5_builderpackage_upload-images-linux.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=amd64 -f source_reference=${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
 
       - name: Request pkg_deb_agent_builder_arm64 update
         if: steps.changes.outputs.pkg_deb_agent_builder_arm64 == 'true'
         run: |
-          gh workflow run packages-upload-agent-images-arm.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=deb -f architecture=arm64 -f source_reference=${{ github.ref_name }}
+          gh workflow run 5_builderpackage_upload-images-linux.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=deb -f architecture=arm64 -f source_reference=${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
 
       - name: Request pkg_rpm_agent_builder_arm64 update
         if: steps.changes.outputs.pkg_rpm_agent_builder_arm64 == 'true'
         run: |
-          gh workflow run packages-upload-agent-images-arm.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=arm64 -f source_reference=${{ github.ref_name }}
+          gh workflow run 5_builderpackage_upload-images-linux.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=arm64 -f source_reference=${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
 

--- a/.github/workflows/5_builderpackage_docker-upload.yml
+++ b/.github/workflows/5_builderpackage_docker-upload.yml
@@ -133,52 +133,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
 
-      - name: Request pkg_deb_agent_builder_i386 update
-        if: steps.changes.outputs.pkg_deb_agent_builder_i386 == 'true'
-        run: |
-          gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=deb -f architecture=i386 -f source_reference=${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
-
-      - name: Request pkg_deb_agent_builder_ppc64le update
-        if: steps.changes.outputs.pkg_deb_agent_builder_ppc64le == 'true'
-        run: |
-          gh workflow run packages-upload-agent-images-ppc.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=deb -f source_reference=${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
-
       - name: Request pkg_rpm_agent_builder_amd64 update
         if: steps.changes.outputs.pkg_rpm_agent_builder_amd64 == 'true'
         run: |
           gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=amd64 -f source_reference=${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
-
-      - name: Request pkg_rpm_agent_builder_i386 update
-        if: steps.changes.outputs.pkg_rpm_agent_builder_i386 == 'true'
-        run: |
-          gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=amd64 -f source_reference=${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
-
-      - name: Request pkg_rpm_agent_builder_ppc64le update
-        if: steps.changes.outputs.pkg_rpm_agent_builder_ppc64le == 'true'
-        run: |
-          gh workflow run packages-upload-agent-images-ppc.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f source_reference=${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
-
-      - name: Request pkg_rpm_legacy_builder_amd64 update
-        if: steps.changes.outputs.pkg_rpm_legacy_builder_amd64 == 'true'
-        run: |
-          gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=amd64 -f legacy=true -f source_reference=${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
-
-      - name: Request pkg_rpm_legacy_builder_i386 update
-        if: steps.changes.outputs.pkg_rpm_legacy_builder_i386 == 'true'
-        run: |
-          gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=i386 -f legacy=true -f source_reference=${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
 
@@ -189,13 +147,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
 
-      - name: Request pkg_deb_agent_builder_armhf update
-        if: steps.changes.outputs.pkg_deb_agent_builder_armhf == 'true'
-        run: |
-          gh workflow run packages-upload-agent-images-arm.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=deb -f architecture=armhf -f source_reference=${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
-
       - name: Request pkg_rpm_agent_builder_arm64 update
         if: steps.changes.outputs.pkg_rpm_agent_builder_arm64 == 'true'
         run: |
@@ -203,23 +154,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
 
-      - name: Request pkg_rpm_agent_builder_armhf update
-        if: steps.changes.outputs.pkg_rpm_agent_builder_armhf == 'true'
-        run: |
-          gh workflow run packages-upload-agent-images-arm.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=armhf -f source_reference=${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
-
-      - name: Request compile_windows_agent update
-        if: steps.changes.outputs.compile_windows_agent == 'true'
-        run: |
-          gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=windows -f architecture=i386 -f source_reference=${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
-
-      - name: Request commom_wpk_builder update
-        if: steps.changes.outputs.commom_wpk_builder == 'true'
-        run: |
-          gh workflow run packages-upload-wpk-images.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=common -f source_reference=${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}


### PR DESCRIPTION
## Description

This PR is part of an effort to align product workflows with a convention.

This PR aims to update the links to the new workflows for 5.x versions.

## Proposed Changes

Rename the following workflow links at **5_builderpackage_docker-upload**:

| Current link                     | New link                             |
|----------------------------------|--------------------------------------|
| packages-build-linux-agent-amd   | 5_builderpackage_agent-linux         |
| packages-build-linux-agent-arm   | 5_builderpackage_agent-linux         |

In addition, remove the support for:

- packages-build-linux-agent-ppc
- packages-build-solaris-i386-agent
- packages-build-special-agent
- packages-build-wpk
- packages-upload-agent-images-arm
- packages-upload-agent-images-ppc
- packages-upload-wpk-images

### Results and Evidence

We cannot provide any evidence of the newly named workflows until they are in the _main_ branch.

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

N/A

## Dependencies

> [!IMPORTANT]
> This change may affect other workflows or processes using these workflows. Please ensure those dependencies are resolved before merging this PR.

- https://github.com/wazuh/wazuh-agent-packages/pull/257

## Review Checklist

- [ ] Code changes reviewed
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
