### PR TITLE
Add io context to SCA

### DIFF
--- a/src/modules/sca/include/sca.hpp
+++ b/src/modules/sca/include/sca.hpp
@@ -157,15 +157,34 @@ private:
         return R"(CREATE TABLE sca (policy TEXT PRIMARY KEY );)";
     }
 
+    /// @brief SCA db file name
     const std::string SCA_DB_DISK_NAME = "sca.db";
+
+    /// @brief SCA module name
     std::string m_name = "SCA";
+
+    /// @brief Pointer to DBSync
     std::unique_ptr<DBSyncType> m_dBSync;
+
+    /// @brief Path to the database file
     std::string m_dbFilePath;
+
+    /// @brief Function for pushing event messages
     std::function<int(Message)> m_pushMessage;
+
+    /// @brief Pointer to a file system wrapper
     std::shared_ptr<IFileSystemWrapper> m_fileSystemWrapper;
+
+    /// @brief Flag indicating whether the module is enabled
     bool m_enabled;
+
+    /// @brief Flag indicating whether to scan on start
     bool m_scanOnStart;
+
+    /// @brief Scan interval in seconds
     std::time_t m_scanInterval;
+
+    /// @brief List of policies
     std::vector<SCAPolicy> m_policies;
 
     /// @brief Boost ASIO context

--- a/src/modules/sca/include/sca_policy.hpp
+++ b/src/modules/sca/include/sca_policy.hpp
@@ -2,12 +2,21 @@
 
 #include <message.hpp>
 
+#include <boost/asio/awaitable.hpp>
+
 #include <filesystem>
 #include <functional>
 
 class SCAPolicy
 {
 public:
+    /// @brief Runs the policy check
+    /// @return Awaitable void
+    boost::asio::awaitable<void> Run()
+    {
+        co_return;
+    }
+
     /// @brief Loads a policy from a SCA Policy yaml file
     /// @param path The path to the SCA Policy yaml file
     /// @param pushMessage A function that pushes messages

--- a/src/modules/sca/tests/sca_test.cpp
+++ b/src/modules/sca/tests/sca_test.cpp
@@ -62,3 +62,19 @@ TEST_F(ScaTest, NameReturnsCorrectValue)
 {
     EXPECT_EQ(m_sca->Name(), "SCA");
 }
+
+TEST_F(ScaTest, EnqueueTaskExecutesTask)
+{
+    bool taskExecuted = false;
+
+    auto task = [&]() -> boost::asio::awaitable<void> // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+    {
+        taskExecuted = true;
+        m_sca->Stop();
+        co_return;
+    };
+
+    m_sca->EnqueueTask(task());
+    m_sca->Start();
+    EXPECT_TRUE(taskExecuted);
+}


### PR DESCRIPTION
## Description

Closes #682 

This PR adds an io context to the SCA class to allow queuing tasks.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
