### PR TITLE
Fix workflow to read new VERSION.json format

### DIFF
--- a/.github/workflows/6_builderpackage_docker-onpush.yml
+++ b/.github/workflows/6_builderpackage_docker-onpush.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Set TAG
         run: |
-          VERSION=$(sed 's/.*\([0-9]\.[0-9]*\.[0-9]*\).*/\1/' ./src/VERSION)
+          VERSION=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' ./VERSION.json)
           if [ "${{ inputs.docker_image_tag }}" == "auto" ]; then
             echo "TAG=$VERSION" >> $GITHUB_ENV;
           elif [ "${{ inputs.docker_image_tag }}" == "developer" ]; then


### PR DESCRIPTION
## Description

The workflow "Upload agent amd docker images" is currently failing due to the following error:

```
sed: can't read ./src/VERSION: No such file or directory
```

This issue was introduced by pull request #635, which changed the version file from a plain text format (`VERSION`) to a JSON format (`VERSION.json`).

## Proposed Changes

* Update the workflow to read the version from `VERSION.json` instead of the deprecated `VERSION` file.
* Parse the JSON format to extract the required version value.

### Results and Evidence

We have validated the changes by manually triggering the workflow: 

| Status | Workflow File Name                 | Run                                                                |
| :----: | ---------------------------------- | ------------------------------------------------------------------ |
| 🟢      | 6_builderpackage_docker-onpush     | [#2](https://github.com/wazuh/wazuh-agent/actions/runs/15463869340) |

### Artifacts Affected

* `.github/workflows/6_builderpackage_docker-onpush.yml`


## Review Checklist

* [ ] Code changes reviewed
* [ ] Relevant evidence provided
* [ ] Meets requirements and/or definition of done
* [ ] No unresolved dependencies with other issues
