### PR TITLE
Improve wazuh agent documentation

### DIFF
--- a/docs/dev/run-agent.md
+++ b/docs/dev/run-agent.md
@@ -1,5 +1,11 @@
 # Run from Sources
 
+To build the agent from source, refer to: [build-sources.md](./build-sources.md).
+
+> Note: After building, the agent executables are located in:
+> - **Linux/macOS:** `wazuh-agent/build`
+> - **Windows:** `wazuh-agent\build\Debug`
+
 ## Enroll the Agent
 
 To allow the agent to successfully connect to a Wazuh server, it must first enroll with the server. This is done using the --enroll option.
@@ -7,25 +13,92 @@ Ensure that the server is online and ready to accept enrollment requests before 
 
 ### Enrollment Command
 
+- **Linux/macOS:**
 ```
 cd build/
 ./wazuh-agent --enroll --enroll-url https://localhost:55000 --user <username> --password <password> [--name <agent-name>]
 ```
 
+- **Windows:**
+```
+cd .\build\Debug\
+./wazuh-agent --enroll --enroll-url https://localhost:55000 --user <username> --password <password> [--name <agent-name>]
+```
+
 Replace:
 
-* <username> with your Wazuh server username.
-* <password> with your corresponding password.
-* <agent-name> with the desired name for the agent (optional).
+* `<username>` with the Wazuh server username.
+* `<password>` with the corresponding password.
+* `<agent-name>` with the desired name for the agent (optional).
 
 ### View Enrollment Help
 
 For additional options and details, use:
 
 ```
-cd build/
 ./wazuh-agent --enroll --help
 ```
+
+### Important Notes About Enrollment
+
+The agent stores information in a local database during enrollment. By default, the database is created in the following paths:
+
+- **Linux:** `/var/lib/wazuh-agent`
+- **macOS:** `/Library/Application Support/Wazuh agent.app/var`
+- **Windows:** `C:\\ProgramData\\wazuh-agent\\var`
+
+If these directories do not exist at the time of running the enrollment command **when running from sources**, the agent will fail with an error like:
+
+```
+Error: Cannot open database: C:\ProgramData\wazuh-agent\var/agent_info.db
+```
+
+To avoid this, **manually create the directory** before running the command, depending on the operating system:
+
+- **Linux:**
+  ```bash
+  sudo mkdir -p /var/lib/wazuh-agent
+  ```
+
+- **macOS:**
+  ```bash
+  sudo mkdir -p "/Library/Application Support/Wazuh agent.app/var"
+  ```
+
+- **Windows:**
+  ```powershell
+  mkdir "C:\ProgramData\wazuh-agent\var"
+  ```
+
+> Note: If the agent is installed using the installation process, the necessary directories are automatically created.
+
+**Alternative: Use a Custom Data Path**
+
+A custom location for the agent data can be configured by setting the `path.data` option in the `wazuh-agent.yml` configuration file:
+
+```yaml
+agent:
+  ...
+  path.data: "C:/MyCustomPath/"
+```
+
+> Note: Setting `path.data: "."` will make the agent use the current working directory as the data directory.
+
+Default configuration file locations:
+
+- **Linux:** `/etc/wazuh-agent/wazuh-agent.yml`
+- **macOS:** `/Library/Application Support/Wazuh agent.app/etc/wazuh-agent.yml`
+- **Windows:** `C:\\ProgramData\\wazuh-agent\\config\\wazuh-agent.yml`
+
+### Use a Custom Configuration File
+
+A custom config file can also be specified during enrollment using the `--config-file` option:
+
+```bash
+./wazuh-agent --enroll --enroll-url https://localhost:55000 --user <username> --password <password> [--name <agent-name>] --config-file /path/to/wazuh-agent.yml
+```
+
+This is useful when testing with different configurations or running the agent from a non-default directory.
 
 ## Run the Agent on Linux
 

--- a/docs/ref/getting-started/usage.md
+++ b/docs/ref/getting-started/usage.md
@@ -1,0 +1,112 @@
+# Usage
+
+## Enroll the Agent
+
+To allow the agent to successfully connect to a Wazuh server, it must first enroll with the server. This is done using the --enroll option.
+Ensure that the server is online and ready to accept enrollment requests before proceeding.
+
+### Enrollment Command
+
+```
+wazuh-agent --enroll --enroll-url https://localhost:55000 --user <username> --password <password> [--name <agent-name>]
+```
+
+Replace:
+
+* `<username>` with the Wazuh server username.
+* `<password>` with the corresponding password.
+* `<agent-name>` with the desired name for the agent (optional).
+
+### View Enrollment Help
+
+For additional options and details, use:
+
+```
+wazuh-agent --enroll --help
+```
+
+## Run the Agent on Linux
+
+- **To run the agent in the foreground from the CLI**
+
+    The agent can be started and its status checked with:
+
+    ```bash
+    wazuh-agent
+    wazuh-agent --status
+    ```
+
+- **To run the agent as a systemd service**
+
+    Enable the service:
+
+    ```bash
+    systemctl enable wazuh-agent
+    ```
+
+    The agent can be started, stopped, and its status checked using systemctl:
+
+    ```bash
+    systemctl start wazuh-agent
+    systemctl stop wazuh-agent
+    systemctl is-active wazuh-agent
+    systemctl status wazuh-agent
+    ```
+
+## Run the Agent on macOS
+
+- **To run the agent in the foreground from the CLI**
+
+    The agent can be started and its status checked with:
+
+    ```bash
+    wazuh-agent
+    wazuh-agent --status
+    ```
+
+- **To run the agent as a launchd service**
+
+    Load the service:
+
+    ```bash
+    sudo launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist
+    ```
+
+    > This command has superseeded `load` in the legacy syntax. The daemon will run after load as indicated
+    in the property list file.
+
+    Unload the service:
+
+    ```bash
+    sudo launchctl bootout system /Library/LaunchDaemons/com.wazuh.agent.plist
+    ```
+
+    > This command has superseeded `unload` in the legacy syntax.
+
+    Verify the service is running:
+
+    ```bash
+    sudo launchctl print system/com.wazuh.agent
+    ```
+
+## Run the Agent on Windows
+
+- **To run the agent in the foreground from the CLI**
+
+    The agent can be started and its status checked with:
+
+    ```bash
+    wazuh-agent
+    wazuh-agent --status
+    ```
+
+- **To run the agent as a Windows service**
+
+    The agent service can be started, stopped, or restarted from the CLI:
+
+    ```bash
+    net start "wazuh-agent"
+    net stop "wazuh-agent"
+    ```
+
+    > This can also be done using Windows SCM.

--- a/docs/ref/uninstall.md
+++ b/docs/ref/uninstall.md
@@ -23,6 +23,6 @@
 
 - MSI
     ```powershell
-    msiexec /x '.\wazuh-agent_x.y.z.msi' /l*v uninstall.log
+    msiexec /x wazuh-agent_x.y.z.msi /l*v uninstall.log
     ```
 **Note:** The package can also be uninstalled on Windows through the OS's "Add or Remove Programs" section.


### PR DESCRIPTION
## Description

This PR adds some changes to the documentation to clarify the use of agent through sources or through the installed package.

## Proposed Changes

- In the section `Run from sources` it is explained where the executables are located once the agent is built.
- Adds a new section `usage.md` to `getting-started`, which explains how to run the installed package.
- Fixes the Windows Agent uninstallation command. 

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Screenshots
- Before/after comparisons
-->

### Artifacts Affected

None

### Configuration Changes

None

### Documentation Updates

- `docs/dev/run-agent.md`
- `docs/ref/getting-started/usage.md`
- `docs/ref/uninstall.md`

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
