### PR TITLE
Replaces yaml cpp with libyaml in SCA module

### DIFF
--- a/src/modules/sca/CMakeLists.txt
+++ b/src/modules/sca/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(yaml CONFIG REQUIRED)
 add_library(
     SCA
     src/sca.cpp
+    src/yaml_document.cpp
+    src/yaml_node.cpp
     src/sca_policy.cpp
     src/sca_policy_check.cpp
     src/sca_policy_loader.cpp

--- a/src/modules/sca/CMakeLists.txt
+++ b/src/modules/sca/CMakeLists.txt
@@ -7,11 +7,10 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# include(../../cmake/CommonSettings.cmake)
-# set_common_settings()
+# include(../../cmake/CommonSettings.cmake) set_common_settings()
 
 find_package(pcre2 CONFIG REQUIRED)
-find_package(yaml-cpp CONFIG REQUIRED)
+find_package(yaml CONFIG REQUIRED)
 
 add_library(
     SCA
@@ -37,12 +36,13 @@ target_link_libraries(
            sysinfo # available in 4.x, uses processes method
            cmd_helper # Utils::exec differs from 6.x to 4.x, needs to be adapted
            nlohmann_json::nlohmann_json
-    PRIVATE yaml-cpp::yaml-cpp
+    PRIVATE yaml
             PCRE2::8BIT
             hash_helper # uses Utils::HashData class available in 4.x hashHelper.h
             string_helper # uses Utils::Trim and Utils::asciiToHex (available in 4.x stringHelper.h)
             time_helper # uses Utils::getCurrentISO8601 available in 4.x timeHelper.h
-            $<$<PLATFORM_ID:Windows>:registry_helper>) # uses Utils::Registry class (available) and Utils::KeyExists (not available)
+            $<$<PLATFORM_ID:Windows>:registry_helper>) # uses Utils::Registry class (available) and Utils::KeyExists
+                                                       # (not available)
 
 include(../../cmake/ConfigureTarget.cmake)
 configure_target(SCA)

--- a/src/modules/sca/src/iyaml_document.hpp
+++ b/src/modules/sca/src/iyaml_document.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "yaml_node.hpp"
+
+/// @brief Interface for YAML document class
+class IYamlDocument
+{
+public:
+    /// @brief Destructor
+    virtual ~IYamlDocument() = default;
+
+    /// @brief Gets the root node of the YAML document
+    /// @return YamlNode object representing the root node
+    virtual YamlNode GetRoot() = 0;
+
+    /// @brief Checks if the YAML document has been loaded with no errors
+    /// @return True if the document has been successfully loaded, false otherwise
+    virtual bool IsValidDocument() const = 0;
+};

--- a/src/modules/sca/src/sca_policy_loader.cpp
+++ b/src/modules/sca/src/sca_policy_loader.cpp
@@ -66,7 +66,7 @@ std::vector<std::unique_ptr<ISCAPolicy>> SCAPolicyLoader::LoadPolicies(const Cre
             {
                 // LogDebug("Loading policy from {}", path.string());
 
-                const PolicyParser parser(path);
+                PolicyParser parser(path);
 
                 if (auto policy = parser.ParsePolicy(policiesAndChecks); policy)
                 {

--- a/src/modules/sca/src/yaml_document.cpp
+++ b/src/modules/sca/src/yaml_document.cpp
@@ -1,0 +1,68 @@
+
+#include "yaml_document.hpp"
+#include "yaml_node.hpp"
+
+#include <fstream>
+
+#include <iostream>
+
+YamlDocument::YamlDocument()
+    : m_loaded(false) {};
+
+YamlDocument::YamlDocument(const std::filesystem::path& filename)
+{
+    std::ifstream file(filename.c_str());
+    if (!file)
+    {
+        throw std::runtime_error("Cannot open file");
+    };
+
+    if (!Load(file))
+    {
+        // TODO: Log("Failed to parse YAML document:" filename.string().c_str());
+    }
+}
+
+YamlDocument::YamlDocument(const std::string& yaml_content)
+{
+    std::istringstream ss(yaml_content);
+
+    if (!Load(ss))
+    {
+        // TODO: Log("Failed to parse YAML content");
+    }
+}
+
+YamlDocument::~YamlDocument()
+{
+    if (m_loaded)
+    {
+        yaml_document_delete(&m_document);
+    }
+    yaml_parser_delete(&m_parser);
+}
+
+bool YamlDocument::IsValidDocument() const
+{
+    return m_loaded;
+}
+
+bool YamlDocument::Load(std::istream& input)
+{
+    yaml_parser_initialize(&m_parser);
+    std::string content((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    yaml_parser_set_input_string(&m_parser, reinterpret_cast<const unsigned char*>(content.c_str()), content.size());
+    m_loaded = yaml_parser_load(&m_parser, &m_document);
+
+    return m_loaded;
+}
+
+YamlNode YamlDocument::GetRoot()
+{
+    auto root = yaml_document_get_root_node(&m_document);
+    if (!root)
+    {
+        throw std::runtime_error("Empty YAML document");
+    }
+    return YamlNode(&m_document, root);
+}

--- a/src/modules/sca/src/yaml_document.hpp
+++ b/src/modules/sca/src/yaml_document.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <iyaml_document.hpp>
+#include <yaml.h>
+
+#include <filesystem>
+#include <string>
+
+/// @brief Class representing a YAML document
+class YamlDocument : public IYamlDocument
+{
+public:
+    /// @brief Constructor for loading a YAML document from a file
+    YamlDocument(const std::filesystem::path& filename);
+
+    /// @brief Constructor for loading a YAML document from a string
+    YamlDocument(const std::string& yaml_content);
+
+    /// @brief Default constructor
+    YamlDocument();
+
+    /// @brief Destructor
+    ~YamlDocument();
+
+    /// @copydoc IYamlDocument::GetRoot
+    YamlNode GetRoot() override;
+
+    /// @copydoc IYamlDocument::IsValidDocument
+    bool IsValidDocument() const override;
+
+    friend class YamlNode;
+
+private:
+    /// @brief yaml_parser_t object used to parse the YAML document
+    yaml_parser_t m_parser;
+
+    /// @brief Flag indicating whether the document has been loaded
+    bool m_loaded;
+
+    /// @brief yaml_document_t object representing the parsed YAML document
+    yaml_document_t m_document;
+
+    /// @brief Loads the YAML document from the given input stream
+    /// @param input The input stream to load the document from
+    /// @return True if the document was successfully loaded, false otherwise
+    bool Load(std::istream& input);
+};

--- a/src/modules/sca/src/yaml_node.cpp
+++ b/src/modules/sca/src/yaml_node.cpp
@@ -1,0 +1,377 @@
+#include "yaml_node.hpp"
+#include "yaml_document.hpp"
+
+#include <iostream>
+
+YamlNode::YamlNode(yaml_document_t* doc, yaml_node_t* nodePtr)
+    : m_document(doc)
+    , m_node(nodePtr)
+{
+    if (!m_node)
+    {
+        return;
+    }
+
+    switch (m_node->type)
+    {
+        case YAML_SCALAR_NODE: m_type = Type::Scalar; break;
+        case YAML_SEQUENCE_NODE: m_type = Type::Sequence; break;
+        case YAML_MAPPING_NODE: m_type = Type::Mapping; break;
+        case YAML_NO_NODE: m_type = Type::Undefined; break;
+        default: m_type = Type::Undefined; break;
+    }
+}
+
+void YamlNode::DumpYamlStructure(unsigned int indent) const
+{
+    std::string padding(indent, ' ');
+    std::cout << padding << "Node Type: " << GetNodeTypeAsString();
+    if (IsScalar())
+    {
+        std::cout << ", Value: " << AsString();
+    }
+    std::cout << std::endl;
+
+    if (IsMap())
+    {
+        for (const auto& [key, val] : AsMap())
+        {
+            std::cout << padding << "- Key: " << key << std::endl;
+            val.DumpYamlStructure(indent + 2);
+        }
+    }
+    else if (IsSequence())
+    {
+        auto seq = AsSequence();
+        for (size_t i = 0; i < seq.size(); ++i)
+        {
+            std::cout << padding << "- Index [" << i << "]" << std::endl;
+            seq[i].DumpYamlStructure(indent + 2);
+        }
+    }
+}
+
+YamlNode::Type YamlNode::GetNodeType() const
+{
+    return m_type;
+}
+
+std::string YamlNode::GetNodeTypeAsString() const
+{
+    switch (m_type)
+    {
+        case Type::Scalar: return "Scalar";
+        case Type::Sequence: return "Sequence";
+        case Type::Mapping: return "Mapping";
+        case Type::Undefined: // fallthrough
+        default: return "Undefined";
+    }
+}
+
+bool YamlNode::IsScalar() const
+{
+    return m_type == Type::Scalar;
+}
+
+bool YamlNode::IsSequence() const
+{
+    return m_type == Type::Sequence;
+}
+
+bool YamlNode::IsMap() const
+{
+    return m_type == Type::Mapping;
+}
+
+std::string YamlNode::AsString() const
+{
+    if (!IsScalar())
+    {
+        throw std::runtime_error("Node is not a scalar");
+    }
+    return std::string(reinterpret_cast<const char*>(m_node->data.scalar.value));
+}
+
+std::vector<YamlNode> YamlNode::AsSequence() const
+{
+    if (!IsSequence())
+    {
+        throw std::runtime_error("Node is not a sequence");
+    }
+    if (!sequence_cache.empty())
+    {
+        return sequence_cache;
+    }
+
+    for (yaml_node_item_t* item = m_node->data.sequence.items.start; item < m_node->data.sequence.items.top; ++item)
+    {
+        sequence_cache.emplace_back(m_document, yaml_document_get_node(m_document, *item));
+    }
+    return sequence_cache;
+}
+
+std::map<std::string, YamlNode> YamlNode::AsMap() const
+{
+    if (!IsMap())
+    {
+        throw std::runtime_error("Node is not a map");
+    }
+    if (!map_cache.empty())
+    {
+        return map_cache;
+    }
+
+    for (yaml_node_pair_t* pair = m_node->data.mapping.pairs.start; pair < m_node->data.mapping.pairs.top; ++pair)
+    {
+        auto key_node = yaml_document_get_node(m_document, pair->key);
+        auto val_node = yaml_document_get_node(m_document, pair->value);
+        if (key_node && key_node->type == YAML_SCALAR_NODE)
+        {
+            std::string key = reinterpret_cast<const char*>(key_node->data.scalar.value);
+            map_cache[key] = YamlNode(m_document, val_node);
+        }
+    }
+    return map_cache;
+}
+
+const YamlNode& YamlNode::operator[](const std::string& key) const
+{
+    if (!IsMap())
+    {
+        throw std::runtime_error("Not a map node");
+    }
+    const auto map = AsMap();
+    if (map.find(key) == map.end())
+    {
+        throw std::out_of_range("Key not found");
+    }
+    return map_cache[key];
+}
+
+const YamlNode& YamlNode::operator[](size_t index) const
+{
+    if (!IsSequence())
+    {
+        throw std::runtime_error("Not a sequence node");
+    }
+    const auto seq = AsSequence();
+    if (index >= seq.size())
+    {
+        throw std::out_of_range("Index out of bounds");
+    }
+    return sequence_cache[index];
+}
+
+YamlNode& YamlNode::operator[](const std::string& key)
+{
+    if (!IsMap())
+    {
+        throw std::runtime_error("Not a map node");
+    }
+    const auto map = AsMap();
+    if (map.find(key) == map.end())
+    {
+        throw std::out_of_range("Key not found");
+    }
+    return map_cache[key];
+}
+
+YamlNode& YamlNode::operator[](size_t index)
+{
+    if (!IsSequence())
+    {
+        throw std::runtime_error("Not a sequence node");
+    }
+    const auto seq = AsSequence();
+    if (index >= seq.size())
+    {
+        throw std::out_of_range("Index out of bounds");
+    }
+    return sequence_cache[index];
+}
+
+void YamlNode::SetScalarValue(const std::string& new_value)
+{
+    if (!IsScalar())
+    {
+        throw std::runtime_error("Not a scalar node");
+    }
+
+    // Free the old string
+    free(m_node->data.scalar.value);
+
+    // This new string will be owned and freed by the document on destruction
+    const auto newValue = strdup(new_value.c_str());
+
+    m_node->data.scalar.value = reinterpret_cast<yaml_char_t*>(newValue);
+    m_node->data.scalar.length = new_value.size();
+}
+
+bool YamlNode::HasKey(const std::string& key) const
+{
+    if (IsMap())
+    {
+        const auto& map = AsMap();
+        return map.find(key) != map.end();
+    }
+    else if (IsSequence())
+    {
+        const auto seq = AsSequence();
+        for (const auto& item : seq)
+        {
+            if (item.IsMap())
+            {
+                const auto& itemMap = item.AsMap();
+                if (itemMap.find(key) != itemMap.end())
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    return false;
+}
+
+void YamlNode::RemoveKey(const std::string& key)
+{
+    if (!IsMap())
+    {
+        throw std::runtime_error("Not a map node");
+    }
+    yaml_node_t* const map_node = m_node;
+
+    yaml_node_pair_t* out = map_node->data.mapping.pairs.start;
+    for (yaml_node_pair_t* in = map_node->data.mapping.pairs.start; in < map_node->data.mapping.pairs.top; ++in)
+    {
+        const auto key_node = yaml_document_get_node(m_document, in->key);
+        std::string current_key = reinterpret_cast<const char*>(key_node->data.scalar.value);
+        if (current_key != key)
+        {
+            *out++ = *in;
+        }
+    }
+    map_node->data.mapping.pairs.top = out;
+    map_cache.clear();
+}
+
+int YamlNode::GetId() const
+{
+    for (int i = 1; i <= m_document->nodes.top - m_document->nodes.start; ++i)
+    {
+        const yaml_node_t* const candidate = yaml_document_get_node(m_document, i);
+        if (candidate == m_node)
+        {
+            return i;
+        }
+    }
+    throw std::runtime_error("Node not found in document");
+};
+
+YamlNode YamlNode::CreateEmptySequence(const std::string& key)
+{
+    if (!IsMap())
+    {
+        throw std::runtime_error("Not a map node");
+    }
+
+    yaml_char_t* const key_str = reinterpret_cast<yaml_char_t*>(strdup(key.c_str()));
+    const yaml_char_t* tag = reinterpret_cast<const yaml_char_t*>(YAML_STR_TAG);
+    const int key_id =
+        yaml_document_add_scalar(m_document, tag, key_str, static_cast<int>(key.length()), YAML_PLAIN_SCALAR_STYLE);
+
+    // Free the key string - yaml_document_add_scalar will make its own copy
+    free(key_str);
+
+    const int seq_id = yaml_document_add_sequence(m_document, tag, YAML_BLOCK_SEQUENCE_STYLE);
+
+    const int mapping_id = GetId();
+
+    yaml_document_append_mapping_pair(m_document, mapping_id, key_id, seq_id);
+
+    // important to clear our cache here
+    map_cache.clear();
+
+    yaml_node_t* const sequence_node = yaml_document_get_node(m_document, seq_id);
+    return YamlNode(m_document, sequence_node);
+}
+
+void YamlNode::AppendToSequence(const std::string& value)
+{
+    if (!IsSequence())
+    {
+        throw std::runtime_error("Not a sequence node");
+    }
+
+    yaml_char_t* const val_str = reinterpret_cast<yaml_char_t*>(strdup(value.c_str()));
+    const int scalar_id = yaml_document_add_scalar(m_document,
+                                                   reinterpret_cast<const yaml_char_t*>(YAML_STR_TAG),
+                                                   val_str,
+                                                   static_cast<int>(value.length()),
+                                                   YAML_PLAIN_SCALAR_STYLE);
+
+    free(val_str);
+
+    yaml_document_append_sequence_item(m_document, GetId(), scalar_id);
+    sequence_cache.clear();
+}
+
+YamlNode YamlNode::CloneInto(yaml_document_t* dest_doc) const
+{
+    switch (GetNodeType())
+    {
+        case Type::Scalar:
+        {
+            const std::string value = AsString();
+            yaml_char_t* const val_str = reinterpret_cast<yaml_char_t*>(strdup(value.c_str()));
+            const int scalar_id = yaml_document_add_scalar(dest_doc,
+                                                           reinterpret_cast<const yaml_char_t*>(YAML_STR_TAG),
+                                                           val_str,
+                                                           static_cast<int>(value.length()),
+                                                           YAML_PLAIN_SCALAR_STYLE);
+            free(val_str);
+            return YamlNode(dest_doc, yaml_document_get_node(dest_doc, scalar_id));
+        }
+        case Type::Sequence:
+        {
+            const int seq_id = yaml_document_add_sequence(
+                dest_doc, reinterpret_cast<const yaml_char_t*>(YAML_SEQ_TAG), YAML_BLOCK_SEQUENCE_STYLE);
+            for (const auto& item : AsSequence())
+            {
+                const YamlNode cloned = item.CloneInto(dest_doc);
+                yaml_document_append_sequence_item(dest_doc, seq_id, cloned.GetId());
+            }
+            return YamlNode(dest_doc, yaml_document_get_node(dest_doc, seq_id));
+        }
+        case Type::Mapping:
+        {
+            const int map_id = yaml_document_add_mapping(
+                dest_doc, reinterpret_cast<const yaml_char_t*>(YAML_MAP_TAG), YAML_BLOCK_MAPPING_STYLE);
+            for (const auto& [key, val] : AsMap())
+            {
+                yaml_char_t* const key_str = reinterpret_cast<yaml_char_t*>(strdup(key.c_str()));
+                const int key_id = yaml_document_add_scalar(dest_doc,
+                                                            reinterpret_cast<const yaml_char_t*>(YAML_STR_TAG),
+                                                            key_str,
+                                                            static_cast<int>(key.length()),
+                                                            YAML_PLAIN_SCALAR_STYLE);
+                free(key_str);
+                const YamlNode cloned_val = val.CloneInto(dest_doc);
+                yaml_document_append_mapping_pair(dest_doc, map_id, key_id, cloned_val.GetId());
+            }
+            return YamlNode(dest_doc, yaml_document_get_node(dest_doc, map_id));
+        }
+        case Type::Undefined: // fallthrough
+        default: throw std::runtime_error("Unsupported or undefined node type");
+    }
+}
+
+YamlDocument YamlNode::Clone() const
+{
+    YamlDocument new_doc;
+    yaml_document_initialize(&new_doc.m_document, nullptr, nullptr, nullptr, 0, 0);
+    yaml_parser_initialize(&new_doc.m_parser);
+    new_doc.m_loaded = true;
+    CloneInto(&new_doc.m_document);
+    return new_doc;
+}

--- a/src/modules/sca/src/yaml_node.hpp
+++ b/src/modules/sca/src/yaml_node.hpp
@@ -1,0 +1,144 @@
+
+#pragma once
+
+#include <yaml.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+class YamlDocument;
+
+/// @brief Class representing a YAML node
+class YamlNode
+{
+public:
+    /// @brief Type of a YAML node
+    enum class Type
+    {
+        Scalar,
+        Sequence,
+        Mapping,
+        Undefined
+    };
+
+    /// @brief Constructor for a YAML node
+    /// @param doc Pointer to the yaml_document_t object parenting this node
+    /// @param node Pointer to the yaml_node_t this object represents
+    YamlNode(yaml_document_t* doc, yaml_node_t* node);
+
+    /// @brief Default constructor
+    YamlNode() = default;
+
+    /// @brief Gets the type of the YAML node
+    /// @return Type of the node
+    Type GetNodeType() const;
+
+    /// @brief Gets the type of the YAML node as a string
+    /// @return String representation of the node type
+    std::string GetNodeTypeAsString() const;
+
+    /// @brief Checks if the YAML node is a scalar
+    /// @return True if the node is a scalar, false otherwise
+    bool IsScalar() const;
+
+    /// @brief Checks if the YAML node is a sequence
+    /// @return True if the node is a sequence, false otherwise
+    bool IsSequence() const;
+
+    /// @brief Checks if the YAML node is a map
+    /// @return True if the node is a map, false otherwise
+    bool IsMap() const;
+
+    /// @brief Gets the ID (or index) of the YAML node
+    /// @details For nodes loaded from a file, there is no way to get the ID other than
+    /// traversing the YAML document comparing the nodes and returning the corresponding index.
+    /// @return ID of the node
+    int GetId() const;
+
+    /// @brief Gets the value of the YAML node as a string
+    /// @return String value of the node
+    std::string AsString() const;
+
+    /// @brief Gets the value of the YAML node as a sequence
+    /// @return Vector of YamlNode objects representing the sequence
+    std::vector<YamlNode> AsSequence() const;
+
+    /// @brief Gets the value of the YAML node as a map
+    /// @return Map of YamlNode objects representing the map
+    std::map<std::string, YamlNode> AsMap() const;
+
+    /// @brief Gets the value of the YAML node (mapping only)
+    /// @param key Key of the map to get
+    /// @return YamlNode object representing the value
+    const YamlNode& operator[](const std::string& key) const;
+
+    /// @brief Gets the value of the YAML node (sequence only)
+    /// @param index Index of the sequence to get
+    /// @return YamlNode object representing the value
+    const YamlNode& operator[](size_t index) const;
+
+    /// @brief Gets the value of the YAML node (mapping only)
+    /// @param key Key of the map to get
+    /// @return YamlNode object representing the value
+    YamlNode& operator[](const std::string& key);
+
+    /// @brief Gets the value of the YAML node (sequence only)
+    /// @param index Index of the sequence to get
+    /// @return YamlNode object representing the value
+    YamlNode& operator[](size_t index);
+
+    /// @brief Sets the value of the YAML node
+    /// @param new_value New value to set
+    void SetScalarValue(const std::string& new_value);
+
+    /// @brief Checks if the YAML node has a key
+    /// @param key Key to check
+    /// @return True if the key exists, false otherwise
+    bool HasKey(const std::string& key) const;
+
+    /// @brief Removes a key from the YAML node
+    /// @param key Key to remove
+    void RemoveKey(const std::string& key);
+
+    /// @brief Creates an empty sequence in the YAML node
+    /// @param key Key to create the sequence under
+    /// @return YamlNode object representing the sequence
+    YamlNode CreateEmptySequence(const std::string& key);
+
+    /// @brief Appends a value to the YAML node sequence
+    /// @param value Value to append
+    void AppendToSequence(const std::string& value);
+
+    /// @brief Dump the YAML structure to the console for debugging purposes
+    /// @param indent Indentation level
+    void DumpYamlStructure(unsigned int indent = 2) const;
+
+    /// @brief Clones the YAML node
+    /// @return YamlDocument object holding the cloned node
+    YamlDocument Clone() const;
+
+private:
+    /// @brief Clones the YAML node into a new document
+    /// @param dest_doc Document to clone the node into
+    /// @return YamlNode object representing the cloned node
+    YamlNode CloneInto(yaml_document_t* dest_doc) const;
+
+    /// @brief The underlying yaml_document_t
+    yaml_document_t* m_document = nullptr;
+
+    /// @brief The underlying yaml_node_t
+    yaml_node_t* m_node = nullptr;
+
+    /// @brief The type of the YAML node
+    Type m_type = Type::Undefined;
+
+    /// @brief Cache for mapping nodes
+    mutable std::map<std::string, YamlNode> map_cache;
+
+    /// @brief Cache for sequence nodes
+    mutable std::vector<YamlNode> sequence_cache;
+
+    /// @brief Cache for scalar nodes
+    mutable std::string scalar_cache;
+};

--- a/src/modules/sca/tests/CMakeLists.txt
+++ b/src/modules/sca/tests/CMakeLists.txt
@@ -78,7 +78,7 @@ add_test(NAME ProcessRuleEvaluatorTest COMMAND process_rule_evaluator_test)
 add_executable(sca_policy_parser_test sca_policy_parser_test.cpp)
 configure_target(sca_policy_parser_test)
 target_include_directories(sca_policy_parser_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-target_link_libraries(sca_policy_parser_test PRIVATE SCA GTest::gtest GTest::gtest_main)
+target_link_libraries(sca_policy_parser_test PRIVATE SCA GTest::gtest GTest::gmock GTest::gtest_main)
 add_test(NAME SCAPolicyParserTest COMMAND sca_policy_parser_test)
 
 if(WIN32)

--- a/src/modules/sca/tests/CMakeLists.txt
+++ b/src/modules/sca/tests/CMakeLists.txt
@@ -81,6 +81,12 @@ target_include_directories(sca_policy_parser_test PRIVATE ${CMAKE_CURRENT_SOURCE
 target_link_libraries(sca_policy_parser_test PRIVATE SCA GTest::gtest GTest::gmock GTest::gtest_main)
 add_test(NAME SCAPolicyParserTest COMMAND sca_policy_parser_test)
 
+add_executable(yaml_wrapper_test yaml_wrapper_test.cpp ../src/yaml_document.cpp ../src/yaml_node.cpp)
+configure_target(yaml_wrapper_test)
+target_include_directories(yaml_wrapper_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_link_libraries(yaml_wrapper_test PRIVATE GTest::gtest GTest::gtest_main yaml)
+add_test(NAME YamlWrapperTest COMMAND yaml_wrapper_test)
+
 if(WIN32)
     add_executable(registry_rule_evaluator_test registry_rule_evaluator_test.cpp)
     configure_target(registry_rule_evaluator_test)

--- a/src/modules/sca/tests/mocks/mock_yaml_document.hpp
+++ b/src/modules/sca/tests/mocks/mock_yaml_document.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <iyaml_document.hpp>
+
+#include <gmock/gmock.h>
+
+class MockYamlDocument : public IYamlDocument
+{
+public:
+    MOCK_METHOD(YamlNode, GetRoot, (), (override));
+    MOCK_METHOD(bool, IsValidDocument, (), (const, override));
+};

--- a/src/modules/sca/tests/yaml_wrapper_test.cpp
+++ b/src/modules/sca/tests/yaml_wrapper_test.cpp
@@ -1,0 +1,352 @@
+#include <gtest/gtest.h>
+
+#include "mocks/mock_yaml_document.hpp"
+#include <yaml_document.hpp>
+#include <yaml_node.hpp>
+
+#include <string>
+
+using namespace testing;
+
+// NOLINTBEGIN(bugprone-exception-escape)
+
+TEST(YamlWrapperTest, YamlDocDefaultConstructor)
+{
+    auto doc = std::make_unique<YamlDocument>();
+
+    ASSERT_FALSE(doc->IsValidDocument());
+}
+
+TEST(YamlWrapperTest, YamlDocLoadInvalidString)
+{
+    const std::string yml = R"(
+      variables:
+        $var1: /etc
+       $var11: /usr
+      policy:
+        *id: policy1
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_FALSE(doc->IsValidDocument());
+}
+
+TEST(YamlWrapperTest, YamlDocLoadValidString)
+{
+    const std::string yml = R"(
+      variables:
+        $var1: /etc
+        $var11: /usr
+      policy:
+        id: policy1
+      checks:
+        - id: check1
+          title: "title"
+          condition: "all"
+          rules:
+            - 'f: $var1/passwd exists'
+            - 'f: $var11/shared exists'
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+}
+
+TEST(YamlWrapperTest, YamlDocGetRoot)
+{
+    const std::string yml = R"(
+      variables:
+        $var1: /etc
+        $var11: /usr
+      policy:
+        id: policy1
+      checks:
+        - id: check1
+          title: "title"
+          condition: "all"
+          rules:
+            - 'f: $var1/passwd exists'
+            - 'f: $var11/shared exists'
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+
+    EXPECT_NO_THROW({ auto node = doc->GetRoot(); });
+}
+
+TEST(YamlWrapperTest, YamlNodeSubscriptOperatorAndGetNodeType)
+{
+    const std::string yml = R"(
+      variables:
+        $var1: /etc
+        $var11: /usr
+      policy:
+        id: policy1
+      checks:
+        - id: check1
+          title: "the_title"
+          condition: "all"
+          rules:
+            - 'f: $var1/passwd exists'
+            - 'f: $var11/shared exists'
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+
+    auto root = doc->GetRoot();
+    ASSERT_TRUE(root.GetNodeType() == YamlNode::Type::Mapping);
+    EXPECT_EQ(root.GetNodeTypeAsString(), "Mapping");
+
+    // root node is a mapping, should take a key as subscript
+    auto checks = root["checks"];
+    ASSERT_TRUE(checks.GetNodeType() == YamlNode::Type::Sequence);
+    EXPECT_EQ(checks.GetNodeTypeAsString(), "Sequence");
+
+    // checks node is a sequence, should take an index as subscript
+    // Element 0 is a mapping, should take a key as subscript
+    auto tittle = checks[0]["title"];
+    ASSERT_TRUE(tittle.GetNodeType() == YamlNode::Type::Scalar);
+    EXPECT_EQ(tittle.GetNodeTypeAsString(), "Scalar");
+
+    auto rules = checks[0]["rules"];
+    ASSERT_TRUE(rules.GetNodeType() == YamlNode::Type::Sequence);
+
+    // checks node is a sequence, should not take a key as subscript, should throw
+    EXPECT_THROW({ auto fail = checks["rules"]; }, std::runtime_error);
+
+    // root node is a mapping, should not take an index as subscript, should throw
+    EXPECT_THROW({ auto fail2 = root[0]; }, std::runtime_error);
+}
+
+TEST(YamlWrapperTest, YamlNodeIs_Scalar_Sequence_Map)
+{
+    const std::string yml = R"(
+      variables:
+        $var1: /etc
+        $var11: /usr
+      checks:
+        - id: check1
+          title: "the_title"
+          condition: "all"
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+
+    auto root = doc->GetRoot();
+    ASSERT_TRUE(root.IsMap());
+
+    auto checks = root["checks"];
+    ASSERT_TRUE(checks.IsSequence());
+
+    auto tittle = checks[0]["title"];
+    ASSERT_TRUE(tittle.IsScalar());
+}
+
+TEST(YamlWrapperTest, YamlNodeHasKey)
+{
+    const std::string yml = R"(
+      variables:
+        $var1: /etc
+        $var11: /usr
+      checks:
+        - id: check1
+          title: "the_title"
+          condition: "all"
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+
+    auto root = doc->GetRoot();
+    ASSERT_TRUE(root.HasKey("checks"));
+    ASSERT_TRUE(root.HasKey("variables"));
+    ASSERT_FALSE(root.HasKey("wazuh"));
+}
+
+TEST(YamlWrapperTest, YamlNodeAsString)
+{
+    const std::string yml = R"(
+      variables:
+        $var1: /etc
+        $var11: /usr
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+
+    auto root = doc->GetRoot();
+
+    EXPECT_EQ(root["variables"]["$var1"].AsString(), "/etc");
+    EXPECT_EQ(root["variables"]["$var11"].AsString(), "/usr");
+}
+
+TEST(YamlWrapperTest, YamlNodeAsMap)
+{
+    const std::string yml = R"(
+      mapElem1: "MyElement1"
+      mapElem2: "MyElement2"
+      mapElem3: "MyElement3"
+      mapElem4: "MyElement4"
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+
+    auto root = doc->GetRoot();
+    auto rootMap = root.AsMap();
+    EXPECT_EQ(rootMap["mapElem1"].AsString(), "MyElement1");
+    EXPECT_EQ(rootMap["mapElem2"].AsString(), "MyElement2");
+    EXPECT_EQ(rootMap["mapElem3"].AsString(), "MyElement3");
+    EXPECT_EQ(rootMap["mapElem4"].AsString(), "MyElement4");
+}
+
+TEST(YamlWrapperTest, YamlNodeRemoveKey)
+{
+    const std::string yml = R"(
+      mapElem1: "MyElement1"
+      mapElem2: "MyElement2"
+      mapElem3: "MyElement3"
+      mapElem4: "MyElement4"
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+
+    auto root = doc->GetRoot();
+
+    root.RemoveKey("mapElem3");
+    EXPECT_FALSE(root.HasKey("mapElem3"));
+}
+
+TEST(YamlWrapperTest, YamlNodeAsSequence)
+{
+    const std::string yml = R"(
+      - "MySeqElement1"
+      - "MySeqElement2"
+      - "MySeqElement3"
+      - "MySeqElement4"
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+
+    auto root = doc->GetRoot();
+    auto rootSeq = root.AsSequence();
+    EXPECT_EQ(rootSeq[0].AsString(), "MySeqElement1");
+    EXPECT_EQ(rootSeq[1].AsString(), "MySeqElement2");
+    EXPECT_EQ(rootSeq[2].AsString(), "MySeqElement3");
+    EXPECT_EQ(rootSeq[3].AsString(), "MySeqElement4");
+}
+
+TEST(YamlWrapperTest, YamlNodeAppendToSequence)
+{
+    const std::string yml = R"(
+      - "MySeqElement1"
+      - "MySeqElement2"
+      - "MySeqElement3"
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+
+    auto root = doc->GetRoot();
+    root.AppendToSequence("MySeqElement4");
+
+    auto rootSeq = root.AsSequence();
+    EXPECT_EQ(rootSeq[0].AsString(), "MySeqElement1");
+    EXPECT_EQ(rootSeq[1].AsString(), "MySeqElement2");
+    EXPECT_EQ(rootSeq[2].AsString(), "MySeqElement3");
+    EXPECT_EQ(rootSeq[3].AsString(), "MySeqElement4");
+}
+
+TEST(YamlWrapperTest, YamlNodeSetScalarValue)
+{
+    const std::string yml = R"(
+      variables:
+        $var1: /etc
+        $var11: /usr
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+
+    auto root = doc->GetRoot();
+
+    EXPECT_EQ(root["variables"]["$var1"].AsString(), "/etc");
+    root["variables"]["$var1"].SetScalarValue("NewValue");
+    EXPECT_EQ(root["variables"]["$var1"].AsString(), "NewValue");
+}
+
+TEST(YamlWrapperTest, YamlNodeSequenceCreation)
+{
+    const std::string yml = R"(
+      variables:
+        $var1: /etc
+        $var11: /usr
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+
+    auto root = doc->GetRoot();
+
+    root.CreateEmptySequence("NewSequence");
+
+    // The new sequence exists
+    EXPECT_TRUE(root.HasKey("NewSequence"));
+
+    auto newSeq = root["NewSequence"];
+    // The new sequence size is 0
+    EXPECT_EQ(newSeq.AsSequence().size(), 0);
+
+    newSeq.AppendToSequence("MySeqElement1");
+    newSeq.AppendToSequence("MySeqElement2");
+    newSeq.AppendToSequence("MySeqElement3");
+    newSeq.AppendToSequence("MySeqElement4");
+    EXPECT_EQ(newSeq.AsSequence().size(), 4);
+}
+
+TEST(YamlWrapperTest, YamlNodeClone)
+{
+
+    const std::string yml = R"(
+      mapElem1: "MyElement1"
+      mapElem2: "MyElement2"
+      mapElem3: "MyElement3"
+      mapElem4: "MyElement4"
+      )";
+
+    auto doc = std::make_unique<YamlDocument>(std::string(yml));
+
+    ASSERT_TRUE(doc->IsValidDocument());
+
+    auto root = doc->GetRoot();
+
+    auto newDoc = root.Clone();
+    doc.reset();
+
+    auto newRoot = newDoc.GetRoot();
+    auto newRootMap = newRoot.AsMap();
+    EXPECT_EQ(newRootMap["mapElem1"].AsString(), "MyElement1");
+    EXPECT_EQ(newRootMap["mapElem2"].AsString(), "MyElement2");
+    EXPECT_EQ(newRootMap["mapElem3"].AsString(), "MyElement3");
+    EXPECT_EQ(newRootMap["mapElem4"].AsString(), "MyElement4");
+}
+
+// NOLINTEND(bugprone-exception-escape)

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -97,6 +97,10 @@
         {
             "name": "yaml-cpp",
             "version>=": "0.8.0"
+        },
+        {
+            "name": "libyaml",
+            "version>=": "0.2.5#5"
         }
     ],
     "vcpkg-configuration": {


### PR DESCRIPTION
## Description

To port SCA from 6.x to 5.x we need to replace the YAML parsing library used so we avoid adding new external dependencies to 5.x. This replacement needs only to be done for the 5.x migration.

### Results and Evidence

YAML Document is loaded and policy parsed successfully:

![image](https://github.com/user-attachments/assets/3c26cf27-1f91-4926-8881-5393319a45e2)

### Tests pass:

YamlDocument and YamlNode tests:

```
 ctest -R YamlWrapperTest --verbose
UpdateCTestConfiguration  from :/home/ariel/Documents/wazuh-agent/src/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/home/ariel/Documents/wazuh-agent/src/build/DartConfiguration.tcl
Test project /home/ariel/Documents/wazuh-agent/src/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 39
    Start 39: YamlWrapperTest

39: Test command: /home/ariel/Documents/wazuh-agent/src/build/modules/sca/tests/yaml_wrapper_test
39: Test timeout computed to be: 10000000
39: Running main() from /home/ariel/Documents/vcpkg/buildtrees/gtest/src/v1.15.2-41f5afb119.clean/googletest/src/gtest_main.cc
39: [==========] Running 15 tests from 1 test suite.
39: [----------] Global test environment set-up.
39: [----------] 15 tests from YamlWrapperTest
39: [ RUN      ] YamlWrapperTest.YamlDocDefaultConstructor
39: [       OK ] YamlWrapperTest.YamlDocDefaultConstructor (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlDocLoadInvalidString
39: [       OK ] YamlWrapperTest.YamlDocLoadInvalidString (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlDocLoadValidString
39: [       OK ] YamlWrapperTest.YamlDocLoadValidString (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlDocGetRoot
39: [       OK ] YamlWrapperTest.YamlDocGetRoot (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlNodeSubscriptOperatorAndGetNodeType
39: [       OK ] YamlWrapperTest.YamlNodeSubscriptOperatorAndGetNodeType (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlNodeIs_Scalar_Sequence_Map
39: [       OK ] YamlWrapperTest.YamlNodeIs_Scalar_Sequence_Map (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlNodeHasKey
39: [       OK ] YamlWrapperTest.YamlNodeHasKey (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlNodeAsString
39: [       OK ] YamlWrapperTest.YamlNodeAsString (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlNodeAsMap
39: [       OK ] YamlWrapperTest.YamlNodeAsMap (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlNodeRemoveKey
39: [       OK ] YamlWrapperTest.YamlNodeRemoveKey (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlNodeAsSequence
39: [       OK ] YamlWrapperTest.YamlNodeAsSequence (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlNodeAppendToSequence
39: [       OK ] YamlWrapperTest.YamlNodeAppendToSequence (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlNodeSetScalarValue
39: [       OK ] YamlWrapperTest.YamlNodeSetScalarValue (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlNodeSequenceCreation
39: [       OK ] YamlWrapperTest.YamlNodeSequenceCreation (0 ms)
39: [ RUN      ] YamlWrapperTest.YamlNodeClone
39: [       OK ] YamlWrapperTest.YamlNodeClone (0 ms)
39: [----------] 15 tests from YamlWrapperTest (0 ms total)
39: 
39: [----------] Global test environment tear-down
39: [==========] 15 tests from 1 test suite ran. (0 ms total)
39: [  PASSED  ] 15 tests.
1/1 Test #39: YamlWrapperTest ..................   Passed    0.00 sec

The following tests passed:
        YamlWrapperTest

100% tests passed, 0 tests failed out of 1
```

PolicyParser tests are mostly the same as existed in 6.x except for a couple that became irrelevant.

PolicyParserTest:
```
ctest -R PolicyParserTest --verbose
UpdateCTestConfiguration  from :/home/ariel/Documents/wazuh-agent/src/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/home/ariel/Documents/wazuh-agent/src/build/DartConfiguration.tcl
Test project /home/ariel/Documents/wazuh-agent/src/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 38
    Start 38: SCAPolicyParserTest

38: Test command: /home/ariel/Documents/wazuh-agent/src/build/modules/sca/tests/sca_policy_parser_test
38: Test timeout computed to be: 10000000
38: Running main() from /home/ariel/Documents/vcpkg/buildtrees/gtest/src/v1.15.2-41f5afb119.clean/googletest/src/gtest_main.cc
38: [==========] Running 10 tests from 1 test suite.
38: [----------] Global test environment set-up.
38: [----------] 10 tests from PolicyParserTest
38: [ RUN      ] PolicyParserTest.InvalidYamlFileNotThrows
38: [       OK ] PolicyParserTest.InvalidYamlFileNotThrows (0 ms)
38: [ RUN      ] PolicyParserTest.YamlSequenceIsValid
38: [       OK ] PolicyParserTest.YamlSequenceIsValid (0 ms)
38: [ RUN      ] PolicyParserTest.YamlMapIsValid
38: [       OK ] PolicyParserTest.YamlMapIsValid (0 ms)
38: [ RUN      ] PolicyParserTest.ConstructorExtractsVariables
38: [       OK ] PolicyParserTest.ConstructorExtractsVariables (0 ms)
38: [ RUN      ] PolicyParserTest.MissingPolicyReturnsNullopt
38: [       OK ] PolicyParserTest.MissingPolicyReturnsNullopt (0 ms)
38: [ RUN      ] PolicyParserTest.EmptyRequirementsReturnsNullopt
38: [       OK ] PolicyParserTest.EmptyRequirementsReturnsNullopt (0 ms)
38: [ RUN      ] PolicyParserTest.MissingChecksReturnsNullopt
38: [       OK ] PolicyParserTest.MissingChecksReturnsNullopt (0 ms)
38: [ RUN      ] PolicyParserTest.InvalidConditionReturnsNullopt
38: [       OK ] PolicyParserTest.InvalidConditionReturnsNullopt (0 ms)
38: [ RUN      ] PolicyParserTest.InvalidRuleIsHandledGracefully
38: [       OK ] PolicyParserTest.InvalidRuleIsHandledGracefully (0 ms)
38: [ RUN      ] PolicyParserTest.YamlNodeToJsonParsesMapWithSequenceValues
38: [       OK ] PolicyParserTest.YamlNodeToJsonParsesMapWithSequenceValues (0 ms)
38: [----------] 10 tests from PolicyParserTest (0 ms total)
38: 
38: [----------] Global test environment tear-down
38: [==========] 10 tests from 1 test suite ran. (0 ms total)
38: [  PASSED  ] 10 tests.
1/1 Test #38: SCAPolicyParserTest ..............   Passed    0.00 sec

The following tests passed:
        SCAPolicyParserTest

100% tests passed, 0 tests failed out of 1
```

Full set of agent tests:

```
Test project /home/ariel/Documents/wazuh-agent/src/build
      Start 38: SCAPolicyParserTest
      Start  1: byteArrayHelperTests
      Start  2: cmdHelperTests
      Start  3: sysInfoPackagesLinuxHelper_unit_test
 1/61 Test  #1: byteArrayHelperTests .....................   Passed    0.00 sec
      Start  4: sysInfoPackagesBerkeleyDB_unit_test
 2/61 Test #38: SCAPolicyParserTest ......................   Passed    0.00 sec
      Start  5: sysInfoNetworkLinux_unit_test
 3/61 Test  #3: sysInfoPackagesLinuxHelper_unit_test .....   Passed    0.00 sec
      Start  6: sysInfoRpm_unit_test
 4/61 Test  #4: sysInfoPackagesBerkeleyDB_unit_test ......   Passed    0.00 sec
      Start  7: sysInfoPackageLinuxParserRPM_unit_test
 5/61 Test  #5: sysInfoNetworkLinux_unit_test ............   Passed    0.00 sec
      Start  8: sysinfo_unit_test
 6/61 Test  #2: cmdHelperTests ...........................   Passed    0.00 sec
      Start  9: sysInfoPackages_unit_test
 7/61 Test  #6: sysInfoRpm_unit_test .....................   Passed    0.00 sec
      Start 10: sysInfoPort_unit_test
 8/61 Test  #7: sysInfoPackageLinuxParserRPM_unit_test ...   Passed    0.00 sec
      Start 11: dbsync_unit_test
 9/61 Test  #9: sysInfoPackages_unit_test ................   Passed    0.00 sec
      Start 12: dbsyncPipelineFactory_unit_test
10/61 Test #10: sysInfoPort_unit_test ....................   Passed    0.00 sec
      Start 13: dbengine_unit_test
11/61 Test  #8: sysinfo_unit_test ........................   Passed    0.01 sec
      Start 14: fim_integration_test
12/61 Test #13: dbengine_unit_test .......................   Passed    0.00 sec
      Start 15: Filesystem
13/61 Test #15: Filesystem ...............................   Passed    0.00 sec
      Start 16: FileIO
14/61 Test #12: dbsyncPipelineFactory_unit_test ..........   Passed    0.01 sec
      Start 17: globHelperTests
15/61 Test #16: FileIO ...................................   Passed    0.00 sec
      Start 18: hashHelperTests
16/61 Test #17: globHelperTests ..........................   Passed    0.00 sec
      Start 19: jsonHelperTests
17/61 Test #19: jsonHelperTests ..........................   Passed    0.00 sec
      Start 20: linuxHelperTests
18/61 Test #18: hashHelperTests ..........................   Passed    0.01 sec
      Start 21: LoggerTest
19/61 Test #21: LoggerTest ...............................   Passed    0.00 sec
      Start 22: mapWrapperTests
20/61 Test #22: mapWrapperTests ..........................   Passed    0.00 sec
      Start 23: pipelineHelperTests
21/61 Test #20: linuxHelperTests .........................   Passed    0.02 sec
      Start 24: sqliteWrapperTests
22/61 Test #23: pipelineHelperTests ......................   Passed    0.01 sec
      Start 25: stringHelperTests
23/61 Test #25: stringHelperTests ........................   Passed    0.00 sec
      Start 26: threadDispatcherTests
24/61 Test #26: threadDispatcherTests ....................   Passed    0.00 sec
      Start 27: timeHelperTests
25/61 Test #27: timeHelperTests ..........................   Passed    0.01 sec
      Start 28: SCATest
26/61 Test #28: SCATest ..................................   Passed    0.00 sec
      Start 29: SCAPolicyLoaderTest
27/61 Test #29: SCAPolicyLoaderTest ......................   Passed    0.00 sec
      Start 30: SCAEventHandlerTest
28/61 Test #30: SCAEventHandlerTest ......................   Passed    0.01 sec
      Start 31: SCAUtilsTest
29/61 Test #31: SCAUtilsTest .............................   Passed    0.00 sec
      Start 32: CheckConditionEvaluatorTest
30/61 Test #32: CheckConditionEvaluatorTest ..............   Passed    0.00 sec
      Start 33: RuleCreationTest
31/61 Test #33: RuleCreationTest .........................   Passed    0.00 sec
      Start 34: FileRuleEvaluatorTest
32/61 Test #34: FileRuleEvaluatorTest ....................   Passed    0.00 sec
      Start 35: CommandRuleEvaluatorTest
33/61 Test #35: CommandRuleEvaluatorTest .................   Passed    0.00 sec
      Start 36: DirectoryRuleEvaluatorTest
34/61 Test #36: DirectoryRuleEvaluatorTest ...............   Passed    0.00 sec
      Start 37: ProcessRuleEvaluatorTest
35/61 Test #37: ProcessRuleEvaluatorTest .................   Passed    0.00 sec
      Start 39: ModuleManagerTest
36/61 Test #24: sqliteWrapperTests .......................   Passed    0.04 sec
      Start 40: AgentInfoTest
37/61 Test #40: AgentInfoTest ............................   Passed    0.00 sec
      Start 41: AgentInfoPersistenceTest
38/61 Test #11: dbsync_unit_test .........................   Passed    0.08 sec
      Start 42: CentralizedConfiguration
39/61 Test #41: AgentInfoPersistenceTest .................   Passed    0.00 sec
      Start 43: CommandHandlerTest
40/61 Test #42: CentralizedConfiguration .................   Passed    0.00 sec
      Start 44: CommandStoreTest
41/61 Test #44: CommandStoreTest .........................   Passed    0.00 sec
      Start 45: CommunicatorTest
42/61 Test #39: ModuleManagerTest ........................   Passed    0.03 sec
      Start 46: ConfigParserTest
43/61 Test #46: ConfigParserTest .........................   Passed    0.00 sec
      Start 47: ConfigParserUtilsTest
44/61 Test #47: ConfigParserUtilsTest ....................   Passed    0.00 sec
      Start 48: HttpClientTest
45/61 Test #48: HttpClientTest ...........................   Passed    0.00 sec
      Start 49: HttpSocketTest
46/61 Test #49: HttpSocketTest ...........................   Passed    0.00 sec
      Start 50: HttpsSocketTest
47/61 Test #50: HttpsSocketTest ..........................   Passed    0.01 sec
      Start 51: InstanceCommunicatorTest
48/61 Test #14: fim_integration_test .....................   Passed    0.21 sec
      Start 52: MultiTypeQueueTest
49/61 Test #52: MultiTypeQueueTest .......................   Passed    0.00 sec
      Start 53: StorageTest
50/61 Test #53: StorageTest ..............................   Passed    0.00 sec
      Start 54: SQLiteManager_test
51/61 Test #54: SQLiteManager_test .......................   Passed    0.06 sec
      Start 55: TaskManagerTest
52/61 Test #55: TaskManagerTest ..........................   Passed    0.05 sec
      Start 56: RestartHandler
53/61 Test #43: CommandHandlerTest .......................   Passed    2.01 sec
      Start 57: AgentTest
54/61 Test #57: AgentTest ................................   Passed    0.00 sec
      Start 58: AgentEnrollmentTest
55/61 Test #58: AgentEnrollmentTest ......................   Passed    0.00 sec
      Start 59: SignalHandlerTest
56/61 Test #59: SignalHandlerTest ........................   Passed    0.00 sec
      Start 60: MessageQueueUtilsTest
57/61 Test #60: MessageQueueUtilsTest ....................   Passed    0.00 sec
      Start 61: InstanceHandlerTest
58/61 Test #61: InstanceHandlerTest ......................   Passed    0.00 sec
59/61 Test #51: InstanceCommunicatorTest .................   Passed    7.00 sec
60/61 Test #45: CommunicatorTest .........................   Passed    8.01 sec
61/61 Test #56: RestartHandler ...........................   Passed   11.01 sec

100% tests passed, 0 tests failed out of 61

Total Test time (real) =  11.35 sec
```