### PR TITLE
Add support for "Not Applicable" SCA check result

### DIFF
--- a/src/modules/sca/include/sca_event_handler.hpp
+++ b/src/modules/sca/include/sca_event_handler.hpp
@@ -2,6 +2,7 @@
 
 #include <idbsync.hpp>
 #include <message.hpp>
+#include <sca_utils.hpp>
 
 #include <nlohmann/json.hpp>
 
@@ -43,8 +44,9 @@ public:
     /// @brief Reports the result of a check execution.
     /// @param policyId The ID of the policy associated with the check.
     /// @param checkId The ID of the check.
-    /// @param passed Indicates whether the check passed or failed.
-    void ReportCheckResult(const std::string& policyId, const std::string& checkId, bool passed) const;
+    /// @param result Indicates the result of the check execution.
+    void
+    ReportCheckResult(const std::string& policyId, const std::string& checkId, const sca::CheckResult result) const;
 
 protected:
     /// @brief Processes modified items and returns a list of events.

--- a/src/modules/sca/include/sca_policy.hpp
+++ b/src/modules/sca/include/sca_policy.hpp
@@ -36,13 +36,14 @@ public:
     boost::asio::awaitable<void>
     Run(std::time_t scanInterval,
         bool scanOnStart,
-        std::function<void(const std::string&, const std::string&, bool)> reportCheckResult);
+        std::function<void(const std::string&, const std::string&, const sca::CheckResult)> reportCheckResult);
 
     /// @brief Stops the policy check
     void Stop();
 
 private:
-    void Scan(const std::function<void(const std::string&, const std::string&, bool)>& reportCheckResult);
+    void
+    Scan(const std::function<void(const std::string&, const std::string&, const sca::CheckResult)>& reportCheckResult);
 
     std::string m_id;
     Check m_requirements;

--- a/src/modules/sca/include/sca_utils.hpp
+++ b/src/modules/sca/include/sca_utils.hpp
@@ -23,6 +23,30 @@ namespace sca
         WM_SCA_TYPE_COMMAND
     };
 
+    /// @brief Types of supported check results.
+    enum class CheckResult
+    {
+        Passed,
+        Failed,
+        NotApplicable,
+        NotRun
+    };
+
+    /// @brief Converts a CheckResult enum value to its string representation.
+    /// @param result The CheckResult enum value to convert.
+    /// @return The string representation of the CheckResult enum value.
+    constexpr std::string_view CheckResultToString(const CheckResult result)
+    {
+        switch (result)
+        {
+            case CheckResult::Passed: return "Passed";
+            case CheckResult::Failed: return "Failed";
+            case CheckResult::NotApplicable: return "Not applicable";
+            case CheckResult::NotRun: return "Not run";
+            default: return "Unknown";
+        }
+    }
+
     /// @brief Parses the rule type from the input string.
     /// @param input The input string to parse.
     /// @return An optional pair containing the rule type and its string representation if successful.

--- a/src/modules/sca/src/sca.cpp
+++ b/src/modules/sca/src/sca.cpp
@@ -53,7 +53,7 @@ void SecurityConfigurationAssessment::Run()
     {
         EnqueueTask(policy.Run(m_scanInterval,
                                m_scanOnStart,
-                               [this](const std::string& policyId, const std::string& checkId, bool result)
+                               [this](const std::string& policyId, const std::string& checkId, sca::CheckResult result)
                                {
                                    const SCAEventHandler eventHandler(m_agentUUID, m_dBSync, m_pushMessage);
                                    eventHandler.ReportCheckResult(policyId, checkId, result);

--- a/src/modules/sca/src/sca_event_handler.cpp
+++ b/src/modules/sca/src/sca_event_handler.cpp
@@ -53,11 +53,13 @@ void SCAEventHandler::ReportPoliciesDelta(
     }
 }
 
-void SCAEventHandler::ReportCheckResult(const std::string& policyId, const std::string& checkId, bool passed) const
+void SCAEventHandler::ReportCheckResult(const std::string& policyId,
+                                        const std::string& checkId,
+                                        const sca::CheckResult checkResult) const
 {
     auto policyData = GetPolicyById(policyId);
     auto checkData = GetPolicyCheckById(checkId);
-    checkData["result"] = passed ? "passed" : "failed";
+    checkData["result"] = sca::CheckResultToString(checkResult);
 
     auto updateResultQuery = SyncRowQuery::builder().table("sca_check").data(checkData).returnOldData().build();
 

--- a/src/modules/sca/src/sca_policy_loader.cpp
+++ b/src/modules/sca/src/sca_policy_loader.cpp
@@ -118,11 +118,11 @@ void SCAPolicyLoader::SyncPoliciesAndReportDelta(const nlohmann::json& data, con
             {
                 if (check.second["result"] == INSERTED)
                 {
-                    check.second["data"]["result"] = "Not run";
+                    check.second["data"]["result"] = sca::CheckResultToString(sca::CheckResult::NotRun);
                 }
                 else if (check.second["result"] == MODIFIED)
                 {
-                    check.second["data"]["new"]["result"] = "Not run";
+                    check.second["data"]["new"]["result"] = sca::CheckResultToString(sca::CheckResult::NotRun);
                     UpdateCheckResult(check.second["data"]["new"]);
                 }
             }


### PR DESCRIPTION
## Description

This pull request addresses the need to handle scenarios where SCA checks cannot be executed due to unmet requirements. It introduces logic to assign a "Not Applicable" result to such checks, ensuring accurate reporting. This enhancement improves the clarity of SCA scan outcomes by explicitly indicating checks that are irrelevant in certain contexts.

## Proposed Changes

* Implemented logic to assign "Not Applicable" results to SCA checks when their requirements are not met.
* Updated the `SCAPolicy` class to handle and report "Not Applicable" results appropriately.
* `enum class CheckResult` added to define all possible results.
### Results and Evidence


## Results and Evidence
In the following messages received by the mock server, the create event with a "Not run" result can be seen, followed by an update event with a "Not applicable" result. The test was performed using the Amazon Linux policy file in an Ubuntu environment:

```
{"agent":{"groups":[],"host":{"architecture":"x86_64","hostname":"asus","ip":["172.17.0.1","fe80::42:a7ff:fe65:cecf","fe80::34bf:39ff:fe7b:dce9","192.168.1.32","fe80::c84a:c1b:8ab7:3840"],"os":{"name":"Ubuntu","type":"Linux","version":"22.04.5 LTS (Jammy Jellyfish)"}},"id":"d9a65288-11bc-4362-8198-fa4939116a73","name":"dummy","type":"Endpoint","version":"v5.0.0"}}
{"id":"a2c4e0f50e828ce3fce0ce199f387e4c5a59fdd3","module":"sca","operation":"create"}
{"check":{"compliance":["cis:1.1.1.1","cis_csc:13","pci_dss:2.2.5","tsc:CC6.3"],"condition":"all","description":"The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image.","id":"20000","rationale":"Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it.","references":"AJ Lewis, \"LVM HOWTO\", https://tldp.org/HOWTO/LVM-HOWTO/","remediation":"Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install cramfs /bin/true. Run the following command to unload the cramfs module: rmmod cramfs","result":"Not run","rules":["c:modprobe -n -v cramfs -> r:install /bin/true|Module cramfs not found","not c:lsmod -> r:cramfs"],"title":"Ensure mounting of cramfs filesystems is disabled."},"policy":{"description":"This document provides prescriptive guidance for establishing a secure configuration posture for Amazon Linux systems.","file":"cis_amazon_linux_1.yml","id":"cis_amazon_linux_1","name":"CIS Amazon Linux Benchmark v2.1.0","references":"https://www.cisecurity.org/cis-benchmarks/"},"timestamp":"2025-05-05T13:10:42.831Z"}
{"id":"a2c4e0f50e828ce3fce0ce199f387e4c5a59fdd3","module":"sca","operation":"update"}
{"check":{"compliance":["cis:1.1.1.1","cis_csc:13","pci_dss:2.2.5","tsc:CC6.3"],"condition":"all","description":"The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image.","id":"20000","rationale":"Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it.","remediation":"Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install cramfs /bin/true. Run the following command to unload the cramfs module: rmmod cramfs","result":"Not applicable","rules":["c:modprobe -n -v cramfs -> r:install /bin/true|Module cramfs not found","not c:lsmod -> r:cramfs"]},"policy":{"description":"This document provides prescriptive guidance for establishing a secure configuration posture for Amazon Linux systems.","file":"cis_amazon_linux_1.yml","id":"cis_amazon_linux_1","name":"CIS Amazon Linux Benchmark v2.1.0"},"timestamp":"2025-05-05T13:10:42.852Z"}
```

### Artifacts Affected

- Executables 

### Configuration Changes

None

### Documentation Updates

None

### Tests Introduced

None

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
