### PR TITLE
Fixes IPv6 address format reported by NetworkWindowsHelper

### DIFF
--- a/src/common/networkHelper/src/networkWindowsHelper.cpp
+++ b/src/common/networkHelper/src/networkWindowsHelper.cpp
@@ -294,56 +294,24 @@ namespace Utils
 
     std::string getIpV6Address(const uint8_t* addrParam)
     {
-        std::string retVal;
-
-        if (addrParam)
+        if (!addrParam)
         {
-            constexpr auto IPV6_BUFFER_ADDRESS_SIZE {16};
-            std::array<char, IPV6_BUFFER_ADDRESS_SIZE> buffer;
-            memcpy(buffer.data(), addrParam, IPV6_BUFFER_ADDRESS_SIZE);
-
-            std::array<char, IPV6_BUFFER_ADDRESS_SIZE> addrComparator;
-            addrComparator.fill(0);
-
-            if (std::equal(buffer.begin(), buffer.end(), addrComparator.begin()))
-            {
-                retVal = "::";
-            }
-            else
-            {
-                addrComparator.at(IPV6_BUFFER_ADDRESS_SIZE - 1) = 0x1;
-
-                if (std::equal(buffer.begin(), buffer.end(), addrComparator.begin()))
-                {
-                    retVal = "::1";
-                }
-                else
-                {
-                    std::stringstream ss;
-                    bool separator {false};
-                    ss << std::hex << std::setfill('0');
-
-                    for (const auto& value : buffer)
-                    {
-                        ss << std::setw(2) << (static_cast<unsigned>(value) & 0xFF);
-
-                        if (separator)
-                        {
-                            ss << ":";
-                        }
-
-                        separator = !separator;
-                    }
-
-                    retVal = ss.str();
-                    Utils::replaceAll(retVal, "0000", "");
-                    Utils::replaceAll(retVal, ":::", "::");
-                    retVal = retVal.substr(0, retVal.size() - 1);
-                }
-            }
+            return "";
         }
 
-        return retVal;
+        sockaddr_in6 sa6 {};
+        sa6.sin6_family = AF_INET6;
+        memcpy(&sa6.sin6_addr, addrParam, 16);
+
+        wchar_t buffer[128] = {};
+        DWORD bufSize = 128;
+
+        if (WSAAddressToStringW(reinterpret_cast<SOCKADDR*>(&sa6), sizeof(sa6), nullptr, buffer, &bufSize) != 0)
+        {
+            return "";
+        }
+
+        return wstringToStringUTF8(buffer);
     }
 
     std::string ipv6Netmask(const uint8_t maskLength)

--- a/src/common/networkHelper/tests/networkWindowsHelper_test.cpp
+++ b/src/common/networkHelper/tests/networkWindowsHelper_test.cpp
@@ -1,9 +1,18 @@
 #include "networkWindowsHelper_test.hpp"
 #include "networkWindowsHelper.hpp"
 
-void NetworkWindowsHelperTest::SetUp() {};
+#include <array>
 
-void NetworkWindowsHelperTest::TearDown() {};
+void NetworkWindowsHelperTest::SetUp()
+{
+    WSADATA wsaData;
+    WSAStartup(MAKEWORD(2, 2), &wsaData);
+};
+
+void NetworkWindowsHelperTest::TearDown()
+{
+    WSACleanup();
+};
 
 TEST_F(NetworkWindowsHelperTest, ipv6NetMask_64)
 {
@@ -50,4 +59,131 @@ TEST_F(NetworkWindowsHelperTest, ipv6NetMask_INVALID)
     const int addressPrefixLength {130};
     std::string netMask {Utils::ipv6Netmask(addressPrefixLength)};
     EXPECT_TRUE(netMask.empty());
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressNullInputReturnsEmptyString)
+{
+    EXPECT_EQ(Utils::getIpV6Address(nullptr), "");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressAllZerosReturnsDoubleColon)
+{
+    std::array<uint8_t, 16> addr = {0};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "::");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressLoopbackReturnsDoubleColonOne)
+{
+    // ::1
+    std::array<uint8_t, 16> addr = {0};
+    addr[15] = 1;
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "::1");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressValidAddressReturnsCompressedIPv6)
+{
+    std::array<uint8_t, 16> addr = {
+        0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x47, 0xf9, 0x90, 0xce, 0xdd, 0xf9, 0x71, 0x1a};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "fe80::47f9:90ce:ddf9:711a");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressGlobalUnicastReturnsCorrectFormat)
+{
+    std::array<uint8_t, 16> addr = {
+        0x20, 0x01, 0x0d, 0xb8, 0x85, 0xa3, 0x00, 0x00, 0x00, 0x00, 0x8a, 0x2e, 0x03, 0x70, 0x73, 0x34};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "2001:db8:85a3::8a2e:370:7334");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressLinkLocalReturnsCorrectFormat)
+{
+    std::array<uint8_t, 16> addr = {
+        0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x01, 0xff, 0xfe, 0x23, 0x45, 0x67, 0x89, 0x0a, 0x00, 0x00};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "fe80::1ff:fe23:4567:890a:0");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressMulticastReturnsCorrectFormat)
+{
+    std::array<uint8_t, 16> addr = {
+        0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "ff02::1");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressMultipleZeroBlocksCompressesCorrectly)
+{
+    std::array<uint8_t, 16> addr = {
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x00, 0x00, 0x42, 0x83, 0x29};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "2001:db8::ff00:42:8329");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressLeadingZerosInHextetsOmitsLeadingZeros)
+{
+    std::array<uint8_t, 16> addr = {
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x00, 0x00, 0x42, 0x83, 0x29};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "2001:db8::ff00:42:8329");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressIPv4MappedReturnsCorrectFormat)
+{
+    std::array<uint8_t, 16> addr = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x01, 0x01};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "::ffff:192.168.1.1");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressNoZeroBlocksReturnsFullAddress)
+{
+    std::array<uint8_t, 16> addr = {
+        0x20, 0x01, 0x0d, 0xb8, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "2001:db8:1234:5678:9abc:def0:1234:5678");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressEndWithZerosCompressesCorrectly)
+{
+    std::array<uint8_t, 16> addr = {
+        0x20, 0x01, 0x0d, 0xb8, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "2001:db8:1234:5678::");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressStartWithZerosCompressesCorrectly)
+{
+    std::array<uint8_t, 16> addr = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x00, 0x00};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "::1234:5678:9abc:def0:0");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressMiddleZerosCompressesCorrectly)
+{
+    std::array<uint8_t, 16> addr = {
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "2001:db8::1234:5678:0");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressAllOnesReturnsCorrectFormat)
+{
+    std::array<uint8_t, 16> addr = {
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressCompressionAtStartAndEndCompressesCorrectly)
+{
+    std::array<uint8_t, 16> addr = {
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    EXPECT_EQ(Utils::getIpV6Address(addr.data()), "0:1:2:3:4::");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressNullPointerReturnsEmptyString)
+{
+    EXPECT_EQ(Utils::getIpV6Address(nullptr), "");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressNullBufferWithSizeReturnsEmptyString)
+{
+    uint8_t* nullBuffer = nullptr;
+    EXPECT_EQ(Utils::getIpV6Address(nullBuffer), "");
+}
+
+TEST_F(NetworkWindowsHelperTest, getIpV6AddressZeroLengthBufferReturnsEmptyString)
+{
+    std::array<uint8_t, 0> emptyAddr;
+    EXPECT_EQ(Utils::getIpV6Address(emptyAddr.data()), "");
 }


### PR DESCRIPTION
|Related issue|
|---|
|#777|

## Description

The original function manually formats the IPv6 address by converting each byte to hexadecimal and inserting colons, but it doesn't follow the standard IPv6 compression rules. Specifically, it fails to properly identify and compress the longest sequence of zero blocks (::), which can lead to invalid or non-canonical representations like "fe80:::47f9:90ce:ddf9:711a". This results in incorrect formatting and potential interoperability issues.

## Proposed Changes

The improved version uses the Windows API function WSAAddressToStringW, which properly formats and compresses IPv6 addresses according to standard rules (e.g., :: for zero blocks, mixed IPv4 notation when applicable). This approach ensures correctness, avoids manual formatting errors, and produces canonical, human-readable IPv6 strings reliably.

### Results and Evidence

<details><summary>Tests</summary>

```
Test project D:/a/wazuh-agent/wazuh-agent/build-windows-2022
      Start  1: byteArrayHelperTests
 1/68 Test  #1: byteArrayHelperTests ..............   Passed    0.01 sec
      Start  2: cmdHelperTests
 2/68 Test  #2: cmdHelperTests ....................   Passed    0.11 sec
      Start  3: sysInfoWindows_unit_test
 3/68 Test  #3: sysInfoWindows_unit_test ..........   Passed    0.09 sec
      Start  4: sysInfoWindowsWuaWmi_unit_test
 4/68 Test  #4: sysInfoWindowsWuaWmi_unit_test ....   Passed    1.22 sec
      Start  5: sysInfoNetworkWindows_unit_test
 5/68 Test  #5: sysInfoNetworkWindows_unit_test ...   Passed    0.01 sec
      Start  6: sysinfo_unit_test
 6/68 Test  #6: sysinfo_unit_test .................   Passed    0.01 sec
      Start  7: sysInfoPackages_unit_test
 7/68 Test  #7: sysInfoPackages_unit_test .........   Passed    0.01 sec
      Start  8: sysInfoPort_unit_test
 8/68 Test  #8: sysInfoPort_unit_test .............   Passed    0.01 sec
      Start  9: dbsync_unit_test
 9/68 Test  #9: dbsync_unit_test ..................   Passed    0.13 sec
      Start 10: dbsyncPipelineFactory_unit_test
10/68 Test #10: dbsyncPipelineFactory_unit_test ...   Passed    0.02 sec
      Start 11: dbengine_unit_test
11/68 Test #11: dbengine_unit_test ................   Passed    0.01 sec
      Start 12: fim_integration_test
12/68 Test #12: fim_integration_test ..............   Passed    0.40 sec
      Start 13: encodingHelperTests
13/68 Test #13: encodingHelperTests ...............   Passed    0.01 sec
      Start 14: Filesystem
14/68 Test #14: Filesystem ........................   Passed    0.01 sec
      Start [15](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:17): FileIO
15/68 Test #15: FileIO ............................   Passed    0.01 sec
      Start [16](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:18): globHelperTests
16/68 Test #16: globHelperTests ...................   Passed    0.01 sec
      Start [17](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:19): hashHelperTests
17/68 Test #17: hashHelperTests ...................   Passed    0.02 sec
      Start [18](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:20): jsonHelperTests
18/68 Test #18: jsonHelperTests ...................   Passed    0.01 sec
      Start [19](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:21): LoggerTest
19/68 Test #19: LoggerTest ........................   Passed    0.01 sec
      Start [20](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:22): mapWrapperTests
20/68 Test #20: mapWrapperTests ...................   Passed    0.01 sec
      Start [21](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:23): networkHelperTests
21/68 Test #21: networkHelperTests ................   Passed    0.02 sec
      Start [22](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:24): PalTimeTest
22/68 Test #22: PalTimeTest .......................   Passed    0.01 sec
      Start [23](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:25): pipelineHelperTests
23/68 Test #23: pipelineHelperTests ...............   Passed    0.01 sec
      Start [24](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:26): registryHelperTests
24/68 Test #24: registryHelperTests ...............   Passed    0.01 sec
      Start [25](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:27): sqliteWrapperTests
25/68 Test #25: sqliteWrapperTests ................   Passed    0.09 sec
      Start [26](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:28): stringHelperTests
26/68 Test #26: stringHelperTests .................   Passed    0.01 sec
      Start [27](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:29): threadDispatcherTests
27/68 Test #27: threadDispatcherTests .............   Passed    0.01 sec
      Start [28](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:30): timeHelperTests
28/68 Test #28: timeHelperTests ...................   Passed    0.01 sec
      Start [29](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:31): windowsHelperTests
29/68 Test #29: windowsHelperTests ................   Passed    0.03 sec
      Start [30](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:32): InventoryImpTest
30/68 Test #30: InventoryImpTest ..................   Passed   28.23 sec
      Start [31](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:33): InvNormalizerTest
31/68 Test #31: InvNormalizerTest .................   Passed    0.02 sec
      Start [32](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:34): StatelessEventUnitTest
32/68 Test #32: StatelessEventUnitTest ............   Passed    0.01 sec
      Start [33](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:35): LogcollectorUnitTests
33/68 Test #33: LogcollectorUnitTests .............   Passed    0.01 sec
      Start [34](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:36): SCATest
34/68 Test #34: SCATest ...........................   Passed    0.02 sec
      Start [35](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:37): SCAPolicyLoaderTest
35/68 Test #35: SCAPolicyLoaderTest ...............   Passed    0.01 sec
      Start [36](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:38): SCAEventHandlerTest
36/68 Test #36: SCAEventHandlerTest ...............   Passed    0.02 sec
      Start [37](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:39): SCAUtilsTest
37/68 Test #37: SCAUtilsTest ......................   Passed    0.01 sec
      Start [38](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:40): CheckConditionEvaluatorTest
38/68 Test #38: CheckConditionEvaluatorTest .......   Passed    0.01 sec
      Start [39](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:41): RuleCreationTest
39/68 Test #39: RuleCreationTest ..................   Passed    0.01 sec
      Start [40](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:42): FileRuleEvaluatorTest
40/68 Test #40: FileRuleEvaluatorTest .............   Passed    0.01 sec
      Start [41](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:43): CommandRuleEvaluatorTest
41/68 Test #41: CommandRuleEvaluatorTest ..........   Passed    0.01 sec
      Start [42](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:44): DirectoryRuleEvaluatorTest
42/68 Test #42: DirectoryRuleEvaluatorTest ........   Passed    0.01 sec
      Start [43](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:45): ProcessRuleEvaluatorTest
43/68 Test #43: ProcessRuleEvaluatorTest ..........   Passed    0.01 sec
      Start [44](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:46): SCAPolicyParserTest
44/68 Test #44: SCAPolicyParserTest ...............   Passed    0.01 sec
      Start [45](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:47): RegistryRuleEvaluatorTest
45/68 Test #45: RegistryRuleEvaluatorTest .........   Passed    0.01 sec
      Start [46](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:48): ModuleManagerTest
46/68 Test #46: ModuleManagerTest .................   Passed    0.05 sec
      Start [47](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:49): AgentInfoTest
47/68 Test #47: AgentInfoTest .....................   Passed    0.01 sec
      Start [48](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:50): AgentInfoPersistenceTest
48/68 Test #48: AgentInfoPersistenceTest ..........   Passed    0.01 sec
      Start [49](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:51): CentralizedConfiguration
49/68 Test #49: CentralizedConfiguration ..........   Passed    0.01 sec
      Start [50](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:52): CommandHandlerTest
50/68 Test #50: CommandHandlerTest ................   Passed    2.03 sec
      Start [51](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:53): CommandStoreTest
51/68 Test #51: CommandStoreTest ..................   Passed    0.01 sec
      Start [52](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:54): CommunicatorTest
52/68 Test #52: CommunicatorTest ..................   Passed    8.05 sec
      Start [53](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:55): ConfigParserTest
53/68 Test #53: ConfigParserTest ..................   Passed    0.01 sec
      Start [54](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:56): ConfigParserUtilsTest
54/68 Test #54: ConfigParserUtilsTest .............   Passed    0.01 sec
      Start [55](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:57): HttpClientTest
55/68 Test #55: HttpClientTest ....................   Passed    0.02 sec
      Start [56](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:58): HttpSocketTest
56/68 Test #56: HttpSocketTest ....................   Passed    0.01 sec
      Start [57](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:59): HttpsSocketTest
57/68 Test #57: HttpsSocketTest ...................   Passed    0.02 sec
      Start [58](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:60): HttpsVerifierTest
58/68 Test #58: HttpsVerifierTest .................   Passed    0.01 sec
      Start [59](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:61): InstanceCommunicatorTest
59/68 Test #59: InstanceCommunicatorTest ..........   Passed    7.04 sec
      Start [60](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:62): MultiTypeQueueTest
60/68 Test #60: MultiTypeQueueTest ................   Passed    0.02 sec
      Start [61](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:63): StorageTest
61/68 Test #61: StorageTest .......................   Passed    0.01 sec
      Start [62](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:64): SQLiteManager_test
62/68 Test #62: SQLiteManager_test ................   Passed    0.07 sec
      Start [63](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:65): TaskManagerTest
63/68 Test #63: TaskManagerTest ...................   Passed    0.01 sec
      Start [64](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:66): AgentTest
64/68 Test #64: AgentTest .........................   Passed    0.02 sec
      Start [65](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:67): AgentEnrollmentTest
65/68 Test #65: AgentEnrollmentTest ...............   Passed    0.01 sec
      Start [66](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:68): SignalHandlerTest
66/68 Test #66: SignalHandlerTest .................   Passed    0.01 sec
      Start [67](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:69): MessageQueueUtilsTest
67/68 Test #67: MessageQueueUtilsTest .............   Passed    0.01 sec
      Start [68](https://github.com/wazuh/wazuh-agent/actions/runs/14912236209/job/41889226909?pr=778#step:7:70): WindowsServiceTest
68/68 Test #68: WindowsServiceTest ................   Passed    0.02 sec

100% tests passed, 0 tests failed out of 68

Total Test time (real) =  48.25 sec
```

</details>

<details><summary>Server log when receiving events</summary>

```
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":5208},"source":{"ip":["::"],"port":500}}
{"collector":"ports","id":"18477a58a3edeec0e5f614ac5b9d30bc60919652","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":5208},"source":{"ip":["::"],"port":4500}}
{"collector":"ports","id":"e4f4f9b168f2248d524ed77d9b965de272dd7f69","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"chrome.exe","pid":13520},"source":{"ip":["::"],"port":5353}}
{"collector":"ports","id":"9c467e1a52fd48e98fa0ed0dc41abc544f0e1f65","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":1776},"source":{"ip":["::"],"port":5355}}
{"collector":"ports","id":"cf9c12663ae1b6671f7aafd4bf8ceac1889fb7fc","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":1776},"source":{"ip":["::"],"port":57262}}
{"collector":"ports","id":"0e381f86a7e5ee3faf839a10c30064c5c3605ab1","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"nvcontainer.exe","pid":5324},"source":{"ip":["::"],"port":60010}}
{"collector":"ports","id":"76d6dd9c1af1eb90e74fb50331472ca8b0480834","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":14960},"source":{"ip":["::1"],"port":1900}}
{"collector":"ports","id":"61ff80d3753c32ac2c44a7157b73bf54410cf5fc","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":14960},"source":{"ip":["::1"],"port":63034}}
{"collector":"ports","id":"519b0c45d34ed49aa8cd43e21b1bc7f5608dc633","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":14960},"source":{"ip":["fe80::1084:ca:78f:1d5c"],"port":1900}}
{"collector":"ports","id":"6651d0449f7d53c93544d66cb2732b22ff81dc90","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":19672},"source":{"ip":["fe80::1084:ca:78f:1d5c"],"port":2177}}
{"collector":"ports","id":"7eab5eec345862d1620b97d5dc11e833f5c334da","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"nvcontainer.exe","pid":5324},"source":{"ip":["fe80::1084:ca:78f:1d5c"],"port":5353}}
{"collector":"ports","id":"6cc486c7b68e2a11b40d2a90202069462ca31725","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":14960},"source":{"ip":["fe80::1084:ca:78f:1d5c"],"port":63029}}
{"collector":"ports","id":"484df6510e65f24a069606ccf5115b638cc3952f","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":14960},"source":{"ip":["fe80::1d36:21d4:2ce2:e490"],"port":1900}}
{"collector":"ports","id":"f0efe6139c53ce3e637efc466948417abc8ed50d","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":19672},"source":{"ip":["fe80::1d36:21d4:2ce2:e490"],"port":2177}}
{"collector":"ports","id":"af4df941a66a8c2de8bb1ab7a70e50a5a12bd5e0","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"nvcontainer.exe","pid":5324},"source":{"ip":["fe80::1d36:21d4:2ce2:e490"],"port":5353}}
{"collector":"ports","id":"e896af6f7b5c7c7872842ee4b32bd4909a721191","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":14960},"source":{"ip":["fe80::1d36:21d4:2ce2:e490"],"port":63030}}
{"collector":"ports","id":"d98dfeb61133678dd5707cf7b527fb86dddc23f2","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":14960},"source":{"ip":["fe80::5232:b073:f249:bae0"],"port":1900}}
{"collector":"ports","id":"0184caec1851bff988977f19ccd2ca1835c7793a","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":19672},"source":{"ip":["fe80::5232:b073:f249:bae0"],"port":2177}}
{"collector":"ports","id":"dbbad159617447aa680bde5f04ca01adfc90f63e","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":14960},"source":{"ip":["fe80::5232:b073:f249:bae0"],"port":63032}}
{"collector":"ports","id":"a3d0ac05203954c11daf35db0143c4bd575fe25e","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":14960},"source":{"ip":["fe80::5d20:309a:bf97:cdb2"],"port":1900}}
{"collector":"ports","id":"62d4f4c6f1e729f71beff38ed8ef8e714174fc55","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":19672},"source":{"ip":["fe80::5d20:309a:bf97:cdb2"],"port":2177}}
{"collector":"ports","id":"c4239eda4c0e9ebbfd6298d1309d48b60efbc087","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":14960},"source":{"ip":["fe80::5d20:309a:bf97:cdb2"],"port":63033}}
{"collector":"ports","id":"7d0cae2d8222a35818e290488b5ade548d9df438","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":14960},"source":{"ip":["fe80::cb86:5378:e2e0:3a4"],"port":1900}}
{"collector":"ports","id":"b39feb2ad20a8f54929e34f400fabf8012a521a2","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":19672},"source":{"ip":["fe80::cb86:5378:e2e0:3a4"],"port":2177}}
{"collector":"ports","id":"1a288176ec5acd0283db1652b65a11a4e51bf76e","module":"inventory","operation":"create"}
{"@timestamp":"2025-05-08T17:22:15.125Z","destination":{"ip":null,"port":0},"file":{"inode":0},"host":{"network":{"egress":{"queue":null},"ingress":{"queue":null}}},"interface":{"state":null},"network":{"protocol":"udp6"},"process":{"name":"svchost.exe","pid":14960},"source":{"ip":["fe80::cb86:5378:e2e0:3a4"],"port":63031}}
```

</details>


### Tests Introduced

Tests for “networkWindowsHelperTest”

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
