### PR TITLE
SCA implement communication lambdas pass through

### DIFF
--- a/docs/dev/build-sources.md
+++ b/docs/dev/build-sources.md
@@ -53,5 +53,5 @@
 |`ENABLE_CLANG_TIDY`|Check code with _clang-tidy_ (requires `clang-tidy-18`) |`ON`|
 |`ENABLE_INVENTORY`|Enable Inventory module |`ON`|
 |`ENABLE_LOGCOLLECTOR`|Enable Logcollector module|`ON`|
-|`ENABLE_SCA`|Enable SCA module|`OFF`|
+|`ENABLE_SCA`|Enable SCA module|`ON`|
 

--- a/docs/ref/modules/logcollector/architecture.md
+++ b/docs/ref/modules/logcollector/architecture.md
@@ -13,7 +13,7 @@ classDiagram
         + Stop()
         + ExecuteCommand(CommandResult(string))
         + SetPushMessageFunction(std::function)
-        + SendMessage()
+        + PushMessage()
         + EnqueueTask()
         + AddReader()
         + Wait()

--- a/src/agent/include/agent.hpp
+++ b/src/agent/include/agent.hpp
@@ -6,9 +6,9 @@
 #include <iagent_info.hpp>
 #include <icommand_handler.hpp>
 #include <ihttp_client.hpp>
+#include <imoduleManager.hpp>
 #include <imultitype_queue.hpp>
 #include <isignal_handler.hpp>
-#include <moduleManager.hpp>
 #include <signal_handler.hpp>
 #include <sysInfo.hpp>
 #include <task_manager.hpp>
@@ -31,6 +31,7 @@ public:
     /// @param httpClient Pointer to an IHttpClient implementation
     /// @param agentInfo Pointer to a custom IAgentInfo implementation
     /// @param commandHandler Pointer to a custom ICommandHandler implementation
+    /// @param moduleManager Pointer to a custom IModuleManager implementation
     /// @param messageQueue Pointer to a custom IMultiTypeQueue implementation
     /// @throws std::runtime_error If the Agent is not enrolled
     /// @throws Any exception propagated from dependencies used within the constructor
@@ -40,6 +41,7 @@ public:
           std::unique_ptr<http_client::IHttpClient> httpClient = nullptr,
           std::unique_ptr<IAgentInfo> agentInfo = nullptr,
           std::unique_ptr<command_handler::ICommandHandler> commandHandler = nullptr,
+          std::unique_ptr<IModuleManager> moduleManager = nullptr,
           std::shared_ptr<IMultiTypeQueue> messageQueue = nullptr);
 
     /// @brief Destructor
@@ -78,7 +80,7 @@ private:
     communicator::Communicator m_communicator;
 
     /// @brief Module manager
-    ModuleManager m_moduleManager;
+    std::unique_ptr<IModuleManager> m_moduleManager;
 
     /// @brief Command handler
     std::unique_ptr<command_handler::ICommandHandler> m_commandHandler;

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -8,7 +8,8 @@ target_include_directories(
             ${CMAKE_CURRENT_SOURCE_DIR}/../agent_info/tests/mocks
             ${CMAKE_CURRENT_SOURCE_DIR}/../command_handler/tests/mocks
             ${CMAKE_CURRENT_SOURCE_DIR}/../http_client/tests/mocks
-            ${CMAKE_CURRENT_SOURCE_DIR}/../multitype_queue/tests/mocks)
+            ${CMAKE_CURRENT_SOURCE_DIR}/../multitype_queue/tests/mocks
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../modules/tests/mocks)
 target_link_libraries(agent_test PRIVATE Agent Persistence GTest::gtest GTest::gmock)
 
 if(NOT WIN32)

--- a/src/agent/tests/CMakeLists.txt
+++ b/src/agent/tests/CMakeLists.txt
@@ -12,9 +12,7 @@ target_include_directories(
             ${CMAKE_CURRENT_SOURCE_DIR}/../../modules/tests/mocks)
 target_link_libraries(agent_test PRIVATE Agent Persistence GTest::gtest GTest::gmock)
 
-if(NOT WIN32)
-    add_test(NAME AgentTest COMMAND agent_test)
-endif()
+add_test(NAME AgentTest COMMAND agent_test)
 
 add_executable(agent_enrollment_test agent_enrollment_test.cpp)
 configure_target(agent_enrollment_test)

--- a/src/agent/tests/agent_test.cpp
+++ b/src/agent/tests/agent_test.cpp
@@ -8,6 +8,7 @@
 #include <mock_agent_info.hpp>
 #include <mock_command_handler.hpp>
 #include <mock_http_client.hpp>
+#include <mock_module_manager.hpp>
 #include <mock_multitype_queue.hpp>
 
 class MockSignalHandler : public ISignalHandler
@@ -63,10 +64,15 @@ TEST_F(AgentTests, AgentStopsWhenSignalReceived)
     auto mockAgentInfo = std::make_unique<MockAgentInfo>();
     MockAgentInfo* mockAgentInfoPtr = mockAgentInfo.get();
 
+    auto mockModuleManager = std::make_unique<MockModuleManager>();
+    MockModuleManager* mockModuleManagerPtr = mockModuleManager.get();
+    EXPECT_CALL(*mockModuleManagerPtr, Start()).Times(1);
+    EXPECT_CALL(*mockModuleManagerPtr, Stop()).Times(1);
+
     auto WaitForSignalCalled = false;
 
     const std::vector<std::string> mockGroups = {"group1", "group2"};
-    EXPECT_CALL(*mockAgentInfoPtr, GetUUID()).Times(3).WillRepeatedly(testing::Return("mock_uuid"));
+    EXPECT_CALL(*mockAgentInfoPtr, GetUUID()).Times(2).WillRepeatedly(testing::Return("mock_uuid"));
     EXPECT_CALL(*mockAgentInfoPtr, GetKey()).Times(2).WillRepeatedly(testing::Return("mock_key"));
     EXPECT_CALL(*mockAgentInfoPtr, GetName()).WillOnce(testing::Return("mock_name"));
     EXPECT_CALL(*mockAgentInfoPtr, GetGroups()).WillOnce(testing::Return(mockGroups));
@@ -91,6 +97,7 @@ TEST_F(AgentTests, AgentStopsWhenSignalReceived)
                 std::move(mockHttpClient),
                 std::move(mockAgentInfo),
                 std::move(mockCommandHandler),
+                std::move(mockModuleManager),
                 std::move(mockMultiTypeQueue));
 
     EXPECT_NO_THROW(agent.Run());

--- a/src/cmake/CommonSettings.cmake
+++ b/src/cmake/CommonSettings.cmake
@@ -50,7 +50,7 @@ function(set_common_settings)
     option(COVERAGE "Enable coverage report" OFF)
     option(ENABLE_INVENTORY "Enable Inventory module" ON)
     option(ENABLE_LOGCOLLECTOR "Enable Logcollector module" ON)
-    option(ENABLE_SCA "Enable SCA module" OFF)
+    option(ENABLE_SCA "Enable SCA module" ON)
 
     if(COVERAGE)
         if(NOT TARGET coverage)

--- a/src/modules/include/imoduleManager.hpp
+++ b/src/modules/include/imoduleManager.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <command_entry.hpp>
+#include <message.hpp>
+#include <moduleWrapper.hpp>
+#include <task_manager.hpp>
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+class IModuleManager
+{
+public:
+    /// @brief Default destructor
+    virtual ~IModuleManager() = default;
+
+    /// @brief Adds all modules to the manager
+    virtual void AddModules() = 0;
+
+    /// @brief Get a module by name
+    ///
+    /// @param[in] name Name of the module
+    /// @return Pointer to the module
+    virtual std::shared_ptr<ModuleWrapper> GetModule(const std::string& name) = 0;
+
+    /// @brief Start the modules
+    ///
+    /// This function begins the procedure to start the modules and blocks until the Start function
+    /// for each module has been called. However, it does not guarantee that the modules are fully
+    /// operational upon return; they may still be in the process of initializing.
+    ///
+    /// @note Call this function before interacting with the modules to ensure the startup process is initiated.
+    /// @warning Ensure the modules have fully started before performing any operations that depend on them.
+    virtual void Start() = 0;
+
+    /// @brief Setup the modules
+    virtual void Setup() = 0;
+
+    /// @brief Stop the modules
+    virtual void Stop() = 0;
+};

--- a/src/modules/include/moduleManager.hpp
+++ b/src/modules/include/moduleManager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <command_entry.hpp>
+#include <imoduleManager.hpp>
 #include <message.hpp>
 #include <moduleWrapper.hpp>
 #include <task_manager.hpp>
@@ -11,7 +12,7 @@
 #include <string>
 #include <thread>
 
-class ModuleManager
+class ModuleManager : public IModuleManager
 {
 public:
     /// @brief Constructor for ModuleManager
@@ -62,30 +63,20 @@ public:
         m_modules[moduleName] = wrapper;
     }
 
-    /// @brief Adds all modules to the manager
-    void AddModules();
+    /// @copydoc IModuleManager::AddModules
+    void AddModules() override;
 
-    /// @brief Get a module by name
-    ///
-    /// @param[in] name Name of the module
-    /// @return Pointer to the module
-    std::shared_ptr<ModuleWrapper> GetModule(const std::string& name);
+    /// @copydoc IModuleManager::GetModule
+    std::shared_ptr<ModuleWrapper> GetModule(const std::string& name) override;
 
-    /// @brief Start the modules
-    ///
-    /// This function begins the procedure to start the modules and blocks until the Start function
-    /// for each module has been called. However, it does not guarantee that the modules are fully
-    /// operational upon return; they may still be in the process of initializing.
-    ///
-    /// @note Call this function before interacting with the modules to ensure the startup process is initiated.
-    /// @warning Ensure the modules have fully started before performing any operations that depend on them.
-    void Start();
+    /// @copydoc IModuleManager::Start
+    void Start() override;
 
-    /// @brief Setup the modules
-    void Setup();
+    /// @copydoc IModuleManager::Setup
+    void Setup() override;
 
-    /// @brief Stop the modules
-    void Stop();
+    /// @copydoc IModuleManager::Stop
+    void Stop() override;
 
 private:
     /// @brief The task manager

--- a/src/modules/inventory/include/inventory.hpp
+++ b/src/modules/inventory/include/inventory.hpp
@@ -49,7 +49,8 @@ public:
               const std::string& dbPath,
               const std::string& normalizerConfigPath,
               const std::string& normalizerType);
-    virtual void SendDeltaEvent(const std::string& data);
+
+    virtual void PushMessage(const std::string& data);
 
     const std::string& AgentUUID() const
     {

--- a/src/modules/inventory/src/inventory.cpp
+++ b/src/modules/inventory/src/inventory.cpp
@@ -24,7 +24,7 @@ void Inventory::Start()
     {
         Inventory::Instance().Init(
             std::make_shared<SysInfo>(),
-            [this](const std::string& diff) { this->SendDeltaEvent(diff); },
+            [this](const std::string& diff) { this->PushMessage(diff); },
             m_dbFilePath,
             m_normConfigPath,
 #if defined(__linux__)
@@ -101,7 +101,7 @@ void Inventory::SetPushMessageFunction(const std::function<int(Message)>& pushMe
     m_pushMessage = pushMessage;
 }
 
-void Inventory::SendDeltaEvent(const std::string& data)
+void Inventory::PushMessage(const std::string& data)
 {
 
     const auto jsonData = nlohmann::json::parse(data);

--- a/src/modules/inventory/tests/inventory/inventory_test.cpp
+++ b/src/modules/inventory/tests/inventory/inventory_test.cpp
@@ -39,7 +39,7 @@ TEST_F(InventoryTest, SendUpdateEvent_Stateful)
         "data": {"key": "value"}
     })";
 
-    inventory.SendDeltaEvent(inputData);
+    inventory.PushMessage(inputData);
 }
 
 TEST_F(InventoryTest, SendDeleteEvent_Stateful)
@@ -69,7 +69,7 @@ TEST_F(InventoryTest, SendDeleteEvent_Stateful)
         "data": {"key": "value"}
     })";
 
-    inventory.SendDeltaEvent(inputData);
+    inventory.PushMessage(inputData);
 }
 
 TEST_F(InventoryTest, SendUpdateEvent_WithStateless)
@@ -106,7 +106,7 @@ TEST_F(InventoryTest, SendUpdateEvent_WithStateless)
         "stateless": {"alert": "high"}
     })";
 
-    inventory.SendDeltaEvent(inputData);
+    inventory.PushMessage(inputData);
 }
 
 TEST_F(InventoryTest, PushMessageFails_LogsWarning)
@@ -125,7 +125,7 @@ TEST_F(InventoryTest, PushMessageFails_LogsWarning)
         "data": {"key": "value"}
     })";
 
-    inventory.SendDeltaEvent(inputData);
+    inventory.PushMessage(inputData);
 }
 
 int main(int argc, char** argv)

--- a/src/modules/logcollector/include/logcollector.hpp
+++ b/src/modules/logcollector/include/logcollector.hpp
@@ -50,12 +50,12 @@ namespace logcollector
         /// @param pushMessage Push message function
         void SetPushMessageFunction(const std::function<int(Message)>& pushMessage);
 
-        /// @brief Sends a message to que queue
+        /// @brief Pushes a message to que queue
         /// @param location Location of the message
         /// @param log Message to send
         /// @param collectorType type of logcollector
         /// @pre The message queue must be set with SetMessageQueue
-        virtual void SendMessage(const std::string& location, const std::string& log, const std::string& collectorType);
+        virtual void PushMessage(const std::string& location, const std::string& log, const std::string& collectorType);
 
         /// @brief Enqueues an ASIO task (coroutine)
         /// @param task Task to enqueue

--- a/src/modules/logcollector/src/file_reader/src/file_reader.cpp
+++ b/src/modules/logcollector/src/file_reader/src/file_reader.cpp
@@ -49,7 +49,7 @@ Awaitable FileReader::ReadLocalfile(Localfile* lf)
 
         while (!log.empty())
         {
-            m_logcollector.SendMessage(lf->Filename(), log, m_collectorType);
+            m_logcollector.PushMessage(lf->Filename(), log, m_collectorType);
             log = lf->NextLog();
         }
 

--- a/src/modules/logcollector/src/journald_reader/src/journald_reader.cpp
+++ b/src/modules/logcollector/src/journald_reader/src/journald_reader.cpp
@@ -73,7 +73,7 @@ namespace logcollector
                             LogDebug("Truncating message of length {}", message.length());
                             message.resize(MAX_LINE_LENGTH);
                         }
-                        m_logcollector.SendMessage(filteredMessage->fieldValue, message, COLLECTOR_TYPE);
+                        m_logcollector.PushMessage(filteredMessage->fieldValue, message, COLLECTOR_TYPE);
                     }
                 }
                 catch (const JournalLogException& e)

--- a/src/modules/logcollector/src/logcollector.cpp
+++ b/src/modules/logcollector/src/logcollector.cpp
@@ -126,7 +126,7 @@ void Logcollector::SetPushMessageFunction(const std::function<int(Message)>& pus
     m_pushMessage = pushMessage;
 }
 
-void Logcollector::SendMessage(const std::string& location, const std::string& log, const std::string& collectorType)
+void Logcollector::PushMessage(const std::string& location, const std::string& log, const std::string& collectorType)
 {
     if (!m_pushMessage)
     {

--- a/src/modules/logcollector/src/macos_reader/src/macos_reader.cpp
+++ b/src/modules/logcollector/src/macos_reader/src/macos_reader.cpp
@@ -59,7 +59,7 @@ namespace logcollector
                 m_lastLogEntryTimeInSecondsSince1970 = slightlyBigger;
 
                 const auto logAndDate = log.date + " " + log.log;
-                m_logcollector.SendMessage(COLLECTOR_TYPE, logAndDate, COLLECTOR_TYPE);
+                m_logcollector.PushMessage(COLLECTOR_TYPE, logAndDate, COLLECTOR_TYPE);
             }
 
             co_await m_logcollector.Wait(std::chrono::milliseconds(m_waitInMillis));

--- a/src/modules/logcollector/src/winevt_reader/src/event_reader_win.cpp
+++ b/src/modules/logcollector/src/winevt_reader/src/event_reader_win.cpp
@@ -113,7 +113,7 @@ namespace logcollector::winevt
                     LogError("Cannot convert utf16 string: {}", e.what());
                     return;
                 }
-                m_logcollector.SendMessage(m_channel, logString, COLLECTOR_TYPE);
+                m_logcollector.PushMessage(m_channel, logString, COLLECTOR_TYPE);
             }
         }
     }

--- a/src/modules/logcollector/tests/unit/logcollector_test.cpp
+++ b/src/modules/logcollector/tests/unit/logcollector_test.cpp
@@ -53,7 +53,7 @@ TEST(Logcollector, SetupFileReader)
     ASSERT_NE(capturedReader2, nullptr);
 }
 
-TEST(Logcollector, SendMessageFile)
+TEST(Logcollector, PushMessageFile)
 {
     PushMessageMock mock;
     LogcollectorMock logcollector;
@@ -69,7 +69,7 @@ TEST(Logcollector, SendMessageFile)
     const auto LOG = "test log";
     const auto METADATA = R"({"collector":"file","module":"logcollector"})";
 
-    logcollector.SendMessage(LOCATION, LOG, "file");
+    logcollector.PushMessage(LOCATION, LOG, "file");
 
     ASSERT_EQ(capturedMessage.type, MessageType::STATELESS);
     ASSERT_EQ(capturedMessage.data["log"]["file"]["path"], LOCATION);
@@ -78,7 +78,7 @@ TEST(Logcollector, SendMessageFile)
     ASSERT_EQ(capturedMessage.metaData, METADATA);
 }
 
-TEST(Logcollector, SendMessageApp)
+TEST(Logcollector, PushMessageApp)
 {
     PushMessageMock mock;
     LogcollectorMock logcollector;
@@ -94,7 +94,7 @@ TEST(Logcollector, SendMessageApp)
     const auto LOG = "test log";
     const auto METADATA = R"({"collector":"windows-eventlog","module":"logcollector"})";
 
-    logcollector.SendMessage(LOCATION, LOG, "windows-eventlog");
+    logcollector.PushMessage(LOCATION, LOG, "windows-eventlog");
 
     ASSERT_EQ(capturedMessage.type, MessageType::STATELESS);
     ASSERT_EQ(capturedMessage.data["event"]["original"], LOG);

--- a/src/modules/logcollector/tests/unit/winevt_reader/event_reader_mocks.hpp
+++ b/src/modules/logcollector/tests/unit/winevt_reader/event_reader_mocks.hpp
@@ -62,7 +62,7 @@ namespace logcollector::winevt
         MOCK_METHOD(void, AddReader, (std::shared_ptr<IReader> reader), (override));
         MOCK_METHOD(void, EnqueueTask, (Awaitable task), (override));
         MOCK_METHOD(void,
-                    SendMessage,
+                    PushMessage,
                     (const std::string& channel, const std::string& message, const std::string& collectorType),
                     (override));
 

--- a/src/modules/sca/include/sca.hpp
+++ b/src/modules/sca/include/sca.hpp
@@ -56,7 +56,7 @@ public:
 
         m_policies = [this, &configurationParser]()
         {
-            SCAPolicyLoader policyLoader(m_fileSystemWrapper, configurationParser);
+            SCAPolicyLoader policyLoader(m_fileSystemWrapper, configurationParser, m_pushMessage);
             return policyLoader.GetPolicies();
         }();
 

--- a/src/modules/sca/include/sca.hpp
+++ b/src/modules/sca/include/sca.hpp
@@ -78,8 +78,15 @@ public:
     Co_CommandExecutionResult ExecuteCommand([[maybe_unused]] const std::string command,
                                              [[maybe_unused]] const nlohmann::json parameters)
     {
-        co_return module_command::CommandExecutionResult {module_command::Status::FAILURE,
-                                                          "SCA command handling not implemented yet"};
+        if (!m_enabled)
+        {
+            LogInfo("SCA module is disabled.");
+            co_return module_command::CommandExecutionResult {module_command::Status::FAILURE, "Module is disabled"};
+        }
+
+        LogInfo("Command: {}", command);
+        co_return module_command::CommandExecutionResult {module_command::Status::SUCCESS,
+                                                          "Command not implemented yet"};
     }
 
     /// @brief Returns the name of the module

--- a/src/modules/sca/include/sca_policy.hpp
+++ b/src/modules/sca/include/sca_policy.hpp
@@ -1,15 +1,20 @@
 #pragma once
 
+#include <message.hpp>
+
 #include <filesystem>
+#include <functional>
 
 class SCAPolicy
 {
 public:
     /// @brief Loads a policy from a SCA Policy yaml file
     /// @param path The path to the SCA Policy yaml file
+    /// @param pushMessage A function that pushes messages
     /// @returns A SCAPolicy object
     /// @note This function is a placeholder and should be implemented in the actual code
-    static SCAPolicy LoadFromFile([[maybe_unused]] const std::filesystem::path& path)
+    static SCAPolicy LoadFromFile([[maybe_unused]] const std::filesystem::path& path,
+                                  [[maybe_unused]] std::function<int(Message)> pushMessage)
     {
         return {};
     }

--- a/src/modules/sca/include/sca_policy_loader.hpp
+++ b/src/modules/sca/include/sca_policy_loader.hpp
@@ -4,6 +4,7 @@
 
 #include <configuration_parser.hpp>
 #include <ifilesystem_wrapper.hpp>
+#include <message.hpp>
 #include <sca_policy.hpp>
 
 #include <filesystem>
@@ -16,14 +17,16 @@ class SCAPolicyLoader : public ISCAPolicyLoader
 {
 public:
     /// @brief Type alias for a function that loads a policy from a SCA Policy yaml file
-    using PolicyLoaderFunc = std::function<SCAPolicy(const std::filesystem::path&)>;
+    using PolicyLoaderFunc = std::function<SCAPolicy(const std::filesystem::path&, std::function<int(Message)>)>;
 
     /// @brief Constructor for SCAPolicyLoader
     /// @param fileSystemWrapper A shared pointer to a file system wrapper
     /// @param configurationParser A shared pointer to a configuration parser
+    /// @param pushMessage A function that pushes messages
     /// @param loader A function that loads a policy from a SCA Policy yaml file
     SCAPolicyLoader(std::shared_ptr<IFileSystemWrapper> fileSystemWrapper = nullptr,
                     std::shared_ptr<const configuration::ConfigurationParser> configurationParser = nullptr,
+                    std::function<int(Message)> pushMessage = nullptr,
                     PolicyLoaderFunc loader = SCAPolicy::LoadFromFile);
 
     /// @brief Destructor for SCAPolicyLoader
@@ -35,6 +38,7 @@ public:
 
 private:
     std::shared_ptr<IFileSystemWrapper> m_fileSystemWrapper;
+    std::function<int(Message)> m_pushMessage;
     PolicyLoaderFunc m_policyLoader;
 
     std::vector<std::filesystem::path> m_customPoliciesPaths;

--- a/src/modules/sca/src/sca_policy_loader.cpp
+++ b/src/modules/sca/src/sca_policy_loader.cpp
@@ -7,9 +7,11 @@
 
 SCAPolicyLoader::SCAPolicyLoader(std::shared_ptr<IFileSystemWrapper> fileSystemWrapper,
                                  std::shared_ptr<const configuration::ConfigurationParser> configurationParser,
+                                 std::function<int(Message)> pushMessage,
                                  PolicyLoaderFunc loader)
     : m_fileSystemWrapper(fileSystemWrapper ? std::move(fileSystemWrapper)
                                             : std::make_shared<file_system::FileSystemWrapper>())
+    , m_pushMessage(std::move(pushMessage))
     , m_policyLoader(std::move(loader))
 {
     const auto loadPoliciesPathsFromConfig = [this, configurationParser](const std::string& configKey)
@@ -55,7 +57,7 @@ std::vector<SCAPolicy> SCAPolicyLoader::GetPolicies() const
         {
             try
             {
-                policies.emplace_back(m_policyLoader(path));
+                policies.emplace_back(m_policyLoader(path, m_pushMessage));
                 LogDebug("Loading policy from {}", path.string());
             }
             catch (const std::exception& e)

--- a/src/modules/sca/tests/sca_policy_loader_test.cpp
+++ b/src/modules/sca/tests/sca_policy_loader_test.cpp
@@ -27,11 +27,7 @@ TEST(ScaPolicyLoaderTest, NoPolicies)
         return SCAPolicy {};
     };
 
-    const std::filesystem::path defaultDir = "";
-    EXPECT_CALL(*fsMock, exists(defaultDir)).WillOnce(testing::Return(false));
-
     const SCAPolicyLoader loader(fsMock, configurationParser, nullptr, fakeLoader);
-
     ASSERT_EQ(loader.GetPolicies().size(), 0);
 }
 
@@ -49,16 +45,9 @@ TEST(ScaPolicyLoaderTest, GetPoliciesReturnsOnePolicyFromConfiguration)
 
     const std::filesystem::path configPoliciesValue = "test_path";
     const std::filesystem::path configPoliciesDisabledValue = "test_path_disabled";
-    const std::filesystem::path defaultDir = "";
 
     EXPECT_CALL(*fsMock, exists(configPoliciesValue)).WillOnce(testing::Return(true));
     EXPECT_CALL(*fsMock, exists(configPoliciesDisabledValue)).WillOnce(testing::Return(true));
-    EXPECT_CALL(*fsMock, exists(defaultDir)).WillOnce(testing::Return(true));
-    EXPECT_CALL(*fsMock, is_directory(defaultDir)).WillOnce(testing::Return(true));
-    EXPECT_CALL(*fsMock, list_directory(defaultDir))
-        .WillOnce(testing::Return(std::vector<std::filesystem::path> {configPoliciesDisabledValue}));
-
-    EXPECT_CALL(*fsMock, is_regular_file(configPoliciesDisabledValue)).WillOnce(testing::Return(true));
 
     const auto fakeLoader =
         [=](const std::filesystem::path&, std::function<int(Message)>) // NOLINT(performance-unnecessary-value-param)

--- a/src/modules/sca/tests/sca_policy_loader_test.cpp
+++ b/src/modules/sca/tests/sca_policy_loader_test.cpp
@@ -21,7 +21,8 @@ TEST(ScaPolicyLoaderTest, NoPolicies)
 {
     auto fsMock = std::make_shared<testing::NiceMock<MockFileSystemWrapper>>();
     auto configurationParser = std::make_shared<configuration::ConfigurationParser>(std::string(R"()"));
-    const auto fakeLoader = [=](const std::filesystem::path&)
+    const auto fakeLoader =
+        [=](const std::filesystem::path&, std::function<int(Message)>) // NOLINT(performance-unnecessary-value-param)
     {
         return SCAPolicy {};
     };
@@ -29,7 +30,7 @@ TEST(ScaPolicyLoaderTest, NoPolicies)
     const std::filesystem::path defaultDir = "";
     EXPECT_CALL(*fsMock, exists(defaultDir)).WillOnce(testing::Return(false));
 
-    const SCAPolicyLoader loader(fsMock, configurationParser, fakeLoader);
+    const SCAPolicyLoader loader(fsMock, configurationParser, nullptr, fakeLoader);
 
     ASSERT_EQ(loader.GetPolicies().size(), 0);
 }
@@ -59,11 +60,12 @@ TEST(ScaPolicyLoaderTest, GetPoliciesReturnsOnePolicyFromConfiguration)
 
     EXPECT_CALL(*fsMock, is_regular_file(configPoliciesDisabledValue)).WillOnce(testing::Return(true));
 
-    const auto fakeLoader = [=](const std::filesystem::path&)
+    const auto fakeLoader =
+        [=](const std::filesystem::path&, std::function<int(Message)>) // NOLINT(performance-unnecessary-value-param)
     {
         return SCAPolicy {};
     };
-    const SCAPolicyLoader loader(fsMock, configurationParser, fakeLoader);
+    const SCAPolicyLoader loader(fsMock, configurationParser, nullptr, fakeLoader);
 
     ASSERT_EQ(loader.GetPolicies().size(), 1);
 }

--- a/src/modules/tests/mocks/mock_module_manager.hpp
+++ b/src/modules/tests/mocks/mock_module_manager.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <gmock/gmock.h>
+#include <memory>
+#include <string>
+
+#include <imoduleManager.hpp>
+#include <moduleWrapper.hpp>
+
+class MockModuleManager : public IModuleManager
+{
+public:
+    MOCK_METHOD(void, AddModules, (), (override));
+    MOCK_METHOD(std::shared_ptr<ModuleWrapper>, GetModule, (const std::string& name), (override));
+    MOCK_METHOD(void, Start, (), (override));
+    MOCK_METHOD(void, Setup, (), (override));
+    MOCK_METHOD(void, Stop, (), (override));
+};


### PR DESCRIPTION
## Description

Closes #683 

Most of the requirements of the issue were already implemented.

This PR passes the PushMessage function to the point of creation of SCAPolicies.

## Proposed Changes

* Forward the PushMessage function to the SCAPolicy creation.
* Enable SCA compilation.
* Rename functions that use the push message functions (Inventory, LogCollector) so they match semantically.
* Introduce IModuleManager interface so AgentTests work, there was an issue with the SCA::Setup method because it was creating a DBSync instance in these tests. This didn't happen before with Inventory because the creation of its DBSync instance is done when Start is run.

### Results and Evidence

New SCA tests running on workflows/actions.

### Artifacts Affected

None.

### Configuration Changes

Default value for enabling SCA has changed.

### Documentation Updates

Default value for enabling SCA has changed, documentation is updated accordingly.

### Tests Introduced

No new tests, but SCA tests are now compiled and run.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
