### PR TITLE
Fix unzip failure on macOS due to read-only root filesystem

### DIFF
--- a/.github/actions/6_builderpackage_agent_macos/action.yml
+++ b/.github/actions/6_builderpackage_agent_macos/action.yml
@@ -24,7 +24,8 @@ runs:
       run: |
         mkdir -p src/build && cd src/build && cmake .. && make -j $(sysctl -n hw.ncpu)
         sudo rm -rf _deps vcpkg_installed
-        zip -r ${{ github.workspace }}/wazuh-agent-binaries-${{ inputs.architecture }}.zip ${{ github.workspace }}/
+        cd ../..
+        zip -r wazuh-agent-binaries-${{ inputs.architecture }}.zip etc/config/wazuh-agent.yml src/build
 
     - name: Upload wazuh-agent-binaries.zip
       uses: actions/upload-artifact@v4

--- a/.github/actions/6_builderpackage_binary_macos/action.yml
+++ b/.github/actions/6_builderpackage_binary_macos/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Build macOS package
       shell: bash
       run: |
-        sudo unzip -o wazuh-agent-binaries-${{ inputs.architecture }}.zip -d /
+        unzip -o wazuh-agent-binaries-${{ inputs.architecture }}.zip
         bash packages/macos/generate_wazuh_packages.sh -i
         echo 'generate_wazuh_packages.sh ${{ env.FLAGS }}'
         sudo bash packages/macos/generate_wazuh_packages.sh ${{ env.FLAGS }}

--- a/.github/actions/6_builderpackage_docker_images/build_and_push_image_to_ghcr.sh
+++ b/.github/actions/6_builderpackage_docker_images/build_and_push_image_to_ghcr.sh
@@ -10,7 +10,7 @@ else
 fi
 GITHUB_REPOSITORY="wazuh/wazuh"
 GITHUB_OWNER="wazuh"
-IMAGE_ID_CACHE=ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:latest-5.0
+IMAGE_ID_CACHE=ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:latest-6.0
 IMAGE_ID_CACHE=$(echo ${IMAGE_ID_CACHE} | tr '[A-Z]' '[a-z]')
 IMAGE_ID=ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 IMAGE_ID=$(echo ${IMAGE_ID} | tr '[A-Z]' '[a-z]')


### PR DESCRIPTION
## Description

The GitHub Actions workflow **Build Wazuh agent Mac OS packages** is currently failing with exit code 2.

The error appears when trying to unzip the `wazuh-agent-binaries-arm64.zip` archive, which includes precompiled agent binaries.

The issue is due to the workflow attempting to unzip the archive into the root directory (`/`), which is read-only in recent macOS versions.

## Proposed Changes

* Modify the job that compresses the binaries to include only the `build` directory, preserving its relative path.
* Update the packaging job to unzip the archive relative to `${{ github.workspace }}` instead of `/`.

### Results and Evidence

| Status | Workflow File Name                 | Run                                                                |
| :----: | ---------------------------------- | ------------------------------------------------------------------ |
| 🟢      | `6_builderpackage_agent-macos`       | [#13](https://github.com/wazuh/wazuh-agent/actions/runs/15487859870) |

### Artifacts Affected

* `6_builderpackage_agent-macos.yml` workflow

## Review Checklist

* [x] Code changes reviewed
* [x] Relevant evidence provided
* [x] Meets requirements and/or definition of done
* [x] No unresolved dependencies with other issues
