### PR TITLE
Exclude .git folder from test integration artifacts

### DIFF
--- a/.github/actions/6_builderpackage_agent_linux/action.yml
+++ b/.github/actions/6_builderpackage_agent_linux/action.yml
@@ -56,7 +56,7 @@ runs:
     - name: Zip repository
       shell: bash
       run: |
-        zip -r ${{ github.workspace }}/wazuh-agent-binaries-${{ inputs.architecture }}.zip ${{ github.workspace }}/
+        zip -r ${{ github.workspace }}/wazuh-agent-binaries-${{ inputs.architecture }}.zip ${{ github.workspace }} -x "${{ github.workspace }}/.git/*"
 
     - name: Upload wazuh-agent-binaries.zip
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

This PR modifies multiple test integration workflows to explicitly exclude the `.git` folder from the artifacts they produce. This ensures cleaner artifact packages and prevents potential issues with unnecessary files being included.

## Proposed Changes

### Results and Evidence

- Verified that generated artifacts no longer contain any `.git` folders:
![image](https://github.com/user-attachments/assets/0ccf0d64-67b2-4ec0-91a0-e2c8510ab742)

- All workflows continue to function as expected after the changes:

| Result | Workflow | Link |
|:-:|--|--|
|🟢|`6_builderpackage_agent-linux`|[#5](https://github.com/wazuh/wazuh-agent/actions/runs/15590407661)|


### Artifacts Affected

Modified action:

- `6_builderpackage_agent_linux`

Affected workflow:

- `6_builderpackage_agent-linux`

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided  
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues