### PR TITLE
Fix GH_TOKEN secret reference in Docker image upload workflow

### DIFF
--- a/.github/workflows/6_builderpackage_docker-upload.yml
+++ b/.github/workflows/6_builderpackage_docker-upload.yml
@@ -107,25 +107,25 @@ jobs:
         run: |
           gh workflow run 6_builderpackage_upload-images-linux.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=deb -f architecture=amd64 -f source_reference=${{ github.ref_name }}
         env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
+          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES_CLASSIC }}
 
       - name: Request pkg_rpm_agent_builder_amd64 update
         if: steps.changes.outputs.pkg_rpm_agent_builder_amd64 == 'true'
         run: |
           gh workflow run 6_builderpackage_upload-images-linux.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=amd64 -f source_reference=${{ github.ref_name }}
         env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
+          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES_CLASSIC }}
 
       - name: Request pkg_deb_agent_builder_arm64 update
         if: steps.changes.outputs.pkg_deb_agent_builder_arm64 == 'true'
         run: |
           gh workflow run 6_builderpackage_upload-images-linux.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=deb -f architecture=arm64 -f source_reference=${{ github.ref_name }}
         env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
+          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES_CLASSIC }}
 
       - name: Request pkg_rpm_agent_builder_arm64 update
         if: steps.changes.outputs.pkg_rpm_agent_builder_arm64 == 'true'
         run: |
           gh workflow run 6_builderpackage_upload-images-linux.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=arm64 -f source_reference=${{ github.ref_name }}
         env:
-          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
+          GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES_CLASSIC }}


### PR DESCRIPTION
## Description

The GitHub Actions workflow responsible for uploading Docker package building images was failing due to an incorrect reference to the `GH_TOKEN` secret: [#1](https://github.com/wazuh/wazuh-agent/actions/runs/15488421088).

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```

The error message indicated that the `GH_TOKEN` environment variable was not properly set.

## Proposed Changes

* Updated the workflow to use the `CI_WAZUH_AGENT_PACKAGES_CLASSIC` secret as the value for `GH_TOKEN`.

### Results and Evidence

| Status | Workflow File Name                  | Run                                                                |
| :----: | ----------------------------------- | ------------------------------------------------------------------ |
| 🟢    | `6_builderpackage_docker-upload`     | [#2](https://github.com/wazuh/wazuh-agent/actions/runs/15488607323) |

### Artifacts Affected

* `.github/workflows/6_builderpackage_docker-upload.yml`

## Review Checklist

* [x] Code changes reviewed
* [x] Relevant evidence provided
* [x] Meets requirements and/or definition of done
* [x] No unresolved dependencies with other issues
