### PR TITLE
Adds case insensitive name comparison for keys and values

### DIFF
--- a/src/common/cmdHelper/src/cmdHelper.cpp
+++ b/src/common/cmdHelper/src/cmdHelper.cpp
@@ -70,8 +70,18 @@ namespace Utils
                 ++i;
                 if (i < len)
                 {
+                    if (!quoting && command[i] != '\\' && command[i] != '"')
+                    {
+                        // Outside quotes, preserve the backslash and the character
+                        accum += '\\';
+                    }
                     accum += command[i];
                     ++i;
+                }
+                else
+                {
+                    // Trailing backslash
+                    accum += '\\';
                 }
             }
             else

--- a/src/common/cmdHelper/tests/cmdHelper_test.cpp
+++ b/src/common/cmdHelper/tests/cmdHelper_test.cpp
@@ -92,11 +92,23 @@ TEST_F(CmdUtilsTest, QuotedArgument)
 
 TEST_F(CmdUtilsTest, EscapedCharacters)
 {
-    const auto result = Utils::TokenizeCommand(R"(echo \"escaped\" \\slash)");
+    const auto result = Utils::TokenizeCommand(R"(echo "escaped test" \\slash)");
+
     ASSERT_EQ(result.size(), 3);
     EXPECT_EQ(result[0], "echo");
-    EXPECT_EQ(result[1], "\"escaped\"");
+    EXPECT_EQ(result[1], "escaped test");
     EXPECT_EQ(result[2], "\\slash");
+}
+
+TEST_F(CmdUtilsTest, SingleQuote)
+{
+    const auto result = Utils::TokenizeCommand(R"(echo \" >> myFile.txt)");
+
+    ASSERT_EQ(result.size(), 4);
+    EXPECT_EQ(result[0], "echo");
+    EXPECT_EQ(result[1], "\"");
+    EXPECT_EQ(result[2], ">>");
+    EXPECT_EQ(result[3], "myFile.txt");
 }
 
 TEST_F(CmdUtilsTest, UnclosedQuoteIsHandled)
@@ -131,6 +143,17 @@ TEST_F(CmdUtilsTest, EscapedSpaceWithinQuotes)
     ASSERT_EQ(result.size(), 2);
     EXPECT_EQ(result[0], "echo");
     EXPECT_EQ(result[1], "hello world");
+}
+
+TEST_F(CmdUtilsTest, WindowsRegistryTest)
+{
+    const auto result =
+        Utils::TokenizeCommand(R"(regquery HKLM\Software\Microsoft\Windows\CurrentVersion /v ProductName)");
+    ASSERT_EQ(result.size(), 4);
+    EXPECT_EQ(result[0], "regquery");
+    EXPECT_EQ(result[1], "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion");
+    EXPECT_EQ(result[2], "/v");
+    EXPECT_EQ(result[3], "ProductName");
 }
 
 // NOLINTEND(bugprone-unchecked-optional-access)

--- a/src/common/registryHelper/src/registryHelper.cpp
+++ b/src/common/registryHelper/src/registryHelper.cpp
@@ -321,6 +321,34 @@ namespace Utils
         return ret;
     }
 
+    std::string HandleRegMultiSZ(const BYTE* data, DWORD size)
+    {
+        if (size == 0)
+        {
+            return "";
+        }
+
+        std::string result;
+        const char* current = reinterpret_cast<const char*>(data);
+        const char* end = reinterpret_cast<const char*>(data + size);
+
+        while (current < end && *current != '\0')
+        {
+            size_t remaining = end - current;
+            size_t len = strnlen(current, remaining);
+
+            result.append(current, len);
+            current += len + 1;
+
+            if (current < end && *current != '\0')
+            {
+                result += ' ';
+            }
+        }
+
+        return result;
+    }
+
     std::string Registry::getValue(const std::string& valueName) const
     {
         DWORD type = 0;
@@ -355,6 +383,10 @@ namespace Utils
                 ULONGLONG qwValue;
                 std::memcpy(&qwValue, spBuff.get(), sizeof(ULONGLONG));
                 return std::to_string(qwValue);
+            }
+            case REG_MULTI_SZ:
+            {
+                return HandleRegMultiSZ(spBuff.get(), size);
             }
             default: throw std::runtime_error("Unsupported registry value type for: " + valueName);
         }

--- a/src/modules/sca/src/check_condition_evaluator.hpp
+++ b/src/modules/sca/src/check_condition_evaluator.hpp
@@ -29,5 +29,5 @@ private:
     int m_totalRules {0};
     int m_passedRules {0};
     std::optional<bool> m_result;
-    std::optional<bool> m_hasInvalid;
+    bool m_hasInvalid = false;
 };

--- a/src/modules/sca/src/sca_policy_check_win.cpp
+++ b/src/modules/sca/src/sca_policy_check_win.cpp
@@ -44,8 +44,9 @@ namespace
             }
             return false;
         }
-        catch (...)
+        catch (const std::exception& e)
         {
+            LogDebug("RegistryRuleEvaluator::IsValidKey: Exception: {}", e.what());
             return false;
         }
     };
@@ -150,7 +151,7 @@ RuleResult RegistryRuleEvaluator::CheckKeyForContents()
 {
     const auto pattern = *m_ctx.pattern; // NOLINT(bugprone-unchecked-optional-access)
 
-    LogDebug("Processing registry rule: {} -> {}", m_ctx.rule, pattern);
+    LogDebug("Processing registry rule:{} {} -> {}", m_ctx.isNegated ? "NOT " : "", m_ctx.rule, pattern);
 
     // First check that the key exists
     try
@@ -224,17 +225,17 @@ RuleResult RegistryRuleEvaluator::CheckKeyExistence()
 {
     auto result = RuleResult::NotFound;
 
-    LogDebug("Checking existence of key: '{}'", m_ctx.rule);
+    LogDebug("Processing registry rule:{} {}", m_ctx.isNegated ? "NOT " : "", m_ctx.rule);
 
     try
     {
         if (!m_isValidKey(m_ctx.rule))
         {
-            LogDebug("Key '{}' does not exist", m_ctx.rule);
+            LogDebug("Key does not exist. Rule {}", m_ctx.isNegated ? "passed" : "failed");
         }
         else
         {
-            LogDebug("Key '{}' exists", m_ctx.rule);
+            LogDebug("Key exists.  Rule {}", m_ctx.isNegated ? "failed" : "passed");
             result = RuleResult::Found;
         }
     }

--- a/src/modules/sca/src/sca_policy_check_win.cpp
+++ b/src/modules/sca/src/sca_policy_check_win.cpp
@@ -94,6 +94,17 @@ namespace
         }
     };
 
+    bool CaseInsensitiveEqual(const std::string& a, const std::string& b)
+    {
+        return a.size() == b.size() && std::equal(a.begin(),
+                                                  a.end(),
+                                                  b.begin(),
+                                                  [](char a, char b) {
+                                                      return std::tolower(static_cast<unsigned char>(a)) ==
+                                                             std::tolower(static_cast<unsigned char>(b));
+                                                  });
+    }
+
     RuleResult CheckMatch(const std::string& candidate, const std::string& pattern, bool isRegex)
     {
         if (isRegex)
@@ -104,7 +115,7 @@ namespace
                 return RuleResult::Found;
             }
         }
-        else if (candidate == pattern)
+        else if (CaseInsensitiveEqual(candidate, pattern))
         {
             return RuleResult::Found;
         }
@@ -137,7 +148,9 @@ RuleResult RegistryRuleEvaluator::Evaluate()
 
 RuleResult RegistryRuleEvaluator::CheckKeyForContents()
 {
-    LogDebug("Processing registry rule: {}", m_ctx.rule);
+    const auto pattern = *m_ctx.pattern; // NOLINT(bugprone-unchecked-optional-access)
+
+    LogDebug("Processing registry rule: {} -> {}", m_ctx.rule, pattern);
 
     // First check that the key exists
     try
@@ -155,8 +168,6 @@ RuleResult RegistryRuleEvaluator::CheckKeyForContents()
     }
 
     auto result = RuleResult::NotFound;
-
-    const auto pattern = *m_ctx.pattern; // NOLINT(bugprone-unchecked-optional-access)
 
     if (const auto content = sca::GetPattern(pattern))
     {
@@ -183,6 +194,7 @@ RuleResult RegistryRuleEvaluator::CheckKeyForContents()
             if (CheckMatch(key, pattern, isRegex) == RuleResult::Found)
             {
                 result = RuleResult::Found;
+                LogDebug("Key '{}' exists", pattern);
                 break;
             }
         }
@@ -194,6 +206,7 @@ RuleResult RegistryRuleEvaluator::CheckKeyForContents()
                 if (CheckMatch(value, pattern, isRegex) == RuleResult::Found)
                 {
                     result = RuleResult::Found;
+                    LogDebug("Value '{}' exists", pattern);
                     break;
                 }
             }

--- a/src/modules/sca/tests/check_condition_evaluator_test.cpp
+++ b/src/modules/sca/tests/check_condition_evaluator_test.cpp
@@ -11,28 +11,30 @@ TEST(CheckConditionEvaluatorTest, AllConditionBehavior)
 {
     auto evaluator = CheckConditionEvaluator::FromString("all");
 
-    // No rules added yet: should have failed.
-    EXPECT_EQ(evaluator.Result(), sca::CheckResult::Failed);
+    // No rules added yet: should be NotApplicable.
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 
     evaluator.AddResult(RuleResult::Found);
     evaluator.AddResult(RuleResult::Found);
     evaluator.AddResult(RuleResult::Found);
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
 
-    // Adding a failing rule
-    auto evaluator2 = CheckConditionEvaluator::FromString("all");
-    evaluator2.AddResult(RuleResult::Found);
-    evaluator2.AddResult(RuleResult::NotFound);
-    evaluator2.AddResult(RuleResult::Found);
-    EXPECT_EQ(evaluator2.Result(), sca::CheckResult::Failed);
+    evaluator.AddResult(RuleResult::Invalid);
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
+
+    evaluator.AddResult(RuleResult::NotFound);
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::Failed);
+
+    evaluator.AddResult(RuleResult::Invalid);
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::Failed);
 }
 
 TEST(CheckConditionEvaluatorTest, AnyConditionBehavior)
 {
     auto evaluator = CheckConditionEvaluator::FromString("any");
 
-    // No rules added yet: should have failed.
-    EXPECT_EQ(evaluator.Result(), sca::CheckResult::Failed);
+    // No rules added yet: should be NotApplicable.
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 
     evaluator.AddResult(RuleResult::NotFound);
     evaluator.AddResult(RuleResult::NotFound);
@@ -49,14 +51,20 @@ TEST(CheckConditionEvaluatorTest, NoneConditionBehavior)
 {
     auto evaluator = CheckConditionEvaluator::FromString("none");
 
-    // No rules added yet: should have passed.
-    EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
+    // No rules added yet: should be NotApplicable.
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 
     evaluator.AddResult(RuleResult::NotFound);
     evaluator.AddResult(RuleResult::NotFound);
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
+
+    evaluator.AddResult(RuleResult::Invalid);
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 
     evaluator.AddResult(RuleResult::Found); // At least one passed -> should now be false.
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::Failed);
+
+    evaluator.AddResult(RuleResult::Invalid);
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Failed);
 }
 
@@ -79,7 +87,7 @@ TEST(CheckConditionEvaluatorTest, AddResultStopsAfterResultDetermined)
     EXPECT_EQ(evaluator2.Result(), sca::CheckResult::Failed);
 }
 
-TEST(CheckConditionEvaluatorTest, AllConditionWithInvalidMakesResultFalse)
+TEST(CheckConditionEvaluatorTest, AllConditionWithInvalidMakesResultNotApplicable)
 {
     auto evaluator = CheckConditionEvaluator::FromString("all");
 
@@ -90,7 +98,7 @@ TEST(CheckConditionEvaluatorTest, AllConditionWithInvalidMakesResultFalse)
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 }
 
-TEST(CheckConditionEvaluatorTest, NoneConditionWithInvalidMakesResultFalse)
+TEST(CheckConditionEvaluatorTest, NoneConditionWithInvalidMakesResultNotApplicable)
 {
     auto evaluator = CheckConditionEvaluator::FromString("none");
 
@@ -111,5 +119,8 @@ TEST(CheckConditionEvaluatorTest, AnyConditionWithInvalidCanBeTrueAsLongAsOnePas
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 
     evaluator.AddResult(RuleResult::Found);
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
+
+    evaluator.AddResult(RuleResult::Invalid);
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
 }

--- a/src/modules/sca/tests/registry_rule_evaluator_test.cpp
+++ b/src/modules/sca/tests/registry_rule_evaluator_test.cpp
@@ -169,6 +169,25 @@ TEST_F(RegistryRuleEvaluatorTest, PatternArrowValueFoundReturnsFound)
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
 }
 
+TEST_F(RegistryRuleEvaluatorTest, PatternArrowValueFoundReturnsFoundCaseInsensitive)
+{
+    m_ctx.pattern = std::string("expectedKey -> expectedValue");
+    m_ctx.rule = "HKEY_CURRENT_USER\\MyApp";
+
+    m_enumValues = [](const std::string&)
+    {
+        return std::vector<std::string> {"SomethingElse", "ExpectedKey"};
+    };
+
+    m_getValue = [](const std::string&, const std::string&) -> std::string
+    {
+        return "ExpectedValue";
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
+}
+
 TEST_F(RegistryRuleEvaluatorTest, PatternArrowValueNotFoundReturnsNotFound)
 {
     m_ctx.pattern = std::string("ExpectedKey -> MissingValue");

--- a/src/modules/sca/tests/sca_utils_test.cpp
+++ b/src/modules/sca/tests/sca_utils_test.cpp
@@ -262,4 +262,13 @@ TEST(PatternMatchesTest, MatcherIsCaseInsensitive)
     EXPECT_TRUE(*patternMatch);
 }
 
+TEST(PatternMatchesTest, REG_MULTI_SZtest)
+{
+    const std::string content = "some\\string another\\string third\\string yet\\another\\one";
+    const std::string pattern = "r:third\\\\string";
+    const auto patternMatch = PatternMatches(content, pattern);
+    ASSERT_TRUE(patternMatch.has_value());
+    EXPECT_TRUE(*patternMatch);
+}
+
 // NOLINTEND(bugprone-unchecked-optional-access, modernize-raw-string-literal)


### PR DESCRIPTION
## Description

This PR prevents some rules from failing because of case inconsistency in the names of registry keys and values.
<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes
Adds a function to check for case insensitive equality of two strings.
Also moves / adds some logs for debugging purposes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

`forceguest` value is lowercase in the Windows Registry of a fresh installed OS

![image](https://github.com/user-attachments/assets/6bcfadef-4841-45ed-8f9e-1c0061152693)

Checks for `ForceGuest` do not fail

![image](https://github.com/user-attachments/assets/8c892c8f-bddb-453d-8850-1b8864e9a7d9)

Checks for REG_MULTI_SZ values

![image](https://github.com/user-attachments/assets/75dffd40-c482-4656-b939-b8f7a1ce522d)

Tests pass
```
PS C:\wazuh-agent\build> ctest -R RegistryRuleEvaluatorTest -C RelWithDebInfo  --verbose --output-on-failure
UpdateCTestConfiguration  from :C:/wazuh-agent/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :C:/wazuh-agent/build/DartConfiguration.tcl
Test project C:/wazuh-agent/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 45
    Start 45: RegistryRuleEvaluatorTest

45: Test command: C:\wazuh-agent\build\modules\sca\tests\RelWithDebInfo\registry_rule_evaluator_test.exe
45: Working Directory: C:/wazuh-agent/build/modules/sca/tests
45: Test timeout computed to be: 10000000
45: Running main() from C:\vcpkg\buildtrees\gtest\src\v1.15.2-41f5afb119.clean\googletest\src\gtest_main.cc
45: [==========] Running 10 tests from 1 test suite.
45: [----------] Global test environment set-up.
45: [----------] 10 tests from RegistryRuleEvaluatorTest
45: [ RUN      ] RegistryRuleEvaluatorTest.NoPatternValidKeyReturnsFound
45: [       OK ] RegistryRuleEvaluatorTest.NoPatternValidKeyReturnsFound (0 ms)
45: [ RUN      ] RegistryRuleEvaluatorTest.NoPatternInvalidKeyReturnsNotFound
45: [       OK ] RegistryRuleEvaluatorTest.NoPatternInvalidKeyReturnsNotFound (0 ms)
45: [ RUN      ] RegistryRuleEvaluatorTest.PatternKeyFoundReturnsFound
45: [       OK ] RegistryRuleEvaluatorTest.PatternKeyFoundReturnsFound (0 ms)
45: [ RUN      ] RegistryRuleEvaluatorTest.PatternKeyNotFoundReturnsNotFound
45: [       OK ] RegistryRuleEvaluatorTest.PatternKeyNotFoundReturnsNotFound (0 ms)
45: [ RUN      ] RegistryRuleEvaluatorTest.PatternRegexKeyFoundReturnsFound
45: [       OK ] RegistryRuleEvaluatorTest.PatternRegexKeyFoundReturnsFound (1 ms)
45: [ RUN      ] RegistryRuleEvaluatorTest.PatternRegexKeyNotFoundReturnsNotFound
45: [       OK ] RegistryRuleEvaluatorTest.PatternRegexKeyNotFoundReturnsNotFound (0 ms)
45: [ RUN      ] RegistryRuleEvaluatorTest.PatternArrowValueFoundReturnsFound
45: [       OK ] RegistryRuleEvaluatorTest.PatternArrowValueFoundReturnsFound (0 ms)
45: [ RUN      ] RegistryRuleEvaluatorTest.PatternArrowValueNotFoundReturnsNotFound
45: [       OK ] RegistryRuleEvaluatorTest.PatternArrowValueNotFoundReturnsNotFound (0 ms)
45: [ RUN      ] RegistryRuleEvaluatorTest.PatternArrowRegexValueFoundReturnsFound
45: [       OK ] RegistryRuleEvaluatorTest.PatternArrowRegexValueFoundReturnsFound (0 ms)
45: [ RUN      ] RegistryRuleEvaluatorTest.PatternArrowRegexValueNotFoundReturnsNotFound
45: [       OK ] RegistryRuleEvaluatorTest.PatternArrowRegexValueNotFoundReturnsNotFound (0 ms)
45: [----------] 10 tests from RegistryRuleEvaluatorTest (1 ms total)
45:
45: [----------] Global test environment tear-down
45: [==========] 10 tests from 1 test suite ran. (2 ms total)
45: [  PASSED  ] 10 tests.
1/1 Test #45: RegistryRuleEvaluatorTest ........   Passed    0.09 sec

The following tests passed:
        RegistryRuleEvaluatorTest

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.15 sec
```
<!--
Provide evidence of the changes made, such as:
- Logs
- Screenshots
- Before/after comparisons
-->

### Artifacts Affected
Windows executable
<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes
None
<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Documentation Updates
None
<!--
If applicable, list the sections of documentation that have been updated as part of this pull request.
-->

### Tests Introduced
None
<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
