### PR TITLE
Add logging when stopping an ongoing SCA scan

### DIFF
--- a/src/modules/sca/src/sca_policy.hpp
+++ b/src/modules/sca/src/sca_policy.hpp
@@ -47,4 +47,5 @@ private:
     Check m_requirements;
     std::vector<Check> m_checks;
     std::atomic<bool> m_keepRunning {true};
+    std::atomic<bool> m_scanInProgress {false};
 };


### PR DESCRIPTION
## Description

This PR adds useful logging to identify when an ongoing SCA scan is canceled.

## Proposed Changes

- Add a flag to identify when a scan is in progress.
- When stopping the agent, check the flag and log it accordingly.

### Results and Evidence

Logs:

```
[2025-05-26 15:26:38.225] [wazuh-agent] [debug] [sca_policy.cpp:99] [Scan] Policy check "35559" evaluation completed for policy "cis_ubuntu24-04", result: Not applicable.
[2025-05-26 15:26:38.228] [wazuh-agent] [debug] [sca_policy_check.cpp:372] [CheckDirectoryExistence] Processing directory rule. Checking existence of directory: '/etc/gdm3'
[2025-05-26 15:26:38.228] [wazuh-agent] [debug] [sca_policy_check.cpp:384] [CheckDirectoryExistence] Directory '/etc/gdm3' does not exist or is not a directory
[2025-05-26 15:26:38.228] [wazuh-agent] [debug] [sca_policy_check.cpp:241] [CheckDirectoryForContents] Processing directory rule: '/etc/gdm3'
[2025-05-26 15:26:38.228] [wazuh-agent] [debug] [sca_policy_check.cpp:245] [CheckDirectoryForContents] Path '/etc/gdm3' does not exist
[2025-05-26 15:26:38.228] [wazuh-agent] [debug] [sca_policy_check.cpp:241] [CheckDirectoryForContents] Processing directory rule: '/etc/gdm3'
[2025-05-26 15:26:38.228] [wazuh-agent] [debug] [sca_policy_check.cpp:245] [CheckDirectoryForContents] Path '/etc/gdm3' does not exist
[2025-05-26 15:26:38.228] [wazuh-agent] [debug] [sca_policy.cpp:99] [Scan] Policy check "35560" evaluation completed for policy "cis_ubuntu24-04", result: Passed.
[2025-05-26 15:26:38.232] [wazuh-agent] [debug] [sca_policy_check.cpp:162] [Evaluate] Processing command rule: 'dpkg-query -s autofs'
^C[2025-05-26 15:26:38.238] [wazuh-agent] [info] [agent.cpp:215] [Run] Stopping agent...
[2025-05-26 15:26:38.238] [wazuh-agent] [debug] [sca_policy.cpp:124] [Stop] Aborting current scan for policy "cis_ubuntu24-04"
[2025-05-26 15:26:38.238] [wazuh-agent] [info] [sca.cpp:116] [Stop] SCA module stopped.
[2025-05-26 15:26:38.238] [wazuh-agent] [info] [inventory.cpp:78] [Stop] Inventory module stopping...
[2025-05-26 15:26:38.238] [wazuh-agent] [info] [logcollector.cpp:102] [Stop] Logcollector module stopped.
```

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
