### PR TITLE
Uses the default ConfigurationParser constructor when not explicitly passing a config-file

### DIFF
--- a/src/agent/src/agent_runner.cpp
+++ b/src/agent/src/agent_runner.cpp
@@ -195,7 +195,9 @@ int AgentRunner::StartAgent() const
 
         LogInfo("Starting wazuh-agent");
 
-        Agent agent(std::make_unique<configuration::ConfigurationParser>(std::filesystem::path(configFilePath)));
+        Agent agent(configFilePath.empty()
+                        ? std::make_unique<configuration::ConfigurationParser>()
+                        : std::make_unique<configuration::ConfigurationParser>(std::filesystem::path(configFilePath)));
         agent.Run();
     }
     catch (const std::exception& e)

--- a/src/agent/src/windows/windows_service.cpp
+++ b/src/agent/src/windows/windows_service.cpp
@@ -239,7 +239,9 @@ namespace windows_service
 
             LogInfo("Starting {}.", AGENT_SERVICENAME.c_str());
 
-            Agent agent(std::make_unique<configuration::ConfigurationParser>(std::filesystem::path(configFilePath)));
+            Agent agent(configFilePath.empty() ? std::make_unique<configuration::ConfigurationParser>()
+                                               : std::make_unique<configuration::ConfigurationParser>(
+                                                     std::filesystem::path(configFilePath)));
             agent.Run();
         }
         catch (const std::exception& e)


### PR DESCRIPTION
## Description

This PR makes a fix to read the default configuration file when the “--config-file” option is not passed when wazuh-agent is executed.

## Proposed Changes

Make a check of the variable “configFilePath” to make use of the default ConfigurationParser constructor or the specific constructor with the path.

```
Agent agent(configFilePath.empty() ? std::make_unique<configuration::ConfigurationParser>()
                                               : std::make_unique<configuration::ConfigurationParser>(
                                                     std::filesystem::path(configFilePath)));
```

### Results and Evidence

<details><summary>Before changes</summary>

```
sh-3.2# SPDLOG_LEVEL=debug wazuh-agent
[2025-04-11 08:41:16.479] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:46] [LoadLocalConfig] Loading local config file: /Library/Application Support/Wazuh agent.app/etc/wazuh-agent.yml.
[2025-04-11 08:41:16.480] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.run
[2025-04-11 08:41:16.480] [wazuh-agent] [debug] [DEBUG] [instance_handler_unix.cpp:91] [getInstanceLock] Lock file created: /private/var/run/wazuh-agent.lock
[2025-04-11 08:41:16.480] [wazuh-agent] [info] [INFO] [agent_runner.cpp:196] [StartAgent] Starting wazuh-agent
[2025-04-11 08:41:16.480] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:46] [LoadLocalConfig] Loading local config file: .      <---------------------------Here
[2025-04-11 08:41:16.480] [wazuh-agent] [warning] [WARN] [configuration_parser.cpp:59] [LoadLocalConfig] Using default values due to error parsing wazuh-agent.yml file: The file does not contain a valid YAML structure.
```

</details>

<details><summary>After changes: Linux</summary>

```
root@nico-VirtualBox:/home/nico/wazuh-agent/build# SPDLOG_LEVEL=debug ./wazuh-agent 
[2025-04-11 16:37:21.306] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:46] [LoadLocalConfig] Loading local config file: /etc/wazuh-agent/wazuh-agent.yml.
[2025-04-11 16:37:21.307] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.run
[2025-04-11 16:37:21.310] [wazuh-agent] [debug] [DEBUG] [instance_handler_unix.cpp:91] [getInstanceLock] Lock file created: /var/run/wazuh-agent.lock
[2025-04-11 16:37:21.310] [wazuh-agent] [info] [INFO] [agent_runner.cpp:196] [StartAgent] Starting wazuh-agent
[2025-04-11 16:37:21.310] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:46] [LoadLocalConfig] Loading local config file: /etc/wazuh-agent/wazuh-agent.yml.
[2025-04-11 16:37:21.311] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.data
[2025-04-11 16:37:21.317] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.data
[2025-04-11 16:37:21.324] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:235] [GetParsedConfigInRangeOrDefault] Invalid range: min value is greater or equal to max value.
[2025-04-11 16:37:21.324] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.data
[2025-04-11 16:37:21.326] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:97] [LoadSharedConfig] Loading shared configuration.
[2025-04-11 16:37:21.681] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:239] [PerformHttpRequest] Request /api/v1/authentication: Status 200
[2025-04-11 16:37:21.682] [wazuh-agent] [info] [INFO] [communicator.cpp:109] [SendAuthenticationRequest] Successfully authenticated with the manager.
[2025-04-11 16:37:21.682] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.data
[2025-04-11 16:37:21.682] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 16:37:21.682] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 16:37:21.683] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 16:37:21.683] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:256] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-04-11 16:37:21.689] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 16:37:21.691] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 16:37:21.691] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 16:37:21.691] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 16:37:21.691] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 16:37:21.691] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:256] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-04-11 16:37:21.691] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 16:37:21.692] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 16:37:21.692] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.data
[2025-04-11 16:37:21.692] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.data
[2025-04-11 16:37:21.692] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: hotfixes
[2025-04-11 16:37:21.693] [wazuh-agent] [info] [INFO] [journald_reader.cpp:24] [JournaldReader] Creating JournaldReader with 1 filters
[2025-04-11 16:37:21.704] [wazuh-agent] [info] [INFO] [logcollector.cpp:32] [Run] Logcollector module running.
[2025-04-11 16:37:21.704] [wazuh-agent] [info] [INFO] [file_reader.cpp:83] [AddLocalfiles] Reading log file: /var/log/auth.log
[2025-04-11 16:37:21.705] [wazuh-agent] [info] [INFO] [inventory.cpp:19] [Run] Inventory module running.
[2025-04-11 16:37:21.716] [wazuh-agent] [info] [INFO] [journald_reader.cpp:42] [Run] Initializing journald reader with 1 conditions: [PRIORITY=0|1|2|3|4|5|6|7] 
[2025-04-11 16:37:21.718] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:982] [SyncLoop] Module started.
[2025-04-11 16:37:21.719] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:965] [Scan] Starting evaluation.
[2025-04-11 16:37:21.847] [wazuh-agent] [info] [INFO] [journal_log.cpp:26] [Open] Journal opened successfully
[2025-04-11 16:37:21.848] [wazuh-agent] [info] [INFO] [journal_log.cpp:236] [AddFilterGroup] Adding filter group with 1 conditions
[2025-04-11 16:37:21.848] [wazuh-agent] [debug] [DEBUG] [journal_log.cpp:247] [AddFilterGroup] Adding journal match: PRIORITY=0
[2025-04-11 16:37:21.848] [wazuh-agent] [debug] [DEBUG] [journal_log.cpp:247] [AddFilterGroup] Adding journal match: PRIORITY=1
[2025-04-11 16:37:21.848] [wazuh-agent] [debug] [DEBUG] [journal_log.cpp:247] [AddFilterGroup] Adding journal match: PRIORITY=2
[2025-04-11 16:37:21.848] [wazuh-agent] [debug] [DEBUG] [journal_log.cpp:247] [AddFilterGroup] Adding journal match: PRIORITY=3
[2025-04-11 16:37:21.848] [wazuh-agent] [debug] [DEBUG] [journal_log.cpp:247] [AddFilterGroup] Adding journal match: PRIORITY=4
[2025-04-11 16:37:21.848] [wazuh-agent] [debug] [DEBUG] [journal_log.cpp:247] [AddFilterGroup] Adding journal match: PRIORITY=5
[2025-04-11 16:37:21.848] [wazuh-agent] [debug] [DEBUG] [journal_log.cpp:247] [AddFilterGroup] Adding journal match: PRIORITY=6
[2025-04-11 16:37:21.848] [wazuh-agent] [debug] [DEBUG] [journal_log.cpp:247] [AddFilterGroup] Adding journal match: PRIORITY=7
```

</details>

<details><summary>After changes: macOS</summary>

```
sh-3.2# SPDLOG_LEVEL=debug ./wazuh-agent 
[2025-04-11 12:56:27.669] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:46] [LoadLocalConfig] Loading local config file: /Library/Application Support/Wazuh agent.app/etc/wazuh-agent.yml.
[2025-04-11 12:56:27.669] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.run
[2025-04-11 12:56:27.670] [wazuh-agent] [debug] [DEBUG] [instance_handler_unix.cpp:91] [getInstanceLock] Lock file created: /private/var/run/wazuh-agent.lock
[2025-04-11 12:56:27.670] [wazuh-agent] [info] [INFO] [agent_runner.cpp:196] [StartAgent] Starting wazuh-agent
[2025-04-11 12:56:27.670] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:46] [LoadLocalConfig] Loading local config file: /Library/Application Support/Wazuh agent.app/etc/wazuh-agent.yml.
[2025-04-11 12:56:27.670] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.data
[2025-04-11 12:56:27.808] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.data
[2025-04-11 12:56:27.809] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:235] [GetParsedConfigInRangeOrDefault] Invalid range: min value is greater or equal to max value.
[2025-04-11 12:56:27.809] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.data
[2025-04-11 12:56:27.809] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:97] [LoadSharedConfig] Loading shared configuration.
[2025-04-11 12:56:28.259] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:239] [PerformHttpRequest] Request /api/v1/authentication: Status 200
[2025-04-11 12:56:28.259] [wazuh-agent] [info] [INFO] [communicator.cpp:109] [SendAuthenticationRequest] Successfully authenticated with the manager.
[2025-04-11 12:56:28.260] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.data
[2025-04-11 12:56:28.260] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 12:56:28.260] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 12:56:28.260] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 12:56:28.260] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:256] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-04-11 12:56:28.260] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 12:56:28.260] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 12:56:28.260] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 12:56:28.260] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 12:56:28.260] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 12:56:28.260] [wazuh-agent] [warning] [WARN] [configuration_parser.hpp:256] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-04-11 12:56:28.260] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 12:56:28.260] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: sca
[2025-04-11 12:56:28.261] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.data
[2025-04-11 12:56:28.261] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: path.data
[2025-04-11 12:56:28.261] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: hotfixes
[2025-04-11 12:56:28.261] [wazuh-agent] [debug] [DEBUG] [configuration_parser.hpp:214] [GetConfig] Requested setting not found, default value used. Key not found: localfiles
[2025-04-11 12:56:28.261] [wazuh-agent] [info] [INFO] [inventory.cpp:19] [Run] Inventory module running.
[2025-04-11 12:56:28.261] [wazuh-agent] [info] [INFO] [logcollector.cpp:32] [Run] Logcollector module running.
[2025-04-11 12:56:28.262] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:982] [SyncLoop] Module started.
[2025-04-11 12:56:28.262] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:965] [Scan] Starting evaluation.
[2025-04-11 12:56:28.553] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:977] [Scan] Evaluation finished.
^C[2025-04-11 12:56:32.631] [wazuh-agent] [info] [INFO] [inventory.cpp:78] [Stop] Inventory module stopping...
[2025-04-11 12:56:32.631] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:965] [Scan] Starting evaluation.
[2025-04-11 12:56:32.631] [wazuh-agent] [info] [INFO] [inventoryImp.cpp:977] [Scan] Evaluation finished.
[2025-04-11 12:56:32.631] [wazuh-agent] [info] [INFO] [inventory.cpp:43] [Run] Inventory module stopped.
[2025-04-11 12:56:32.663] [wazuh-agent] [debug] [DEBUG] [logcollector.cpp:204] [Wait] Logcollector coroutine timer was canceled.
[2025-04-11 12:56:33.179] [wazuh-agent] [info] [INFO] [logcollector.cpp:101] [Stop] Logcollector module stopped.
```

</details>

<details><summary>After changes: Windows</summary>

```
PS C:\Program Files\wazuh-agent> .\wazuh-agent.exe
[2025-04-11 17:44:02.178] [wazuh-agent] [info] [INFO] [D:\a\wazuh-agent\wazuh-agent\src\agent\src\instance_handler_win.cpp:47] [getInstanceLock] Mutex created
[2025-04-11 17:44:02.180] [wazuh-agent] [info] [INFO] [D:\a\wazuh-agent\wazuh-agent\src\agent\src\agent_runner.cpp:196] [StartAgent] Starting wazuh-agent
[2025-04-11 17:44:02.210] [wazuh-agent] [warning] [WARN] [D:\a\wazuh-agent\wazuh-agent\src\agent\configuration_parser\include\configuration_parser.hpp:235] [GetParsedConfigInRangeOrDefault] Invalid range: min value is greater or equal to max value.
[2025-04-11 17:44:02.417] [wazuh-agent] [info] [INFO] [D:\a\wazuh-agent\wazuh-agent\src\agent\communicator\src\communicator.cpp:109] [SendAuthenticationRequest] Successfully authenticated with the manager.
[2025-04-11 17:44:02.419] [wazuh-agent] [warning] [WARN] [D:\a\wazuh-agent\wazuh-agent\src\agent\configuration_parser\include\configuration_parser.hpp:256] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-04-11 17:44:02.419] [wazuh-agent] [warning] [WARN] [D:\a\wazuh-agent\wazuh-agent\src\agent\configuration_parser\include\configuration_parser.hpp:256] [GetParsedConfigInRangeOrDefault] Requested setting is not found or out of range, default value used.
[2025-04-11 17:44:02.421] [wazuh-agent] [info] [INFO] [D:\a\wazuh-agent\wazuh-agent\src\modules\inventory\src\inventory.cpp:19] [Run] Inventory module running.
[2025-04-11 17:44:02.421] [wazuh-agent] [info] [INFO] [D:\a\wazuh-agent\wazuh-agent\src\modules\logcollector\src\logcollector.cpp:28] [Run] Logcollector module is disabled.
[2025-04-11 17:44:02.422] [wazuh-agent] [info] [INFO] [D:\a\wazuh-agent\wazuh-agent\src\modules\inventory\src\inventoryImp.cpp:982] [SyncLoop] Module started.
[2025-04-11 17:44:02.422] [wazuh-agent] [info] [INFO] [D:\a\wazuh-agent\wazuh-agent\src\modules\inventory\src\inventoryImp.cpp:965] [Scan] Starting evaluation.
[2025-04-11 17:44:02.569] [wazuh-agent] [info] [INFO] [D:\a\wazuh-agent\wazuh-agent\src\modules\inventory\src\inventoryImp.cpp:977] [Scan] Evaluation finished.
```

</details>

### Artifacts Affected

- Executables:
  - wazuh-agent

### Configuration Changes

None

### Documentation Updates

None

### Tests Introduced

None

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
