### PR TITLE
Add new SCA regex validation cases

### DIFF
--- a/src/common/registryHelper/include/registryHelper.hpp
+++ b/src/common/registryHelper/include/registryHelper.hpp
@@ -88,6 +88,11 @@ namespace Utils
         /// @return True if the value was found
         bool string(const std::string& valueName, std::string& value) const;
 
+        /// @brief Get a value as a string
+        /// @param valueName Name of the value
+        /// @return Value as a string
+        std::string getValue(const std::string& valueName) const;
+
     private:
         /// @brief Open the registry
         /// @param key Key of the registry

--- a/src/modules/sca/src/sca_policy_check.cpp
+++ b/src/modules/sca/src/sca_policy_check.cpp
@@ -45,6 +45,7 @@ namespace
             }
             else
             {
+                LogDebug("Invalid pattern '{}' for file '{}'", pattern, filePath);
                 return RuleResult::Invalid;
             }
         }
@@ -170,6 +171,7 @@ RuleResult CommandRuleEvaluator::Evaluate()
             }
             else
             {
+                LogDebug("Invalid pattern '{}' for command rule evaluation", *m_ctx.pattern);
                 return RuleResult::Invalid;
             }
         }
@@ -279,6 +281,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
                     hadValue = true;
                     if (patternMatch.value())
                     {
+                        LogDebug("Pattern '{}' was found in directory '{}'", pattern, rootPath.string());
                         return m_ctx.isNegated ? RuleResult::NotFound : RuleResult::Found;
                     }
                 }
@@ -296,6 +299,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
             {
                 if (file.filename().string() == pattern)
                 {
+                    LogDebug("Pattern '{}' was found in directory '{}'", pattern, rootPath.string());
                     return m_ctx.isNegated ? RuleResult::NotFound : RuleResult::Found;
                 }
             }
@@ -303,6 +307,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
 
         if (isRegex && !hadValue)
         {
+            LogDebug("Invalid pattern '{}' for directory '{}'", pattern, rootPath.string());
             return RuleResult::Invalid;
         }
     }

--- a/src/modules/sca/src/sca_policy_check.cpp
+++ b/src/modules/sca/src/sca_policy_check.cpp
@@ -15,16 +15,6 @@
 
 namespace
 {
-    bool IsRegexPattern(const std::string& pattern)
-    {
-        return pattern.starts_with("r:") || pattern.starts_with("!r:");
-    }
-
-    bool IsRegexOrNumericPattern(const std::string& pattern)
-    {
-        return IsRegexPattern(pattern) || pattern.starts_with("n:") || pattern.starts_with("!n:");
-    }
-
     template<typename Func>
     auto TryFunc(Func&& func) -> std::optional<decltype(func())>
     {
@@ -45,7 +35,7 @@ namespace
     {
         bool matchFound = false;
 
-        if (IsRegexOrNumericPattern(pattern))
+        if (sca::IsRegexOrNumericPattern(pattern))
         {
             const auto content = fileUtils->getFileContent(filePath);
 
@@ -168,7 +158,7 @@ RuleResult CommandRuleEvaluator::Evaluate()
         output = Utils::Trim(output, "\n");
         error = Utils::Trim(error, "\n");
 
-        if (IsRegexOrNumericPattern(*m_ctx.pattern))
+        if (sca::IsRegexOrNumericPattern(*m_ctx.pattern))
         {
             const auto outputPatternMatch = sca::PatternMatches(output, *m_ctx.pattern);
             const auto errorPatternMatch = sca::PatternMatches(error, *m_ctx.pattern);
@@ -263,7 +253,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
         const auto& files = *filesOpt;
 
         // Check if pattern is a regex
-        const auto isRegex = IsRegexPattern(pattern);
+        const auto isRegex = sca::IsRegexPattern(pattern);
 
         // Check if pattern has content
         const auto content = sca::GetPattern(pattern);

--- a/src/modules/sca/src/sca_policy_check.cpp
+++ b/src/modules/sca/src/sca_policy_check.cpp
@@ -37,6 +37,44 @@ namespace
             return std::nullopt;
         }
     }
+
+    RuleResult FindContentInFile(const std::unique_ptr<IFileIOUtils>& fileUtils,
+                                 const std::string& filePath,
+                                 const std::string& pattern,
+                                 const bool isNegated)
+    {
+        bool matchFound = false;
+
+        if (IsRegexOrNumericPattern(pattern))
+        {
+            const auto content = fileUtils->getFileContent(filePath);
+
+            if (const auto patternMatch = sca::PatternMatches(content, pattern))
+            {
+                matchFound = patternMatch.value();
+            }
+            else
+            {
+                return RuleResult::Invalid;
+            }
+        }
+        else
+        {
+            fileUtils->readLineByLine(filePath,
+                                      [&pattern, &matchFound](const std::string& line)
+                                      {
+                                          if (line == pattern)
+                                          {
+                                              matchFound = true;
+                                              return false;
+                                          }
+                                          return true;
+                                      });
+        }
+
+        LogDebug("Pattern '{}' {} found in file '{}'", pattern, matchFound ? "was" : "was not", filePath);
+        return (matchFound != isNegated) ? RuleResult::Found : RuleResult::NotFound;
+    }
 } // namespace
 
 RuleEvaluator::RuleEvaluator(PolicyEvaluationContext ctx, std::unique_ptr<IFileSystemWrapper> fileSystemWrapper)
@@ -74,8 +112,7 @@ RuleResult FileRuleEvaluator::Evaluate()
 
 RuleResult FileRuleEvaluator::CheckFileForContents()
 {
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    const auto pattern = *m_ctx.pattern;
+    const auto pattern = *m_ctx.pattern; // NOLINT(bugprone-unchecked-optional-access)
 
     LogDebug("Processing file rule. Checking contents of file: '{}' against pattern '{}'", m_ctx.rule, pattern);
 
@@ -85,48 +122,25 @@ RuleResult FileRuleEvaluator::CheckFileForContents()
         return RuleResult::Invalid;
     }
 
-    bool matchFound = false;
-
-    if (IsRegexOrNumericPattern(pattern))
-    {
-        const auto content = m_fileUtils->getFileContent(m_ctx.rule);
-
-        if (const auto patternMatch = sca::PatternMatches(content, pattern))
-        {
-            matchFound = patternMatch.value();
-        }
-        else
-        {
-            return RuleResult::Invalid;
-        }
-    }
-    else
-    {
-        m_fileUtils->readLineByLine(m_ctx.rule,
-                                    [&pattern, &matchFound](const std::string& line)
-                                    {
-                                        if (line == pattern)
-                                        {
-                                            // stop reading
-                                            matchFound = true;
-                                            return false;
-                                        }
-                                        // continue reading
-                                        return true;
-                                    });
-    }
-
-    LogDebug("Pattern '{}' {} found in file '{}'", pattern, matchFound ? "was" : "was not", m_ctx.rule);
-    return (matchFound != m_ctx.isNegated) ? RuleResult::Found : RuleResult::NotFound;
+    return FindContentInFile(m_fileUtils, m_ctx.rule, pattern, m_ctx.isNegated);
 }
 
 RuleResult FileRuleEvaluator::CheckFileExistence()
 {
-    LogDebug("Processing file rule. Checking existence of file: '{}'", m_ctx.rule);
-    const auto exists = m_fileSystemWrapper->exists(m_ctx.rule) && m_fileSystemWrapper->is_regular_file(m_ctx.rule);
-    const auto result = exists ? RuleResult::Found : RuleResult::NotFound;
+    auto result = RuleResult::NotFound;
 
-    LogDebug("File '{}' {} found", m_ctx.rule, exists ? "was" : "was not");
+    LogDebug("Processing file rule. Checking existence of file: '{}'", m_ctx.rule);
+
+    if (!m_fileSystemWrapper->exists(m_ctx.rule) || !m_fileSystemWrapper->is_regular_file(m_ctx.rule))
+    {
+        LogDebug("File '{}' does not exist or is not a file", m_ctx.rule);
+    }
+    else
+    {
+        LogDebug("File '{}' exists", m_ctx.rule);
+        result = RuleResult::Found;
+    }
+
     return m_ctx.isNegated ? (result == RuleResult::Found ? RuleResult::NotFound : RuleResult::Found) : result;
 }
 
@@ -198,8 +212,6 @@ DirRuleEvaluator::DirRuleEvaluator(PolicyEvaluationContext ctx,
 
 RuleResult DirRuleEvaluator::Evaluate()
 {
-    LogDebug("Processing directory rule: '{}'", m_ctx.rule);
-
     if (m_ctx.pattern)
     {
         return CheckDirectoryForContents();
@@ -209,6 +221,8 @@ RuleResult DirRuleEvaluator::Evaluate()
 
 RuleResult DirRuleEvaluator::CheckDirectoryForContents()
 {
+    LogDebug("Processing directory rule: '{}'", m_ctx.rule);
+
     if (!TryFunc([&] { return m_fileSystemWrapper->exists(m_ctx.rule); }).value_or(false))
     {
         LogDebug("Path '{}' does not exist", m_ctx.rule);
@@ -245,24 +259,30 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
             continue;
         }
 
+        bool hadValue = false;
         const auto& files = *filesOpt;
 
-        if (IsRegexPattern(pattern))
+        // Check if pattern is a regex
+        const auto isRegex = IsRegexPattern(pattern);
+
+        // Check if pattern has content
+        const auto content = sca::GetPattern(pattern);
+
+        for (const auto& file : files)
         {
-            bool hadValue = false;
-            for (const auto& file : files)
+            if (TryFunc([&] { return m_fileSystemWrapper->is_symlink(file); }).value_or(false))
             {
-                if (TryFunc([&] { return m_fileSystemWrapper->is_symlink(file); }).value_or(false))
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                if (TryFunc([&] { return m_fileSystemWrapper->is_directory(file); }).value_or(false))
-                {
-                    dirs.emplace(file);
-                    continue;
-                }
+            if (TryFunc([&] { return m_fileSystemWrapper->is_directory(file); }).value_or(false))
+            {
+                dirs.emplace(file);
+                continue;
+            }
 
+            if (isRegex)
+            {
                 const auto patternMatch = sca::PatternMatches(file.filename().string(), pattern);
                 if (patternMatch.has_value())
                 {
@@ -273,74 +293,27 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
                     }
                 }
             }
-
-            if (!hadValue)
+            else if (content.has_value())
             {
-                return RuleResult::Invalid;
-            }
-        }
-        else if (const auto content = sca::GetPattern(pattern))
-        {
-            const auto fileName = pattern.substr(0, pattern.find(" -> "));
-            for (const auto& file : files)
-            {
-                if (TryFunc([&] { return m_fileSystemWrapper->is_symlink(file); }).value_or(false))
-                {
-                    continue;
-                }
-
-                if (TryFunc([&] { return m_fileSystemWrapper->is_directory(file); }).value_or(false))
-                {
-                    dirs.emplace(file);
-                    continue;
-                }
+                const auto fileName = pattern.substr(0, pattern.find(" -> "));
 
                 if (file.filename().string() == fileName)
                 {
-                    bool found = false;
-                    TryFunc(
-                        [&]
-                        {
-                            m_fileUtils->readLineByLine(file,
-                                                        [&content, &found](const std::string& line)
-                                                        {
-                                                            if (line == content.value())
-                                                            {
-                                                                found = true;
-                                                                return false;
-                                                            }
-                                                            return true;
-                                                        });
-                            return true;
-                        });
-
-                    if (found)
-                    {
-                        return m_ctx.isNegated ? RuleResult::NotFound : RuleResult::Found;
-                    }
+                    return FindContentInFile(m_fileUtils, fileName, content.value(), m_ctx.isNegated);
                 }
             }
-        }
-        else
-        {
-            for (const auto& file : files)
+            else
             {
-                if (TryFunc([&] { return m_fileSystemWrapper->is_symlink(file); }).value_or(false))
-                {
-                    continue;
-                }
-
-                if (TryFunc([&] { return m_fileSystemWrapper->is_directory(file); }).value_or(false))
-                {
-                    dirs.emplace(file);
-                    continue;
-                }
-
                 if (file.filename().string() == pattern)
                 {
                     return m_ctx.isNegated ? RuleResult::NotFound : RuleResult::Found;
                 }
             }
+        }
+
+        if (isRegex && !hadValue)
+        {
+            return RuleResult::Invalid;
         }
     }
 
@@ -351,6 +324,8 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
 RuleResult DirRuleEvaluator::CheckDirectoryExistence()
 {
     auto result = RuleResult::NotFound;
+
+    LogDebug("Processing directory rule. Checking existence of directory: '{}'", m_ctx.rule);
 
     if (!m_fileSystemWrapper->exists(m_ctx.rule) || !m_fileSystemWrapper->is_directory(m_ctx.rule))
     {

--- a/src/modules/sca/src/sca_policy_check.hpp
+++ b/src/modules/sca/src/sca_policy_check.hpp
@@ -117,22 +117,24 @@ class RegistryRuleEvaluator : public RuleEvaluator
 {
 public:
     using IsValidRegistryKeyFunc = std::function<bool(const std::string& rootKey)>;
-    using GetRegistryKeysFunc =
-        std::function<std::vector<std::string>(const std::string& root, const std::string& subkey)>;
-    using GetRegistryValuesFunc =
-        std::function<std::vector<std::string>(const std::string& root, const std::string& subkey)>;
+    using GetRegistryValuesFunc = std::function<std::vector<std::string>(const std::string& rootKey)>;
+    using GetRegistryKeyValueFunc = std::function<std::string(const std::string& rootKey, const std::string& key)>;
 
     RegistryRuleEvaluator(PolicyEvaluationContext ctx,
                           IsValidRegistryKeyFunc isValidRegistryKey = nullptr,
-                          GetRegistryKeysFunc getRegistryKeys = nullptr,
-                          GetRegistryValuesFunc getRegistryValues = nullptr);
+                          GetRegistryValuesFunc getRegistryValues = nullptr,
+                          GetRegistryKeyValueFunc getRegistryKeyValue = nullptr);
 
     RuleResult Evaluate() override;
 
 private:
+    RuleResult CheckRegistryForContents();
+
+    RuleResult CheckRegistryExistence();
+
     IsValidRegistryKeyFunc m_isValidRegistryKey = nullptr;
-    GetRegistryKeysFunc m_getRegistryKeys = nullptr;
     GetRegistryValuesFunc m_getRegistryValues = nullptr;
+    GetRegistryKeyValueFunc m_getRegistryKeyValue = nullptr;
 };
 
 class RuleEvaluatorFactory

--- a/src/modules/sca/src/sca_policy_check_win.cpp
+++ b/src/modules/sca/src/sca_policy_check_win.cpp
@@ -7,16 +7,6 @@
 
 namespace
 {
-    bool IsRegexPattern(const std::string& pattern)
-    {
-        return pattern.starts_with("r:") || pattern.starts_with("!r:");
-    }
-
-    bool IsRegexOrNumericPattern(const std::string& pattern)
-    {
-        return IsRegexPattern(pattern) || pattern.starts_with("n:") || pattern.starts_with("!n:");
-    }
-
     // Checks if a registry key exists
     const RegistryRuleEvaluator::IsValidRegistryKeyFunc DEFAULT_IS_VALID_REGISTRY_KEY =
         [](const std::string& rootKey) -> bool
@@ -51,7 +41,7 @@ namespace
     {
         bool matchFound = false;
 
-        if (IsRegexOrNumericPattern(pattern))
+        if (sca::IsRegexOrNumericPattern(pattern))
         {
             if (const auto patternMatch = sca::PatternMatches(value, pattern))
             {
@@ -112,7 +102,7 @@ RuleResult RegistryRuleEvaluator::CheckRegistryForContents()
         bool hadValue = false;
 
         // Check if pattern is a regex
-        const auto isRegex = IsRegexPattern(pattern);
+        const auto isRegex = sca::IsRegexPattern(pattern);
 
         // Check if pattern has content
         const auto content = sca::GetPattern(pattern);

--- a/src/modules/sca/src/sca_policy_check_win.cpp
+++ b/src/modules/sca/src/sca_policy_check_win.cpp
@@ -49,6 +49,7 @@ namespace
             }
             else
             {
+                LogDebug("Invalid pattern '{}' for registry value '{}'", pattern, value);
                 return RuleResult::Invalid;
             }
         }
@@ -117,6 +118,7 @@ RuleResult RegistryRuleEvaluator::CheckRegistryForContents()
                     hadValue = true;
                     if (patternMatch.value())
                     {
+                        LogDebug("Pattern '{}' was found in registry '{}'", pattern, m_ctx.rule);
                         return m_ctx.isNegated ? RuleResult::NotFound : RuleResult::Found;
                     }
                 }
@@ -135,6 +137,7 @@ RuleResult RegistryRuleEvaluator::CheckRegistryForContents()
             {
                 if (value == pattern)
                 {
+                    LogDebug("Pattern '{}' was found in registry '{}'", pattern, m_ctx.rule);
                     return m_ctx.isNegated ? RuleResult::NotFound : RuleResult::Found;
                 }
             }
@@ -142,6 +145,7 @@ RuleResult RegistryRuleEvaluator::CheckRegistryForContents()
 
         if (isRegex && !hadValue)
         {
+            LogDebug("Invalid pattern '{}' for registry '{}'", pattern, m_ctx.rule);
             return RuleResult::Invalid;
         }
     }

--- a/src/modules/sca/src/sca_utils.cpp
+++ b/src/modules/sca/src/sca_utils.cpp
@@ -306,4 +306,14 @@ namespace sca
         }
     }
 
+    bool IsRegexPattern(const std::string& pattern)
+    {
+        return pattern.starts_with("r:") || pattern.starts_with("!r:");
+    }
+
+    bool IsRegexOrNumericPattern(const std::string& pattern)
+    {
+        return IsRegexPattern(pattern) || pattern.starts_with("n:") || pattern.starts_with("!n:");
+    }
+
 } // namespace sca

--- a/src/modules/sca/src/sca_utils.hpp
+++ b/src/modules/sca/src/sca_utils.hpp
@@ -56,4 +56,14 @@ namespace sca
     std::optional<bool> PatternMatches(const std::string& content,
                                        const std::string& pattern,
                                        RegexEngineType engine = RegexEngineType::PCRE2);
+
+    /// @brief Checks if the given pattern is a regex pattern.
+    /// @param pattern The pattern to check.
+    /// @return True if the pattern is a regex pattern, false otherwise.
+    bool IsRegexPattern(const std::string& pattern);
+
+    /// @brief Checks if the given pattern is a regex pattern or a numeric pattern.
+    /// @param pattern The pattern to check.
+    /// @return True if the pattern is a regex pattern or a numeric pattern, false otherwise.
+    bool IsRegexOrNumericPattern(const std::string& pattern);
 } // namespace sca

--- a/src/modules/sca/tests/directory_rule_evaluator_test.cpp
+++ b/src/modules/sca/tests/directory_rule_evaluator_test.cpp
@@ -129,6 +129,38 @@ TEST_F(DirRuleEvaluatorTest, PatternWithArrowMatchesFileContentReturnsFound)
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
 }
 
+TEST_F(DirRuleEvaluatorTest, PatternWithArrowMatchesRegexFileContentReturnsFound)
+{
+    m_ctx.pattern = std::string("target.txt -> r:hello");
+    m_ctx.rule = "dir/";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, list_directory(std::filesystem::path("dir/")))
+        .WillOnce(::testing::Return(std::vector<std::filesystem::path> {"target.txt"}));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("target.txt"))).WillOnce(::testing::Return(false));
+    EXPECT_CALL(*m_rawIoMock, getFileContent("target.txt")).WillOnce(::testing::Return("hello"));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
+}
+
+TEST_F(DirRuleEvaluatorTest, PatternWithArrowMatchesRegexFileContentReturnsNotFound)
+{
+    m_ctx.pattern = std::string("target.txt -> r:hello");
+    m_ctx.rule = "dir/";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, list_directory(std::filesystem::path("dir/")))
+        .WillOnce(::testing::Return(std::vector<std::filesystem::path> {"target.txt"}));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("target.txt"))).WillOnce(::testing::Return(false));
+    EXPECT_CALL(*m_rawIoMock, getFileContent("target.txt")).WillOnce(::testing::Return("bye"));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::NotFound);
+}
+
 TEST_F(DirRuleEvaluatorTest, ExactPatternMatchesFileNameReturnsFound)
 {
     m_ctx.pattern = std::string("match.txt");


### PR DESCRIPTION
## Description

This PR adds support for some missing rule cases that can use regular expressions.

## Proposed Changes

- Add support to content files regex validation in directory checks.
- Add support to keys regex validation in registry checks.
- Add support to values regex validation in registry checks.

### Results and Evidence

```
> ctest -C RelWithDebInfo --test-dir build --output-log build
Internal ctest changing into directory: C:/Users/USUARIO/Desktop/wazuh-agent/build
Test project C:/Users/USUARIO/Desktop/wazuh-agent/build
      Start  1: byteArrayHelperTests
 1/68 Test  #1: byteArrayHelperTests ..............   Passed    0.01 sec
      Start  2: cmdHelperTests
 2/68 Test  #2: cmdHelperTests ....................   Passed    0.15 sec
      Start  3: sysInfoWindows_unit_test
 3/68 Test  #3: sysInfoWindows_unit_test ..........   Passed    0.08 sec
      Start  4: sysInfoWindowsWuaWmi_unit_test
 4/68 Test  #4: sysInfoWindowsWuaWmi_unit_test ....   Passed    2.03 sec
      Start  5: sysInfoNetworkWindows_unit_test
 5/68 Test  #5: sysInfoNetworkWindows_unit_test ...   Passed    0.03 sec
      Start  6: sysinfo_unit_test
 6/68 Test  #6: sysinfo_unit_test .................   Passed    0.02 sec
      Start  7: sysInfoPackages_unit_test
 7/68 Test  #7: sysInfoPackages_unit_test .........   Passed    0.02 sec
      Start  8: sysInfoPort_unit_test
 8/68 Test  #8: sysInfoPort_unit_test .............   Passed    0.02 sec
      Start  9: dbsync_unit_test
 9/68 Test  #9: dbsync_unit_test ..................   Passed    0.37 sec
      Start 10: dbsyncPipelineFactory_unit_test
10/68 Test #10: dbsyncPipelineFactory_unit_test ...   Passed    0.08 sec
      Start 11: dbengine_unit_test
11/68 Test #11: dbengine_unit_test ................   Passed    0.02 sec
      Start 12: fim_integration_test
12/68 Test #12: fim_integration_test ..............   Passed    0.53 sec
      Start 13: encodingHelperTests
13/68 Test #13: encodingHelperTests ...............   Passed    0.02 sec
      Start 14: Filesystem
14/68 Test #14: Filesystem ........................   Passed    0.02 sec
      Start 15: FileIO
15/68 Test #15: FileIO ............................   Passed    0.02 sec
      Start 16: globHelperTests
16/68 Test #16: globHelperTests ...................   Passed    0.02 sec
      Start 17: hashHelperTests
17/68 Test #17: hashHelperTests ...................   Passed    0.05 sec
      Start 18: jsonHelperTests
18/68 Test #18: jsonHelperTests ...................   Passed    0.02 sec
      Start 19: LoggerTest
19/68 Test #19: LoggerTest ........................   Passed    0.02 sec
      Start 20: mapWrapperTests
20/68 Test #20: mapWrapperTests ...................   Passed    0.02 sec
      Start 21: networkHelperTests
21/68 Test #21: networkHelperTests ................   Passed    0.05 sec
      Start 22: PalTimeTest
22/68 Test #22: PalTimeTest .......................   Passed    0.02 sec
      Start 23: pipelineHelperTests
23/68 Test #23: pipelineHelperTests ...............   Passed    0.02 sec
      Start 24: registryHelperTests
24/68 Test #24: registryHelperTests ...............   Passed    0.02 sec
      Start 25: sqliteWrapperTests
25/68 Test #25: sqliteWrapperTests ................   Passed    0.11 sec
      Start 26: stringHelperTests
26/68 Test #26: stringHelperTests .................   Passed    0.03 sec
      Start 27: threadDispatcherTests
27/68 Test #27: threadDispatcherTests .............   Passed    0.03 sec
      Start 28: timeHelperTests
28/68 Test #28: timeHelperTests ...................   Passed    0.02 sec
      Start 29: windowsHelperTests
29/68 Test #29: windowsHelperTests ................   Passed    0.02 sec
      Start 30: InventoryImpTest
30/68 Test #30: InventoryImpTest ..................   Passed   28.25 sec
      Start 31: InvNormalizerTest
31/68 Test #31: InvNormalizerTest .................   Passed    0.07 sec
      Start 32: StatelessEventUnitTest
32/68 Test #32: StatelessEventUnitTest ............   Passed    0.02 sec
      Start 33: LogcollectorUnitTests
33/68 Test #33: LogcollectorUnitTests .............   Passed    0.03 sec
      Start 34: SCATest
34/68 Test #34: SCATest ...........................   Passed    0.03 sec
      Start 35: SCAPolicyLoaderTest
35/68 Test #35: SCAPolicyLoaderTest ...............   Passed    0.03 sec
      Start 36: SCAEventHandlerTest
36/68 Test #36: SCAEventHandlerTest ...............   Passed    0.03 sec
      Start 37: SCAUtilsTest
37/68 Test #37: SCAUtilsTest ......................   Passed    0.02 sec
      Start 38: CheckConditionEvaluatorTest
38/68 Test #38: CheckConditionEvaluatorTest .......   Passed    0.03 sec
      Start 39: RuleCreationTest
39/68 Test #39: RuleCreationTest ..................   Passed    0.03 sec
      Start 40: FileRuleEvaluatorTest
40/68 Test #40: FileRuleEvaluatorTest .............   Passed    0.03 sec
      Start 41: CommandRuleEvaluatorTest
41/68 Test #41: CommandRuleEvaluatorTest ..........   Passed    0.03 sec
      Start 42: DirectoryRuleEvaluatorTest
42/68 Test #42: DirectoryRuleEvaluatorTest ........   Passed    0.04 sec
      Start 43: ProcessRuleEvaluatorTest
43/68 Test #43: ProcessRuleEvaluatorTest ..........   Passed    0.03 sec
      Start 44: SCAPolicyParserTest
44/68 Test #44: SCAPolicyParserTest ...............   Passed    0.03 sec
      Start 45: RegistryRuleEvaluatorTest
45/68 Test #45: RegistryRuleEvaluatorTest .........   Passed    0.05 sec
      Start 46: ModuleManagerTest
46/68 Test #46: ModuleManagerTest .................   Passed    0.08 sec
      Start 47: AgentInfoTest
47/68 Test #47: AgentInfoTest .....................   Passed    0.04 sec
      Start 48: AgentInfoPersistenceTest
48/68 Test #48: AgentInfoPersistenceTest ..........   Passed    0.03 sec
      Start 49: CentralizedConfiguration
49/68 Test #49: CentralizedConfiguration ..........   Passed    0.03 sec
      Start 50: CommandHandlerTest
50/68 Test #50: CommandHandlerTest ................   Passed    2.05 sec
      Start 51: CommandStoreTest
51/68 Test #51: CommandStoreTest ..................   Passed    0.02 sec
      Start 52: CommunicatorTest
52/68 Test #52: CommunicatorTest ..................   Passed    8.07 sec
      Start 53: ConfigParserTest
53/68 Test #53: ConfigParserTest ..................   Passed    0.04 sec
      Start 54: ConfigParserUtilsTest
54/68 Test #54: ConfigParserUtilsTest .............   Passed    0.02 sec
      Start 55: HttpClientTest
55/68 Test #55: HttpClientTest ....................   Passed    0.03 sec
      Start 56: HttpSocketTest
56/68 Test #56: HttpSocketTest ....................   Passed    0.08 sec
      Start 57: HttpsSocketTest
57/68 Test #57: HttpsSocketTest ...................   Passed    0.04 sec
      Start 58: HttpsVerifierTest
58/68 Test #58: HttpsVerifierTest .................   Passed    0.03 sec
      Start 59: InstanceCommunicatorTest
59/68 Test #59: InstanceCommunicatorTest ..........   Passed    7.09 sec
      Start 60: MultiTypeQueueTest
60/68 Test #60: MultiTypeQueueTest ................   Passed    0.03 sec
      Start 61: StorageTest
61/68 Test #61: StorageTest .......................   Passed    0.02 sec
      Start 62: SQLiteManager_test
62/68 Test #62: SQLiteManager_test ................   Passed    0.16 sec
      Start 63: TaskManagerTest
63/68 Test #63: TaskManagerTest ...................   Passed    0.02 sec
      Start 64: AgentTest
64/68 Test #64: AgentTest .........................   Passed    0.04 sec
      Start 65: AgentEnrollmentTest
65/68 Test #65: AgentEnrollmentTest ...............   Passed    0.03 sec
      Start 66: SignalHandlerTest
66/68 Test #66: SignalHandlerTest .................   Passed    0.02 sec
      Start 67: MessageQueueUtilsTest
67/68 Test #67: MessageQueueUtilsTest .............   Passed    0.02 sec
      Start 68: WindowsServiceTest
68/68 Test #68: WindowsServiceTest ................   Passed    0.03 sec

100% tests passed, 0 tests failed out of 68
```

### Artifacts Affected

All

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

Directory and registry tests.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
