### PR TITLE
Allow agent enrollment from any directory across all platforms

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/postinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/postinst
@@ -4,6 +4,7 @@
 
 set -e
 UPGRADE_RESTART_FLAG="/tmp/wazuh.restart"
+BINARY_DIR="/usr/share/wazuh-agent/bin"
 
 case "$1" in
     configure)
@@ -28,6 +29,8 @@ case "$1" in
     if ! getent passwd ${USER} > /dev/null 2>&1; then
         adduser --system --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
     fi
+
+    ln -sf "${BINARY_DIR}/wazuh-agent" /usr/bin/wazuh-agent
 
     if [ -f ${UPGRADE_RESTART_FLAG} ] ; then
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then

--- a/packages/debs/SPECS/wazuh-agent/debian/postinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/postinst
@@ -4,7 +4,8 @@
 
 set -e
 UPGRADE_RESTART_FLAG="/tmp/wazuh.restart"
-BINARY_DIR="/usr/share/wazuh-agent/bin"
+AGENT_BINARY="/usr/share/wazuh-agent/bin/wazuh-agent"
+AGENT_LINK="/usr/local/bin/wazuh-agent"
 
 case "$1" in
     configure)
@@ -30,7 +31,7 @@ case "$1" in
         adduser --system --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
     fi
 
-    ln -sf "${BINARY_DIR}/wazuh-agent" /usr/bin/wazuh-agent
+    ln -sf "${AGENT_BINARY}" "${AGENT_LINK}"
 
     if [ -f ${UPGRADE_RESTART_FLAG} ] ; then
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then

--- a/packages/debs/SPECS/wazuh-agent/debian/postrm
+++ b/packages/debs/SPECS/wazuh-agent/debian/postrm
@@ -10,6 +10,7 @@ case "$1" in
 
         if [ "$1" = "remove" ]; then
             rm -rf ${WAZUH_SHARE_DIR}
+            rm -f /usr/bin/wazuh-agent
             rm -f /usr/lib/systemd/system/wazuh-agent.service
 
             # Remove the shared library configuration file if it exists

--- a/packages/debs/SPECS/wazuh-agent/debian/postrm
+++ b/packages/debs/SPECS/wazuh-agent/debian/postrm
@@ -10,7 +10,7 @@ case "$1" in
 
         if [ "$1" = "remove" ]; then
             rm -rf ${WAZUH_SHARE_DIR}
-            rm -f /usr/bin/wazuh-agent
+            rm -f /usr/local/bin/wazuh-agent
             rm -f /usr/lib/systemd/system/wazuh-agent.service
 
             # Remove the shared library configuration file if it exists

--- a/packages/macos/package_files/postinstall.sh
+++ b/packages/macos/package_files/postinstall.sh
@@ -13,6 +13,7 @@ USER="wazuh"
 AGENT_DIR="/Library/Application Support/Wazuh agent.app"
 CONF_DIR="$AGENT_DIR/etc"
 DATA_DIR="$AGENT_DIR/var"
+BIN_DIR="$AGENT_DIR/bin"
 SERVICE_FILE="/Library/LaunchDaemons/com.wazuh.agent.plist"
 UPGRADE_FILE_FLAG="${AGENT_DIR}/WAZUH_PKG_UPGRADE"
 
@@ -32,7 +33,7 @@ if [ -f "${UPGRADE_FILE_FLAG}" ]; then
 fi
 
 # Default for all directories
-echo "Seting permissions and ownership for directories and files"
+echo "Setting permissions and ownership for directories and files"
 chmod -R 750 "${AGENT_DIR}"/
 chown -R root:"${GROUP}" "${AGENT_DIR}"/
 chown -R root:wheel "${AGENT_DIR}"/bin
@@ -48,6 +49,11 @@ sudo chmod 644 "$SERVICE_FILE"
 
 chown "${USER}":"${GROUP}" "${AGENT_DIR}"/VERSION.json
 chmod 440 "${AGENT_DIR}"/VERSION.json
+
+# Add symbolic link to the executable wazuh-agent
+BIN_ORIG="$BIN_DIR/wazuh-agent"
+BIN_LINK="/usr/local/bin/wazuh-agent"
+ln -sf "$BIN_ORIG" "$BIN_LINK"
 
 # Remove old ossec user and group if exists and change ownwership of files
 if [[ $(dscl . -read /Groups/ossec) ]]; then

--- a/packages/rpms/SPECS/wazuh_agent.spec
+++ b/packages/rpms/SPECS/wazuh_agent.spec
@@ -48,6 +48,8 @@ rm -fr %{buildroot}
 cmake --install "$(pwd)/src/build" --prefix %{buildroot}%{_localstatedir}
 install -D /usr/lib/systemd/system/wazuh-agent.service %{buildroot}%{_localstatedir}usr/lib/systemd/system/wazuh-agent.service
 sed -i "s|%{buildroot}%{_localstatedir}|/|g" %{buildroot}%{_localstatedir}usr/lib/systemd/system/wazuh-agent.service
+mkdir -p %{buildroot}/usr/bin
+ln -sf %{_localstatedir}usr/share/wazuh-agent/bin/wazuh-agent %{buildroot}/usr/bin/wazuh-agent
 exit 0
 
 %pre
@@ -238,6 +240,7 @@ if [ $1 = 0 ]; then
 
   if [ $1 = 0 ];then
     # Remove lingering folders and files
+    rm -f %{_localstatedir}usr/bin/wazuh-agent
     rm -rf %{_localstatedir}usr/share/wazuh-agent/bin/wazuh-agent
     rm -f %{_localstatedir}usr/lib/systemd/system/wazuh-agent.service
     rm -rf %{_localstatedir}etc/wazuh-agent
@@ -260,6 +263,7 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-agent
 %attr(750, root, wazuh) %{_localstatedir}etc/wazuh-agent/wazuh-agent.yml
 %attr(440, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-agent/VERSION.json
+%attr(755, root, root) %{_localstatedir}usr/bin/wazuh-agent
 
 %changelog
 * Wed Jan 01 2025 Wazuh Inc <info@wazuh.com> - 5.0.0

--- a/packages/rpms/SPECS/wazuh_agent.spec
+++ b/packages/rpms/SPECS/wazuh_agent.spec
@@ -48,8 +48,8 @@ rm -fr %{buildroot}
 cmake --install "$(pwd)/src/build" --prefix %{buildroot}%{_localstatedir}
 install -D /usr/lib/systemd/system/wazuh-agent.service %{buildroot}%{_localstatedir}usr/lib/systemd/system/wazuh-agent.service
 sed -i "s|%{buildroot}%{_localstatedir}|/|g" %{buildroot}%{_localstatedir}usr/lib/systemd/system/wazuh-agent.service
-mkdir -p %{buildroot}/usr/bin
-ln -sf %{_localstatedir}usr/share/wazuh-agent/bin/wazuh-agent %{buildroot}/usr/bin/wazuh-agent
+mkdir -p %{buildroot}/usr/local/bin
+ln -sf %{_localstatedir}usr/share/wazuh-agent/bin/wazuh-agent %{buildroot}/usr/local/bin/wazuh-agent
 exit 0
 
 %pre
@@ -240,7 +240,7 @@ if [ $1 = 0 ]; then
 
   if [ $1 = 0 ];then
     # Remove lingering folders and files
-    rm -f %{_localstatedir}usr/bin/wazuh-agent
+    rm -f %{_localstatedir}usr/local/bin/wazuh-agent
     rm -rf %{_localstatedir}usr/share/wazuh-agent/bin/wazuh-agent
     rm -f %{_localstatedir}usr/lib/systemd/system/wazuh-agent.service
     rm -rf %{_localstatedir}etc/wazuh-agent
@@ -263,7 +263,7 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-agent
 %attr(750, root, wazuh) %{_localstatedir}etc/wazuh-agent/wazuh-agent.yml
 %attr(440, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-agent/VERSION.json
-%attr(755, root, root) %{_localstatedir}usr/bin/wazuh-agent
+%attr(755, root, root) %{_localstatedir}usr/local/bin/wazuh-agent
 
 %changelog
 * Wed Jan 01 2025 Wazuh Inc <info@wazuh.com> - 5.0.0

--- a/packages/windows/cleanup.ps1
+++ b/packages/windows/cleanup.ps1
@@ -73,4 +73,18 @@ if ([System.Diagnostics.EventLog]::SourceExists($sourceName)) {
     Write-Host "Event log source '$sourceName' has already been removed."
 }
 
-    Write-Host "cleanup.ps1 script completed."
+# Remove the wazuh-agent.bat file from System32
+$bakFile = "C:\Windows\System32\wazuh-agent.bat"
+if (Test-Path $bakFile) {
+    try {
+        Write-Host "Removing backup file: $bakFile"
+        Remove-Item -Path $bakFile -Force
+    } catch {
+        Write-Host "Failed to remove backup file: $_"
+        exit 1
+    }
+} else {
+    Write-Host "No backup file found at: $bakFile"
+}
+
+Write-Host "cleanup.ps1 script completed."

--- a/packages/windows/postinstall.ps1
+++ b/packages/windows/postinstall.ps1
@@ -90,6 +90,26 @@ if (-not $eventLogExists) {
     Write-Host "Event log source '$sourceName' is already registered."
 }
 
+if ($env:ProgramFiles) {
+    $installDir = "$env:ProgramFiles\wazuh-agent"
+} else {
+    $installDir = "C:\Program Files\wazuh-agent"
+}
+
+$batFilePath = "$env:SystemRoot\System32\wazuh-agent.bat"
+$batFileContent = @"
+@echo off
+"$installDir\wazuh-agent.exe" %*
+"@
+
+try {
+    $batFileContent | Out-File -FilePath $batFilePath -Encoding ASCII -Force
+    Write-Host "Batch file created at: $batFilePath" -ForegroundColor Green
+}
+catch {
+    Write-Host "Error: $_" -ForegroundColor Red
+}
+
 Write-Host "postinstall.ps1 script completed."
 
 # Delete script after execution

--- a/packages/windows/postinstall.ps1
+++ b/packages/windows/postinstall.ps1
@@ -96,7 +96,7 @@ if ($env:ProgramFiles) {
     $installDir = "C:\Program Files\wazuh-agent"
 }
 
-$batFilePath = "$env:SystemRoot\System32\wazuh-agent.bat"
+$batFilePath = "C:\Windows\System32\wazuh-agent.bat"
 $batFileContent = @"
 @echo off
 "$installDir\wazuh-agent.exe" %*


### PR DESCRIPTION
## Description

Closes #731 
<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:

-->

Improve agent enrollment mechanism to allow executing the --enroll command from any directory, without requiring the user to navigate to the directory where the agent executable is located.

Currently, when trying to enroll the agent from outside the directory containing the executable, the agent fails with errors due to relative paths not being correctly resolved. This behavior should be improved to allow wazuh-agent --enroll to work regardless of the current working directory.

Example error on Windows when not in the executable directory:

```bs
C:\> "C:\Program Files\wazuh-agent\wazuh-agent.exe" --enroll --enroll-url https://192.168.1.100:55000/ --user wazuh --password wazuh --name wazuh 

```
## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->
- [ ] Ensure that on:
  - **Windows**: Executing `wazuh-agent.exe` from any path works, whether installed via MSI or built manually.
  - **Linux**: The `wazuh-agent` binary can be called from anywhere without failing due to relative file path issues.
  - **macOS**: Behavior matches the expected handling of relative/absolute paths.
- [ ] Update documentation:
  - Clarify that the agent can now be enrolled from any directory.
  - Provide examples of enrollment from a directory different from the one containing the executable.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Screenshots
- Before/after comparisons
-->


## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
