### PR TITLE
Validate group identifiers before using them in filesystem paths

### DIFF
--- a/src/agent/centralized_configuration/src/centralized_configuration.cpp
+++ b/src/agent/centralized_configuration/src/centralized_configuration.cpp
@@ -6,6 +6,8 @@
 #include <filesystem_wrapper.hpp>
 #include <logger.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <filesystem>
 #include <random>
@@ -25,6 +27,19 @@ namespace
         auto timestamp = now.time_since_epoch().count();
 
         return std::to_string(timestamp) + "_" + std::to_string(random);
+    }
+
+    bool IsValidGroupId(const std::string& groupId)
+    {
+        if (groupId.empty() || groupId == "." || groupId == ".." || groupId.front() == '.')
+        {
+            return false;
+        }
+
+        return std::all_of(groupId.begin(),
+                           groupId.end(),
+                           [](const unsigned char character)
+                           { return std::isalnum(character) != 0 || character == '_' || character == '-'; });
     }
 } // namespace
 
@@ -64,12 +79,12 @@ namespace centralized_configuration
             if (command == module_command::SET_GROUP_COMMAND)
             {
                 groupIds = parameters.at(module_command::GROUPS_ARG).get<std::vector<std::string>>();
-                if (!std::all_of(groupIds.begin(), groupIds.end(), [](const std::string& id) { return !id.empty(); }))
+                if (!std::all_of(groupIds.begin(), groupIds.end(), IsValidGroupId))
                 {
-                    LogWarn("Group name can not be an empty string.");
+                    LogWarn("Invalid group name. Group names may only contain alphanumeric characters, '_' or '-'.");
                     co_return module_command::CommandExecutionResult {
                         module_command::Status::FAILURE,
-                        "CentralizedConfiguration group set failed, a group name can not be an empty string."};
+                        "CentralizedConfiguration group set failed, invalid group name received."};
                 }
 
                 if (!m_setGroupIdFunction(groupIds))
@@ -136,7 +151,8 @@ namespace centralized_configuration
                     try
                     {
                         if (m_fileSystemWrapper->exists(tmpGroupFile) &&
-                            tmpGroupFile.parent_path() == m_fileSystemWrapper->temp_directory_path())
+                            tmpGroupFile.parent_path().lexically_normal() ==
+                                m_fileSystemWrapper->temp_directory_path().lexically_normal())
                         {
                             if (!m_fileSystemWrapper->remove(tmpGroupFile))
                             {
@@ -156,8 +172,19 @@ namespace centralized_configuration
                         "CentralizedConfiguration validate file failed, invalid file received."};
                 }
 
-                const std::filesystem::path destGroupFile = std::filesystem::path(config::DEFAULT_SHARED_CONFIG_PATH) /
-                                                            (groupId + config::DEFAULT_SHARED_FILE_EXTENSION);
+                const std::filesystem::path sharedConfigPath =
+                    std::filesystem::path(config::DEFAULT_SHARED_CONFIG_PATH);
+                const std::filesystem::path destGroupFile =
+                    (sharedConfigPath / (groupId + config::DEFAULT_SHARED_FILE_EXTENSION)).lexically_normal();
+
+                if (destGroupFile.parent_path().lexically_normal() != sharedConfigPath.lexically_normal())
+                {
+                    LogWarn("Resolved group file path is outside the shared configuration directory: {}",
+                            destGroupFile.string());
+                    co_return module_command::CommandExecutionResult {
+                        module_command::Status::FAILURE,
+                        "CentralizedConfiguration group set failed, invalid group destination path."};
+                }
 
                 try
                 {

--- a/src/agent/centralized_configuration/tests/centralized_configuration_tests.cpp
+++ b/src/agent/centralized_configuration/tests/centralized_configuration_tests.cpp
@@ -163,12 +163,49 @@ TEST(CentralizedConfiguration, ExecuteCommandReturnsFailureOnParseParameters)
                                         "CentralizedConfiguration error while parsing parameters");
 
             const nlohmann::json parameterListCase3 = nlohmann::json::parse(R"({"groups":["", "group2"]})");
-            co_await TestExecuteCommand(
-                centralizedConfiguration,
-                "set-group",
-                parameterListCase3,
-                module_command::Status::FAILURE,
-                "CentralizedConfiguration group set failed, a group name can not be an empty string.");
+            co_await TestExecuteCommand(centralizedConfiguration,
+                                        "set-group",
+                                        parameterListCase3,
+                                        module_command::Status::FAILURE,
+                                        "CentralizedConfiguration group set failed, invalid group name received.");
+        }(),
+        boost::asio::detached);
+
+    io_context.run();
+}
+
+TEST(CentralizedConfiguration, ExecuteCommandRejectsInvalidGroupNames)
+{
+    boost::asio::io_context io_context;
+
+    boost::asio::co_spawn(
+        io_context,
+        []() -> boost::asio::awaitable<void>
+        {
+            CentralizedConfiguration centralizedConfiguration(
+                [](const std::vector<std::string>&) { return true; },
+                []() { return std::vector<std::string> {}; },
+                [](std::string, std::string) -> boost::asio::awaitable<bool> { co_return true; },
+                [](const std::filesystem::path&) { return true; },
+                []() {});
+
+            const std::vector<nlohmann::json> invalidGroupCases = {
+                nlohmann::json::parse(R"({"groups":["../../etc/wazuh-agent"]})"),
+                nlohmann::json::parse(R"({"groups":["/etc/wazuh-agent"]})"),
+                nlohmann::json::parse(R"({"groups":["..\\windows"]})"),
+                nlohmann::json::parse(R"({"groups":[".."]})"),
+                nlohmann::json::parse(R"({"groups":[".hidden"]})"),
+                nlohmann::json::parse(R"({"groups":["group/../escape"]})"),
+                nlohmann::json::parse(R"({"groups":["good", "bad/name"]})")};
+
+            for (const auto& invalidCase : invalidGroupCases)
+            {
+                co_await TestExecuteCommand(centralizedConfiguration,
+                                            "set-group",
+                                            invalidCase,
+                                            module_command::Status::FAILURE,
+                                            "CentralizedConfiguration group set failed, invalid group name received.");
+            }
         }(),
         boost::asio::detached);
 


### PR DESCRIPTION
## Description

Group identifiers received from the manager via the `set-group` command were only checked for being non-empty before being used to build filesystem paths. The raw group name is concatenated into:

- the temporary download path under the system temp directory,
- the destination path under the shared configuration directory (`DEFAULT_SHARED_CONFIG_PATH`),
- the group download URL (`/api/v1/files?file_name=<group>`).

Because `std::filesystem::path::operator/` does not collapse `..`, a group name such as `../../etc/wazuh-agent` resolves the destination **outside** the shared configuration directory, and the agent then calls `create_directories()` and `rename()` into that location — an arbitrary file write driven by a control-plane string. The same non-normalized path also defeats the lexical comparison used by the temporary-file cleanup guard.

This is a privilege-boundary / defense-in-depth fix: the agent should not trust the manager to send filesystem-safe identifiers.

## Changes

- Add `IsValidGroupId()` and validate every group name **before** any path construction. Group names are restricted to alphanumeric characters, `_` and `-`, rejecting path separators, `..`, and leading dots.
- As defense in depth, normalize the resolved destination path and verify it stays directly under the shared configuration directory before creating directories or moving the file.
- Compare normalized paths in the temporary-file cleanup guard instead of a lexical `parent_path()` comparison.
- Update the existing empty-string test to the new validation message and add `ExecuteCommandRejectsInvalidGroupNames` covering traversal, absolute paths, backslashes, bare `..`, leading dots, embedded `..`, and mixed valid/invalid arrays.

## Testing

- Existing `CentralizedConfiguration` unit tests updated; new rejection cases added.
- The `IsValidGroupId` logic was additionally verified standalone under `-Wall -Wextra` against the valid and invalid name sets.

## Review Checklist

- [x] **Path traversal neutralized** — group names containing `/`, `\`, `..`, leading dots, or other non-`[A-Za-z0-9_-]` characters are rejected before any path is built; verified against `../../etc/wazuh-agent`, `/etc/wazuh-agent`, `..\windows`, `..`, `.hidden`, and `group/../escape`.
- [x] **All three sinks covered** — the single validation point guards the temp path, the destination path, and the `file_name` download URL, since they share the same `groupId` string.
- [x] **Defense in depth** — destination path normalized and checked to remain under `DEFAULT_SHARED_CONFIG_PATH`; cleanup guard compares normalized paths.
- [x] **Tests cover the new behavior** — `ExecuteCommandRejectsInvalidGroupNames` added; existing empty-string test updated to the new message; valid names still succeed via existing tests.
- [x] **Validation logic verified** — `IsValidGroupId` compiled and run standalone under `-Wall -Wextra` against valid and invalid name sets (all pass).
- [x] **Formatting** — both files pass `clang-format --dry-run --Werror`; no CMake files changed.
- [x] **No new dependencies** — uses only `std::filesystem` / `<cctype>` / `<algorithm>`; no interface or build changes.
- [x] **Full build + unit-test suite run in the project's Linux toolchain** — full build (221 targets) and complete unit-test suite (66/66 suites, 0 failures) pass locally on RHEL 9 with GCC 11.5, including the updated `CentralizedConfiguration` suite (12/12).
- [ ] **No behavior/config changes requiring doc updates** — group names were always expected to be simple identifiers; this enforces it. Flagging for reviewer confirmation in case the accepted character set should be documented in user-facing config docs.

Closes #858

Reported by @rayhanhanaputra.


