### PR TITLE
Remove manager packages uploading from workflow

### DIFF
--- a/.github/workflows/5_builderpackage_docker-upload.yml
+++ b/.github/workflows/5_builderpackage_docker-upload.yml
@@ -29,16 +29,6 @@ jobs:
         id: changes
         with:
           filters: |
-            pkg_deb_manager_builder_amd64:
-              - 'packages/build.sh'
-              - 'packages/generate_package.sh'
-              - 'packages/debs/amd64/manager/**'
-              - 'packages/debs/utils/**'
-            pkg_rpm_manager_builder_amd64:
-              - 'packages/build.sh'
-              - 'packages/generate_package.sh'
-              - 'packages/rpms/amd64/manager/**'
-              - 'packages/rpms/utils/**'
             pkg_deb_agent_builder_amd64:
               - 'packages/build.sh'
               - 'packages/generate_package.sh'
@@ -112,20 +102,6 @@ jobs:
           VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           echo "TAG=$VERSION" >> $GITHUB_ENV;
 
-      - name: Request pkg_deb_manager_builder_amd64 update
-        if: steps.changes.outputs.pkg_deb_manager_builder_amd64 == 'true'
-        run: |
-          gh workflow run packages-upload-manager-images.yml -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=deb -f source_reference=${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Request pkg_rpm_manager_builder_amd64 update
-        if: steps.changes.outputs.pkg_rpm_manager_builder_amd64 == 'true'
-        run: |
-          gh workflow run packages-upload-manager-images.yml -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f source_reference=${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Request pkg_deb_agent_builder_amd64 update
         if: steps.changes.outputs.pkg_deb_agent_builder_amd64 == 'true'
         run: |
@@ -153,4 +129,3 @@ jobs:
           gh workflow run 5_builderpackage_upload-images-linux.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=arm64 -f source_reference=${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
-


### PR DESCRIPTION
## Description

Testing this issue:

- https://github.com/wazuh/wazuh-agent-packages/issues/252

We're found that the `5_builderpackage_docker-upload` workflow is failing:

https://github.com/wazuh/wazuh-agent/actions/runs/14471062890

> HTTP 404: workflow packages-upload-manager-images.yml not found on the default branch

Indeed, references to the manager packages have no sense in this repo.

## Proposed Changes

Remove references to the manager packages.

### Results and Evidence

https://github.com/wazuh/wazuh-agent/actions/runs/14471238254

### Artifacts Affected

- `5_builderpackage_docker-upload` workflow

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues