### PR TITLE
Add support to not applicable results in sca scans

### DIFF
--- a/src/common/cmdHelper/include/cmdHelper.hpp
+++ b/src/common/cmdHelper/include/cmdHelper.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -29,7 +30,7 @@ namespace Utils
     /// The function waits for the process to finish before returning.
     ///
     /// @param cmd The command to execute (no shell features like piping or expansions).
-    /// @return A ExecResult containing the command's StdOut, StdErr, and ExitCode.
+    /// @return An optional ExecResult containing the command's StdOut, StdErr, and ExitCode.
     /// @throw boost::process::process_error if the command fails to start.
-    ExecResult Exec(const std::string& cmd);
+    std::optional<ExecResult> Exec(const std::string& cmd);
 } // namespace Utils

--- a/src/common/cmdHelper/src/cmdHelper.cpp
+++ b/src/common/cmdHelper/src/cmdHelper.cpp
@@ -110,7 +110,7 @@ namespace Utils
         return result;
     }
 
-    ExecResult Exec(const std::string& cmd)
+    std::optional<ExecResult> Exec(const std::string& cmd)
     {
         try
         {
@@ -136,11 +136,20 @@ namespace Utils
             const auto error = GetStreamOutput(stdErrPipe);
             process.wait();
 
-            return {.StdOut = output, .StdErr = error, .ExitCode = process.exit_code()};
+            ExecResult result;
+            result.StdOut = output;
+            result.StdErr = error;
+            result.ExitCode = process.exit_code();
+            return std::make_optional(result);
         }
         catch (const std::exception& e)
         {
-            return {.StdOut = "", .StdErr = e.what(), .ExitCode = 1};
+            LogDebug("Error executing command: {}", e.what());
+            return std::nullopt;
+        }
+        catch (...)
+        {
+            return std::nullopt;
         }
     }
 } // namespace Utils

--- a/src/common/cmdHelper/src/cmdHelper.cpp
+++ b/src/common/cmdHelper/src/cmdHelper.cpp
@@ -142,7 +142,5 @@ namespace Utils
         {
             return {.StdOut = "", .StdErr = e.what(), .ExitCode = 1};
         }
-
-        return {.StdOut = "", .StdErr = "", .ExitCode = 1};
     }
 } // namespace Utils

--- a/src/common/cmdHelper/tests/cmdHelper_test.cpp
+++ b/src/common/cmdHelper/tests/cmdHelper_test.cpp
@@ -13,6 +13,8 @@ const std::string TEST_CMD_QUOTES = "bash -c \" echo 'Hello world'\"";
 const std::string TEST_CMD_QUOTES_EXPECTED_RESULT = "Hello world\n";
 #endif
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 TEST_F(CmdUtilsTest, PipeOpenCmd)
 {
     const auto result {Utils::PipeOpen(TEST_CMD)};
@@ -22,17 +24,15 @@ TEST_F(CmdUtilsTest, PipeOpenCmd)
 TEST_F(CmdUtilsTest, ExecCmd)
 {
     const auto result {Utils::Exec(TEST_CMD)};
-    EXPECT_FALSE(result.StdOut.empty());
-    EXPECT_TRUE(result.StdErr.empty());
-    EXPECT_EQ(result.ExitCode, 0);
+    EXPECT_FALSE(result->StdOut.empty());
+    EXPECT_TRUE(result->StdErr.empty());
+    EXPECT_EQ(result->ExitCode, 0);
 }
 
 TEST_F(CmdUtilsTest, ExecInvalidCmd)
 {
     const auto result {Utils::Exec("invalid_command")};
-    EXPECT_TRUE(result.StdOut.empty());
-    EXPECT_FALSE(result.StdErr.empty());
-    EXPECT_NE(result.ExitCode, 0);
+    EXPECT_FALSE(result.has_value());
 }
 
 TEST_F(CmdUtilsTest, PipeOpenInvalidCmd)
@@ -44,9 +44,7 @@ TEST_F(CmdUtilsTest, PipeOpenInvalidCmd)
 TEST_F(CmdUtilsTest, ExecEmptyCmd)
 {
     const auto result {Utils::Exec("")};
-    EXPECT_TRUE(result.StdOut.empty());
-    EXPECT_FALSE(result.StdErr.empty());
-    EXPECT_NE(result.ExitCode, 0);
+    EXPECT_FALSE(result.has_value());
 }
 
 TEST_F(CmdUtilsTest, PipeOpenEmptyCmd)
@@ -58,9 +56,9 @@ TEST_F(CmdUtilsTest, PipeOpenEmptyCmd)
 TEST_F(CmdUtilsTest, ExecNestedQuotes)
 {
     const auto result = Utils::Exec(TEST_CMD_QUOTES);
-    EXPECT_EQ(result.StdOut, TEST_CMD_QUOTES_EXPECTED_RESULT);
-    EXPECT_TRUE(result.StdErr.empty());
-    EXPECT_EQ(result.ExitCode, 0);
+    EXPECT_EQ(result->StdOut, TEST_CMD_QUOTES_EXPECTED_RESULT);
+    EXPECT_TRUE(result->StdErr.empty());
+    EXPECT_EQ(result->ExitCode, 0);
 }
 
 TEST_F(CmdUtilsTest, ThrowsOnEmptyString)
@@ -94,7 +92,7 @@ TEST_F(CmdUtilsTest, QuotedArgument)
 
 TEST_F(CmdUtilsTest, EscapedCharacters)
 {
-    const auto result = Utils::TokenizeCommand("echo \\\"escaped\\\" \\\\slash");
+    const auto result = Utils::TokenizeCommand(R"(echo \"escaped\" \\slash)");
     ASSERT_EQ(result.size(), 3);
     EXPECT_EQ(result[0], "echo");
     EXPECT_EQ(result[1], "\"escaped\"");
@@ -120,7 +118,7 @@ TEST_F(CmdUtilsTest, HandlesExtraSpaces)
 
 TEST_F(CmdUtilsTest, NestedEscapedQuotes)
 {
-    const auto result = Utils::TokenizeCommand("bash -c \"echo 'Hello \\\"nested\\\" world'\"");
+    const auto result = Utils::TokenizeCommand(R"(bash -c "echo 'Hello \"nested\" world'")");
     ASSERT_EQ(result.size(), 3);
     EXPECT_EQ(result[0], "bash");
     EXPECT_EQ(result[1], "-c");
@@ -129,8 +127,10 @@ TEST_F(CmdUtilsTest, NestedEscapedQuotes)
 
 TEST_F(CmdUtilsTest, EscapedSpaceWithinQuotes)
 {
-    const auto result = Utils::TokenizeCommand("echo \"hello\\ world\"");
+    const auto result = Utils::TokenizeCommand(R"(echo "hello\ world")");
     ASSERT_EQ(result.size(), 2);
     EXPECT_EQ(result[0], "echo");
     EXPECT_EQ(result[1], "hello world");
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/src/modules/sca/src/check_condition_evaluator.hpp
+++ b/src/modules/sca/src/check_condition_evaluator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sca_policy_check.hpp>
+#include <sca_utils.hpp>
 
 #include <optional>
 #include <string>
@@ -21,11 +22,12 @@ public:
 
     void AddResult(RuleResult result);
 
-    bool Result() const;
+    sca::CheckResult Result() const;
 
 private:
     ConditionType m_type;
     int m_totalRules {0};
     int m_passedRules {0};
     std::optional<bool> m_result;
+    std::optional<bool> m_hasInvalid;
 };

--- a/src/modules/sca/src/sca_policy.cpp
+++ b/src/modules/sca/src/sca_policy.cpp
@@ -90,11 +90,12 @@ void SCAPolicy::Scan(
 
             const auto result = resultEvaluator.Result();
 
-            LogDebug("Policy check evaluation completed for policy \"{}\", result: {}.",
+            // NOLINTBEGIN(bugprone-unchecked-optional-access)
+            LogDebug("Policy check \"{}\" evaluation completed for policy \"{}\", result: {}.",
+                     check.id.value(),
                      m_id,
                      sca::CheckResultToString(result));
 
-            // NOLINTBEGIN(bugprone-unchecked-optional-access)
             reportCheckResult(m_id, check.id.value(), sca::CheckResultToString(result));
             // NOLINTEND(bugprone-unchecked-optional-access)
         }

--- a/src/modules/sca/src/sca_policy.cpp
+++ b/src/modules/sca/src/sca_policy.cpp
@@ -47,7 +47,7 @@ SCAPolicy::Run(std::time_t scanInterval,
 void SCAPolicy::Scan(
     const std::function<void(const std::string&, const std::string&, const std::string&)>& reportCheckResult)
 {
-    auto requirementsOk = true;
+    auto requirementsOk = sca::CheckResult::Passed;
 
     if (!m_requirements.rules.empty())
     {
@@ -68,10 +68,10 @@ void SCAPolicy::Scan(
 
         LogDebug("Policy requirements evaluation completed for policy \"{}\", result: {}.",
                  m_id,
-                 requirementsOk ? "passed" : "failed");
+                 sca::CheckResultToString(requirementsOk));
     }
 
-    if (requirementsOk)
+    if (requirementsOk == sca::CheckResult::Passed)
     {
         LogDebug("Starting Policy checks evaluation for policy \"{}\".", m_id);
 
@@ -90,14 +90,12 @@ void SCAPolicy::Scan(
 
             const auto result = resultEvaluator.Result();
 
-            LogDebug(
-                "Policy check evaluation completed for policy \"{}\", result: {}.", m_id, result ? "passed" : "failed");
+            LogDebug("Policy check evaluation completed for policy \"{}\", result: {}.",
+                     m_id,
+                     sca::CheckResultToString(result));
 
             // NOLINTBEGIN(bugprone-unchecked-optional-access)
-            reportCheckResult(m_id,
-                              check.id.value(),
-                              result ? sca::CheckResultToString(sca::CheckResult::Passed)
-                                     : sca::CheckResultToString(sca::CheckResult::Failed));
+            reportCheckResult(m_id, check.id.value(), sca::CheckResultToString(result));
             // NOLINTEND(bugprone-unchecked-optional-access)
         }
 

--- a/src/modules/sca/src/sca_policy_check.cpp
+++ b/src/modules/sca/src/sca_policy_check.cpp
@@ -141,7 +141,8 @@ RuleResult FileRuleEvaluator::CheckFileExistence()
     }
     else
     {
-        result = RuleResult::Invalid;
+        LogDebug("An error occured and file rule '{}' could not be resolved", m_ctx.rule);
+        return RuleResult::Invalid;
     }
 
     return m_ctx.isNegated ? (result == RuleResult::Found ? RuleResult::NotFound : RuleResult::Found) : result;
@@ -385,7 +386,8 @@ RuleResult DirRuleEvaluator::CheckDirectoryExistence()
     }
     else
     {
-        result = RuleResult::Invalid;
+        LogDebug("An error occured and file rule '{}' could not be resolved", m_ctx.rule);
+        return RuleResult::Invalid;
     }
 
     return m_ctx.isNegated ? (result == RuleResult::Found ? RuleResult::NotFound : RuleResult::Found) : result;

--- a/src/modules/sca/src/sca_policy_check.cpp
+++ b/src/modules/sca/src/sca_policy_check.cpp
@@ -419,16 +419,23 @@ RuleResult ProcessRuleEvaluator::Evaluate()
 {
     LogDebug("Processing process rule: '{}'", m_ctx.rule);
 
-    const auto processes = m_getProcesses();
     auto result = RuleResult::NotFound;
 
-    for (const auto& process : processes)
+    if (const auto processes = TryFunc([this] { return m_getProcesses(); }))
     {
-        if (process == m_ctx.rule)
+        for (const auto& process : processes.value())
         {
-            result = RuleResult::Found;
-            break;
+            if (process == m_ctx.rule)
+            {
+                result = RuleResult::Found;
+                break;
+            }
         }
+    }
+    else
+    {
+        LogDebug("Process rule '{}' execution failed", m_ctx.rule);
+        return RuleResult::Invalid;
     }
 
     LogDebug("Process '{}' {} found", m_ctx.rule, result == RuleResult::Found ? "was" : "was not");

--- a/src/modules/sca/src/sca_policy_check.cpp
+++ b/src/modules/sca/src/sca_policy_check.cpp
@@ -212,7 +212,7 @@ RuleResult CommandRuleEvaluator::Evaluate()
 
     LogDebug("Command rule '{}' pattern '{}' {} found",
              m_ctx.rule,
-             *m_ctx.pattern,
+             m_ctx.pattern.value_or(""),
              result == RuleResult::Found ? "was" : "was not");
 
     return m_ctx.isNegated ? (result == RuleResult::Found ? RuleResult::NotFound : RuleResult::Found) : result;

--- a/src/modules/sca/src/sca_policy_check.hpp
+++ b/src/modules/sca/src/sca_policy_check.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmdHelper.hpp>
 #include <ifile_io_utils.hpp>
 #include <ifilesystem_wrapper.hpp>
 #include <sysInfoInterface.hpp>
@@ -69,7 +70,7 @@ class CommandRuleEvaluator : public RuleEvaluator
 {
 public:
     /// @brief Function that takes a command and returns the output and error as a pair of strings.
-    using CommandExecFunc = std::function<std::pair<std::string, std::string>(const std::string&)>;
+    using CommandExecFunc = std::function<std::optional<Utils::ExecResult>(const std::string&)>;
 
     CommandRuleEvaluator(PolicyEvaluationContext ctx,
                          std::unique_ptr<IFileSystemWrapper> fileSystemWrapper = nullptr,

--- a/src/modules/sca/src/sca_utils.cpp
+++ b/src/modules/sca/src/sca_utils.cpp
@@ -20,8 +20,8 @@ namespace
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         const auto patternPtr = reinterpret_cast<PCRE2_SPTR8>(pattern.c_str());
 
-        auto* re =
-            pcre2_compile(patternPtr, PCRE2_ZERO_TERMINATED, PCRE2_MULTILINE, &errorCode, &error_offset, nullptr);
+        auto* re = pcre2_compile(
+            patternPtr, PCRE2_ZERO_TERMINATED, PCRE2_MULTILINE | PCRE2_CASELESS, &errorCode, &error_offset, nullptr);
 
         if (!re)
         {

--- a/src/modules/sca/src/sca_utils.cpp
+++ b/src/modules/sca/src/sca_utils.cpp
@@ -25,7 +25,16 @@ namespace
 
         if (!re)
         {
-            throw std::runtime_error("PCRE2 compilation failed");
+            throw std::runtime_error(
+                [&errorCode, &error_offset]()
+                {
+                    std::vector<PCRE2_UCHAR> buffer(256); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+                    pcre2_get_error_message(errorCode, buffer.data(), buffer.size());
+
+                    return "PCRE2 compilation failed at offset " + std::to_string(error_offset) + ": " +
+                           // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                           reinterpret_cast<char*>(buffer.data());
+                }());
         }
 
         auto* matchData = pcre2_match_data_create_from_pattern(re, nullptr);

--- a/src/modules/sca/tests/command_rule_evaluator_test.cpp
+++ b/src/modules/sca/tests/command_rule_evaluator_test.cpp
@@ -28,7 +28,7 @@ protected:
     }
 };
 
-TEST_F(CommandRuleEvaluatorTest, EvaluationReturnsInvalidWhenNoPattern)
+TEST_F(CommandRuleEvaluatorTest, EvaluationReturnsFoundWhenCommandGivenButNoPattern)
 {
     m_ctx.rule = "some command";
     m_ctx.pattern = std::nullopt;
@@ -39,7 +39,7 @@ TEST_F(CommandRuleEvaluatorTest, EvaluationReturnsInvalidWhenNoPattern)
     };
 
     auto evaluator = CreateEvaluator();
-    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
 }
 
 TEST_F(CommandRuleEvaluatorTest, CommandReturnsEmptyStringReturnsNotFound)

--- a/src/modules/sca/tests/command_rule_evaluator_test.cpp
+++ b/src/modules/sca/tests/command_rule_evaluator_test.cpp
@@ -14,7 +14,7 @@ protected:
     PolicyEvaluationContext m_ctx;
     std::unique_ptr<MockFileSystemWrapper> m_fsMock;
     MockFileSystemWrapper* m_rawFsMock = nullptr;
-    std::function<std::pair<std::string, std::string>(const std::string&)> m_execMock;
+    std::function<std::optional<Utils::ExecResult>(const std::string&)> m_execMock;
 
     void SetUp() override
     {
@@ -35,7 +35,7 @@ TEST_F(CommandRuleEvaluatorTest, EvaluationReturnsFoundWhenCommandGivenButNoPatt
 
     m_execMock = [](const std::string&)
     {
-        return std::make_pair("", "");
+        return std::make_optional<Utils::ExecResult>();
     };
 
     auto evaluator = CreateEvaluator();
@@ -49,7 +49,7 @@ TEST_F(CommandRuleEvaluatorTest, CommandReturnsEmptyStringReturnsNotFound)
 
     m_execMock = [](const std::string&)
     {
-        return std::make_pair("", "");
+        return std::make_optional<Utils::ExecResult>();
     };
 
     auto evaluator = CreateEvaluator();
@@ -63,7 +63,8 @@ TEST_F(CommandRuleEvaluatorTest, CommandOutputMatchesLiteralPatternReturnsFound)
 
     m_execMock = [](const std::string&)
     {
-        return std::make_pair("exact match", "");
+        const Utils::ExecResult result {.StdOut = "exact match", .StdErr = "", .ExitCode = 0};
+        return std::make_optional<Utils::ExecResult>(result);
     };
 
     auto evaluator = CreateEvaluator();
@@ -77,7 +78,8 @@ TEST_F(CommandRuleEvaluatorTest, CommandOutputDoesNotMatchLiteralPatternReturnsN
 
     m_execMock = [](const std::string&)
     {
-        return std::make_pair("something else", "");
+        const Utils::ExecResult result {.StdOut = "something else", .StdErr = "", .ExitCode = 0};
+        return std::make_optional<Utils::ExecResult>(result);
     };
 
     auto evaluator = CreateEvaluator();
@@ -91,7 +93,8 @@ TEST_F(CommandRuleEvaluatorTest, RegexPatternMatchesOutputReturnsFound)
 
     m_execMock = [](const std::string&)
     {
-        return std::make_pair("success", "");
+        const Utils::ExecResult result {.StdOut = "success", .StdErr = "", .ExitCode = 0};
+        return std::make_optional<Utils::ExecResult>(result);
     };
 
     auto evaluator = CreateEvaluator();
@@ -105,7 +108,8 @@ TEST_F(CommandRuleEvaluatorTest, RegexPatternDoesNotMatchOutputReturnsNotFound)
 
     m_execMock = [](const std::string&)
     {
-        return std::make_pair("ok", "");
+        const Utils::ExecResult result {.StdOut = "ok", .StdErr = "", .ExitCode = 0};
+        return std::make_optional<Utils::ExecResult>(result);
     };
 
     auto evaluator = CreateEvaluator();
@@ -119,7 +123,7 @@ TEST_F(CommandRuleEvaluatorTest, PatternGivenButCommandOutputIsEmptyReturnsNotFo
 
     m_execMock = [](const std::string&)
     {
-        return std::make_pair("", "");
+        return std::make_optional<Utils::ExecResult>();
     };
 
     auto evaluator = CreateEvaluator();
@@ -133,7 +137,8 @@ TEST_F(CommandRuleEvaluatorTest, NumericPatternMatchesOutputReturnsFound)
 
     m_execMock = [](const std::string&)
     {
-        return std::make_pair("42", "");
+        const Utils::ExecResult result {.StdOut = "42", .StdErr = "", .ExitCode = 0};
+        return std::make_optional<Utils::ExecResult>(result);
     };
 
     auto evaluator = CreateEvaluator();
@@ -147,7 +152,8 @@ TEST_F(CommandRuleEvaluatorTest, NumericPatternWithStringMatchesOutputReturnsFou
 
     m_execMock = [](const std::string&)
     {
-        return std::make_pair("Some string:           42", "");
+        const Utils::ExecResult result {.StdOut = "Some string:           42", .StdErr = "", .ExitCode = 0};
+        return std::make_optional<Utils::ExecResult>(result);
     };
 
     auto evaluator = CreateEvaluator();

--- a/src/modules/sca/tests/command_rule_evaluator_test.cpp
+++ b/src/modules/sca/tests/command_rule_evaluator_test.cpp
@@ -159,3 +159,17 @@ TEST_F(CommandRuleEvaluatorTest, NumericPatternWithStringMatchesOutputReturnsFou
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
 }
+
+TEST_F(CommandRuleEvaluatorTest, CommandExecutionReturnsNulloptIsInvalid)
+{
+    m_ctx.rule = "some command";
+    m_ctx.pattern = std::string("something");
+
+    m_execMock = [](const std::string&) -> std::optional<Utils::ExecResult>
+    {
+        return std::nullopt;
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}

--- a/src/modules/sca/tests/directory_rule_evaluator_test.cpp
+++ b/src/modules/sca/tests/directory_rule_evaluator_test.cpp
@@ -291,3 +291,75 @@ TEST_F(DirRuleEvaluatorTest, FileFoundInSubdirectory)
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
 }
+
+TEST_F(DirRuleEvaluatorTest, ExistsThrowsReturnsInvalid)
+{
+    m_ctx.pattern = std::nullopt;
+    m_ctx.rule = "dir/";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("dir/")))
+        .WillOnce(::testing::Throw(std::runtime_error("Permission denied")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}
+
+TEST_F(DirRuleEvaluatorTest, IsDirectoryThrowsReturnsInvalid)
+{
+    m_ctx.pattern = std::nullopt;
+    m_ctx.rule = "dir/";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("dir/")))
+        .WillOnce(::testing::Throw(std::runtime_error("Filesystem error")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}
+
+TEST_F(DirRuleEvaluatorTest, ListDirectoryThrowsReturnsInvalid)
+{
+    m_ctx.pattern = std::string("match.txt");
+    m_ctx.rule = "dir/";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, list_directory(std::filesystem::path("dir/")))
+        .WillOnce(::testing::Throw(std::runtime_error("Access denied")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}
+
+TEST_F(DirRuleEvaluatorTest, SubEntryIsDirectoryThrowsReturnsInvalid)
+{
+    m_ctx.pattern = std::string("match.txt");
+    m_ctx.rule = "dir/";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, list_directory(std::filesystem::path("dir/")))
+        .WillOnce(::testing::Return(std::vector<std::filesystem::path> {"match.txt"}));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("match.txt")))
+        .WillOnce(::testing::Throw(std::runtime_error("Broken stat")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}
+
+TEST_F(DirRuleEvaluatorTest, FileContentThrowsReturnsInvalid)
+{
+    m_ctx.pattern = std::string("target.txt -> r:hello");
+    m_ctx.rule = "dir/";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, list_directory(std::filesystem::path("dir/")))
+        .WillOnce(::testing::Return(std::vector<std::filesystem::path> {"target.txt"}));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("target.txt"))).WillOnce(::testing::Return(false));
+    EXPECT_CALL(*m_rawIoMock, getFileContent("target.txt"))
+        .WillOnce(::testing::Throw(std::runtime_error("Read failure")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}

--- a/src/modules/sca/tests/directory_rule_evaluator_test.cpp
+++ b/src/modules/sca/tests/directory_rule_evaluator_test.cpp
@@ -63,6 +63,19 @@ TEST_F(DirRuleEvaluatorTest, ExistsButNotDirectoryReturnsNotFound)
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::NotFound);
 }
 
+TEST_F(DirRuleEvaluatorTest, ExceptionOnDirectoryCheckReturnsInvalid)
+{
+    m_ctx.pattern = std::nullopt;
+    m_ctx.rule = "dir/";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("dir/")))
+        .WillOnce(::testing::Throw(std::runtime_error("I/O error")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}
+
 TEST_F(DirRuleEvaluatorTest, NoPatternValidDirectoryReturnsFound)
 {
     m_ctx.pattern = std::nullopt;

--- a/src/modules/sca/tests/file_rule_evaluator_test.cpp
+++ b/src/modules/sca/tests/file_rule_evaluator_test.cpp
@@ -55,6 +55,19 @@ TEST_F(FileRuleEvaluatorTest, FileExistsReturnsFound)
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
 }
 
+TEST_F(FileRuleEvaluatorTest, FileExistanceCheckWithExceptionReturnsInvalid)
+{
+    m_ctx.pattern = std::nullopt;
+    m_ctx.rule = "some/file";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("some/file"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_regular_file(std::filesystem::path("some/file")))
+        .WillOnce(::testing::Throw(std::runtime_error("I/O error")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}
+
 TEST_F(FileRuleEvaluatorTest, PatternRegexMatchesContentReturnsFound)
 {
     m_ctx.pattern = std::string("r:foo");

--- a/src/modules/sca/tests/file_rule_evaluator_test.cpp
+++ b/src/modules/sca/tests/file_rule_evaluator_test.cpp
@@ -141,3 +141,56 @@ TEST_F(FileRuleEvaluatorTest, PatternGivenButPathIsNotRegularFileReturnsInvalid)
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
 }
+
+TEST_F(FileRuleEvaluatorTest, FileIsRegularCheckThrowsReturnsInvalid)
+{
+    m_ctx.pattern = std::nullopt;
+    m_ctx.rule = "some/file";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("some/file"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_regular_file(std::filesystem::path("some/file")))
+        .WillOnce(::testing::Throw(std::runtime_error("I/O error")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}
+
+TEST_F(FileRuleEvaluatorTest, PatternGivenButGetFileContentThrowsReturnsInvalid)
+{
+    m_ctx.pattern = std::string("r:foo");
+    m_ctx.rule = "some/file";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("some/file"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_regular_file(std::filesystem::path("some/file"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawIoMock, getFileContent("some/file"))
+        .WillOnce(::testing::Throw(std::runtime_error("Permission denied")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}
+
+TEST_F(FileRuleEvaluatorTest, PatternGivenReadLineByLineThrowsReturnsInvalid)
+{
+    m_ctx.pattern = std::string("exact");
+    m_ctx.rule = "some/file";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("some/file"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_regular_file(std::filesystem::path("some/file"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawIoMock, readLineByLine(std::filesystem::path("some/file"), ::testing::_))
+        .WillOnce(::testing::Throw(std::runtime_error("Failed to open")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}
+
+TEST_F(FileRuleEvaluatorTest, ExistsThrowsReturnsInvalid)
+{
+    m_ctx.pattern = std::nullopt;
+    m_ctx.rule = "some/file";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("some/file")))
+        .WillOnce(::testing::Throw(std::runtime_error("Access denied")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}

--- a/src/modules/sca/tests/process_rule_evaluator_test.cpp
+++ b/src/modules/sca/tests/process_rule_evaluator_test.cpp
@@ -71,3 +71,16 @@ TEST_F(ProcessRuleEvaluatorTest, EmptyProcessListReturnsNotFound)
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::NotFound);
 }
+
+TEST_F(ProcessRuleEvaluatorTest, ProcessListRetrievalFailsReturnsInvalid)
+{
+    m_ctx.rule = "anyprocess";
+
+    m_processesMock = []() -> std::vector<std::string>
+    {
+        throw std::runtime_error("Failed to read /proc");
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+}

--- a/src/modules/sca/tests/sca_utils_test.cpp
+++ b/src/modules/sca/tests/sca_utils_test.cpp
@@ -253,4 +253,13 @@ TEST(PatternMatchesTest, NotRegex_WithCompoundFailing)
     EXPECT_FALSE(*patternMatch);
 }
 
+TEST(PatternMatchesTest, MatcherIsCaseInsensitive)
+{
+    const std::string content = "windows";
+    const std::string pattern = "r:^WINDOWS";
+    const auto patternMatch = PatternMatches(content, pattern);
+    ASSERT_TRUE(patternMatch.has_value());
+    EXPECT_TRUE(*patternMatch);
+}
+
 // NOLINTEND(bugprone-unchecked-optional-access, modernize-raw-string-literal)


### PR DESCRIPTION
## Description

This PR adds support to Not Applicable results in SCA scans.

## Proposed Changes

- Utils::Exec returns an optional, to differentiate failure from the command being executed from an Agent runtime error. 
- CheckConditionEvaluators::Result returns a sca::CheckResult, which supports Not Applicable.
- Several SCA Policy evaluators were modified to return Invalid on certain cases, which may result in Not Applicable being reported.

### Results and Evidence

#### Ubuntu:

<details>

##### SCA scan on 4.x

- Passed: 99
- Failed: 138
- Not applicable: 42

##### SCA scan on 6.x

- Passed: 100
- Failed: 136
- Not applicable: 43

Only two differences:
- Check 35703: we consider it is not applicable as one condition is not met.
- Check 35722: regex to be adapted.

</details>

#### Amazon Linux

<details>

File: cis_amazon_linux_2023.yml

Only differences:

| ID     | 6.x | 4.x | Reason |
|--------|-----|-----|--------|
| 31045  | F   | P   | Contents of the file in both machines differed, on 4.x it was empty, on 6.x it had information about newer versions of Amazon Linux being available. Result of the ruls is as expected in both systems. |
| 31117  | NA  | F   |The file /etc/rsyslog.conf does not exist, result should be NA since the rule is checking for content |
| 31135  | F   | P   |--------|
| 31156  | P   | F   |Fails on 4.x because the wazuh-user sudoer file requires NOPASSWD, once the manager is uninstalled, the file disappears and passes on 6.x|

```yaml
  - id: 31045
    title: "Ensure message of the day is configured properly."
    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version."
    rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
    remediation: "Edit the /etc/motd file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , \\v or references to the OS platform OR If the motd is not used, this file can be removed. Run the following command to remove the motd file: # rm /etc/motd."
    compliance:
      - cis: ["1.7.1"]
      - mitre_techniques: ["T1082", "T1592", "T1592.004"]
      - mitre_tactics: ["TA0007"]
    condition: none
    rules:
      - 'f:/etc/motd -> r:\\v|\\r|\\m|\\s|Amazon'

  - id: 31117
    title: "Ensure rsyslog default file permissions are configured."
    description: "RSyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
    rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
    impact: "The systems global umask could override, but only making the file permissions stricter, what is configured in RSyslog with the FileCreateMode directive. RSyslog also has it's own $umask directive that can alter the intended file creation mode. In addition, consideration should be given to how FileCreateMode is used. Thus it is critical to ensure that the intended file creation mode is not overridden with less restrictive settings in /etc/rsyslog.conf, /etc/rsyslog.d/*conf files and that FileCreateMode is set before any file is created."
    remediation: "Edit either /etc/rsyslog.conf or a dedicated .conf file in /etc/rsyslog.d/ and set $FileCreateMode to 0640 or more restrictive: $FileCreateMode 0640 Restart the service: # systemctl restart rsyslog."
    compliance:
      - cis: ["4.2.1.4"]
      - cis_csc_v8: ["3.3", "8.2"]
      - cis_csc_v7: ["5.1", "6.2", "6.3"]
      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "AU.L2-3.3.1", "MP.L2-3.8.2"]
      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)", "164.312(b)"]
      - iso_27001-2013: ["A.12.4.1", "A.14.2.5", "A.8.1.3"]
      - nist_sp_800-53: ["AC-5", "AC-6", "AU-7"]
      - pci_dss_v3.2.1: ["10.2", "10.3", "7.1", "7.1.1", "7.1.2", "7.1.3"]
      - pci_dss_v4.0: ["1.3.1", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2", "7.1"]
      - soc_2: ["CC5.2", "CC6.1"]
      - mitre_techniques: ["T1070", "T1070.002", "T1083"]
      - mitre_tactics: ["TA0007"]
    condition: all
    rules:
      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 0640|^\$FileCreateMode 0600|^\$FileCreateMode 0400'
      - 'd:/etc/rsyslog.d/ -> r:\.+.conf -> r:^\$FileCreateMode 0640|^\$FileCreateMode 0600|^\$FileCreateMode 0400'


  - id: 31135
    title: "Ensure permissions on /etc/ssh/sshd_config are configured."
    description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
    rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
    remediation: "Run the following commands to set ownership and permissions on /etc/ssh/sshd_config: # chown root:root /etc/ssh/sshd_config # chmod og-rwx /etc/ssh/sshd_config."
    compliance:
      - cis: ["5.2.1"]
      - cis_csc_v8: ["3.3"]
      - cis_csc_v7: ["14.6"]
      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
      - iso_27001-2013: ["A.9.1.1"]
      - nist_sp_800-53: ["AC-5", "AC-6"]
      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
      - pci_dss_v4.0: ["1.3.1", "7.1"]
      - soc_2: ["CC5.2", "CC6.1"]
      - mitre_techniques: ["T1098", "T1098.004", "T1543", "T1543.002"]
      - mitre_tactics: ["TA0005"]
      - mitre_mitigations: ["M1022"]
    condition: all
    rules:
      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)$'

  - id: 31156
    title: "Ensure users must provide password for escalation."
    description: "The operating system must be configured so that users must provide a password for privilege escalation."
    rationale: "Without re-authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user re-authenticate."
    impact: "This will prevent automated processes from being able to elevate privileges. To include Ansible and AWS builds."
    remediation: "Based on the outcome of the audit procedure, use visudo -f <PATH TO FILE> to edit the relevant sudoers file. Remove any line with occurrences of NOPASSWD tags in the file."
    compliance:
      - cis: ["5.3.4"]
      - cis_csc_v8: ["5.4"]
      - cis_csc_v7: ["4.3"]
      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
      - iso_27001-2013: ["A.9.2.3"]
      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
      - soc_2: ["CC6.1", "CC6.3"]
    condition: none
    rules:
      - 'f:/etc/sudoers -> !r:^\s*\t*# && r:NOPASSWD'
      - 'd:/etc/sudoers.d -> r:\.* -> !r:^\s*\t*# && r:NOPASSWD'
```


</details>

### Tests Introduced

- Added missing tests to Utils::TokenizeCommand merged in https://github.com/wazuh/wazuh-agent/pull/791
- New tests for SCA Utils, Policy check evaluators and check condition evaluator.
- Fix for race condition in a TaskManager unit test. 

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
