### PR TITLE
Support regex patterns with spaces in numeric comparison expressions

### DIFF
--- a/src/common/cmdHelper/tests/cmdHelper_test.cpp
+++ b/src/common/cmdHelper/tests/cmdHelper_test.cpp
@@ -5,8 +5,12 @@
 
 #ifdef WIN32
 const std::string TEST_CMD = "whoami";
+const std::string TEST_CMD_QUOTES = "powershell -Command \" Write-Output 'Hello world'\"";
+const std::string TEST_CMD_QUOTES_EXPECTED_RESULT = "Hello world\r\n";
 #else
 const std::string TEST_CMD = "uname";
+const std::string TEST_CMD_QUOTES = "bash -c \" echo 'Hello world'\"";
+const std::string TEST_CMD_QUOTES_EXPECTED_RESULT = "Hello world\n";
 #endif
 
 TEST_F(CmdUtilsTest, PipeOpenCmd)
@@ -49,4 +53,12 @@ TEST_F(CmdUtilsTest, PipeOpenEmptyCmd)
 {
     const auto result {Utils::PipeOpen("")};
     EXPECT_TRUE(result.empty());
+}
+
+TEST_F(CmdUtilsTest, ExecNestedQuotes)
+{
+    const auto result = Utils::Exec(TEST_CMD_QUOTES);
+    EXPECT_EQ(result.StdOut, TEST_CMD_QUOTES_EXPECTED_RESULT);
+    EXPECT_TRUE(result.StdErr.empty());
+    EXPECT_EQ(result.ExitCode, 0);
 }

--- a/src/modules/sca/src/sca_utils.cpp
+++ b/src/modules/sca/src/sca_utils.cpp
@@ -80,18 +80,25 @@ namespace
     bool
     EvaluateNumericRegexComparison(const std::string& content, const std::string& expr, sca::RegexEngineType engine)
     {
-        std::istringstream stream(expr);
-        std::string pattern, compareWord, opStr, expectedValueStr;
+        std::string pattern, opStr, expectedValueStr;
         std::pair<bool, std::string> matchResult {false, ""};
 
-        if (!(stream >> pattern >> compareWord >> opStr >> expectedValueStr))
+        const std::string compareWord = "compare";
+        const auto comparePos = expr.find(compareWord);
+        if (comparePos == std::string::npos)
         {
-            throw std::runtime_error("Invalid expression format");
+            throw std::runtime_error("Invalid expression format, 'compare' keyword missing");
         }
 
-        if (compareWord != "compare")
+        pattern = expr.substr(0, comparePos - 1);
+        const auto remainder = expr.substr(comparePos + compareWord.size() + 1);
+
+        std::istringstream remainderStream(remainder);
+        remainderStream >> opStr >> expectedValueStr;
+
+        if (opStr.empty() || expectedValueStr.empty())
         {
-            throw std::runtime_error("Expected 'compare' keyword in numeric comparison");
+            throw std::runtime_error("Invalid operator or expected value in numeric comparison");
         }
 
         const int expectedValue = std::stoi(expectedValueStr);

--- a/src/modules/sca/tests/command_rule_evaluator_test.cpp
+++ b/src/modules/sca/tests/command_rule_evaluator_test.cpp
@@ -139,3 +139,17 @@ TEST_F(CommandRuleEvaluatorTest, NumericPatternMatchesOutputReturnsFound)
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
 }
+
+TEST_F(CommandRuleEvaluatorTest, NumericPatternWithStringMatchesOutputReturnsFound)
+{
+    m_ctx.rule = "some command";
+    m_ctx.pattern = std::string("n:Some string:\\s+(\\d+) compare >= 24");
+
+    m_execMock = [](const std::string&)
+    {
+        return std::make_pair("Some string:           42", "");
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
+}


### PR DESCRIPTION
## Description

This PR addresses two issues:

1. Numeric comparison expressions using regex patterns with spaces were not parsed correctly.
2. Commands with quoted arguments were being split incorrectly, causing execution errors.

## Proposed Changes

* Updated `EvaluateNumericRegexComparison` to support regex patterns containing spaces.
* Improved `TokenizeCommand` to preserve quoted arguments as single tokens during command parsing.

### Results and Evidence

Refer to https://github.com/wazuh/wazuh-agent/issues/766 to see manual tests.

### Artifacts Affected

- Executables


### Configuration Changes

None

### Documentation Updates

None

### Tests Introduced

- src/common/cmdHelper/tests/cmdHelper_test.cpp -> new case
- src/modules/sca/tests/command_rule_evaluator_test.cpp -> new case

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
