### PR TITLE
Add agent-side UDP/TCP Syslog listener support to Logcollector

### DIFF
--- a/docs/ref/modules/logcollector/README.md
+++ b/docs/ref/modules/logcollector/README.md
@@ -83,6 +83,80 @@ This collector gets logs from Journald on Linux. It needs a field and a value to
 |           | journald.ignore_if_missing | Boolean to ignore the filtering condition for logs without the specified field               | false   |
 |           | journald.conditions        | Vector of journald fields to filter to be applied simultaneously                             |         |
 
+### Agent-side Syslog listener
+
+The Wazuh agent can optionally receive basic Syslog messages directly over UDP or
+TCP through the Logcollector module. This is useful for lightweight remote-site
+deployments where nearby devices or applications need to forward Syslog to a local
+Wazuh agent, while preserving the agent-based collection model. Received messages
+enter the normal Logcollector processing path and are sent through the standard
+agent-to-manager pipeline, so they remain associated with the receiving agent.
+
+No listener is started unless it is explicitly configured. Each `syslog` entry
+defines one listener (one protocol, bind address and port). Several entries may be
+combined to run multiple independent listeners on the same agent.
+
+```yaml
+logcollector:
+  enabled: true
+  syslog:
+    # UDP listener on localhost
+    - protocol: udp
+      bind_address: 127.0.0.1
+      port: 5514
+    # UDP listener on a specific interface
+    - protocol: udp
+      bind_address: 192.168.10.20
+      port: 5515
+    # TCP listener on localhost
+    - protocol: tcp
+      bind_address: 127.0.0.1
+      port: 1514
+```
+
+`bind_address` is optional and defaults to `127.0.0.1`. Binding to `0.0.0.0` (all
+interfaces) must be configured explicitly. Each message is forwarded with the
+`remote-syslog` collector type and the listener identity (`<protocol>:<address>:<port>`)
+as its provider:
+
+```json
+{"module":"logcollector","collector":"remote-syslog"}
+{"event":{"created":"2025-01-17T17:58:26.212Z","original":"<13>Jun 25 10:00:00 testhost testapp: UDP listener test","provider":"udp:127.0.0.1:5514"}}
+```
+
+| Mandatory | Option              | Description                                                              | Default   |
+| :-------: | ------------------- | ----------------------------------------------------------------------- | --------- |
+|     ✔️     | syslog              | Vector of agent-side syslog listeners                                   |           |
+|     ✔️     | syslog.protocol     | Listener transport protocol: `udp` or `tcp`                             |           |
+|     ✔️     | syslog.port         | Listener port (1-65535)                                                  |           |
+|           | syslog.bind_address | Address the listener binds to                                           | 127.0.0.1 |
+
+A listener definition is rejected (and the listener is not started) when the
+protocol is not `udp`/`tcp`, the port is missing or out of range, the bind address
+is malformed, or another listener already uses the same protocol, bind address and
+port combination.
+
+> **Note:** For high-volume Syslog ingestion, TLS Syslog, disk-assisted queues,
+> advanced filtering, transformations, routing, or complex parsing pipelines, use
+> rsyslog, syslog-ng, Logstash, or the Wazuh manager remote Syslog input as
+> appropriate. Source IP filtering for the agent-side listener should be handled
+> with host firewall rules.
+
+#### Limitations and future work
+
+This first version implements only the UDP/TCP IP-socket listeners from
+[wazuh/wazuh#15178](https://github.com/wazuh/wazuh/issues/15178). The following are
+intentionally **not** included yet and are tracked as future work:
+
+| Not yet supported | Notes |
+| ----------------- | ----- |
+| UNIX domain sockets (`unix_stream`, `unix_dgram`, `unix_seq`) | Local socket ingress requested in #15178; reuses the Boost.Asio local-socket pattern. |
+| Named pipe / FIFO (and Windows named pipes) | Pipe ingress requested in #15178; equivalent to the legacy `syslog-pipe` format. |
+| TLS Syslog (TCP) | The TCP listener is plaintext; use rsyslog/syslog-ng for TLS. |
+| TCP octet-counting framing (RFC 6587) | Only newline-delimited ("non-transparent") framing is parsed. Octet-counted messages (`<len> <msg>`) are not auto-detected. |
+| Hostname `bind_address` | Only numeric IP literals (IPv4/IPv6) are accepted; DNS names are rejected. |
+| `allowed-ips` source filtering | Restrict senders with host firewall rules until implemented. |
+
 ### Windows Collector
 
 ```yaml

--- a/docs/ref/modules/logcollector/architecture.md
+++ b/docs/ref/modules/logcollector/architecture.md
@@ -61,11 +61,20 @@ classDiagram
         + Run()
         + Stop()
     }
+    class SyslogReader {
+        - protocol : SyslogProtocol
+        - bindAddress : string
+        - port : uint16
+        + SyslogReader(protocol, bindAddress, port)
+        + Run()
+        + Stop()
+    }
     IModule <-- Logcollector
     Logcollector o-- IReader
     IReader <|-- FileReader
     IReader <|-- JournaldReader
     IReader <|-- WindowsEventTracerReader
     IReader <|-- MacosReader
+    IReader <|-- SyslogReader
     FileReader o-- LocalFile
 ```

--- a/etc/config/wazuh_agent_linux.yml
+++ b/etc/config/wazuh_agent_linux.yml
@@ -29,3 +29,12 @@ logcollector:
       value: 0|1|2|3|4|5|6|7
       exact_match: true
       ignore_if_missing: true
+  # Agent-side syslog listeners (UDP/TCP). Disabled by default: no listener is
+  # started unless explicitly configured here. bind_address defaults to 127.0.0.1.
+  # syslog:
+  #   - protocol: udp
+  #     bind_address: 127.0.0.1
+  #     port: 5514
+  #   - protocol: tcp
+  #     bind_address: 127.0.0.1
+  #     port: 1514

--- a/etc/config/wazuh_agent_macos.yml
+++ b/etc/config/wazuh_agent_macos.yml
@@ -24,3 +24,12 @@ logcollector:
   read_interval: 500ms
   macos:
     - level: info
+  # Agent-side syslog listeners (UDP/TCP). Disabled by default: no listener is
+  # started unless explicitly configured here. bind_address defaults to 127.0.0.1.
+  # syslog:
+  #   - protocol: udp
+  #     bind_address: 127.0.0.1
+  #     port: 5514
+  #   - protocol: tcp
+  #     bind_address: 127.0.0.1
+  #     port: 1514

--- a/etc/config/wazuh_agent_windows.yml
+++ b/etc/config/wazuh_agent_windows.yml
@@ -27,5 +27,14 @@ logcollector:
     - channel: System
     - channel: Application
     - channel: Security
+  # Agent-side syslog listeners (UDP/TCP). Disabled by default: no listener is
+  # started unless explicitly configured here. bind_address defaults to 127.0.0.1.
+  # syslog:
+  #   - protocol: udp
+  #     bind_address: 127.0.0.1
+  #     port: 5514
+  #   - protocol: tcp
+  #     bind_address: 127.0.0.1
+  #     port: 1514
 
 

--- a/src/modules/logcollector/CMakeLists.txt
+++ b/src/modules/logcollector/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(cJSON CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(Boost REQUIRED COMPONENTS asio)
 
-file(GLOB LOGCOLLECTOR_SOURCES src/*.cpp src/file_reader/src/*.cpp)
+file(GLOB LOGCOLLECTOR_SOURCES src/*.cpp src/file_reader/src/*.cpp src/syslog_reader/src/*.cpp)
 file(GLOB JOURNALD_SOURCES src/journald_reader/src/*.cpp)
 file(GLOB MACOS_SOURCES src/macos_reader/src/*.cpp)
 file(GLOB WIN_SOURCES src/winevt_reader/src/*.cpp)
@@ -44,6 +44,7 @@ target_include_directories(
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
             ${CMAKE_CURRENT_SOURCE_DIR}/src/file_reader/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/syslog_reader/include
             $<$<PLATFORM_ID:Linux>:${CMAKE_CURRENT_SOURCE_DIR}/src/journald_reader/include>
             $<$<PLATFORM_ID:Linux>:${SYSTEMD_INCLUDE_DIRS}>
             $<$<PLATFORM_ID:Windows>:${CMAKE_CURRENT_SOURCE_DIR}/src/winevt_reader/include>

--- a/src/modules/logcollector/include/logcollector.hpp
+++ b/src/modules/logcollector/include/logcollector.hpp
@@ -81,6 +81,15 @@ namespace logcollector
         /// @param configurationParser Configuration parser
         void SetupFileReader(const std::shared_ptr<const configuration::ConfigurationParser> configurationParser);
 
+        /// @brief Sets up the agent-side syslog listeners (UDP/TCP)
+        ///
+        /// Reads every listener definition from the configuration, validates it and
+        /// creates one reader per valid definition. Invalid or duplicate definitions
+        /// are reported and skipped so that no listener is silently started.
+        ///
+        /// @param configurationParser Configuration parser
+        void SetupSyslogReaders(const std::shared_ptr<const configuration::ConfigurationParser> configurationParser);
+
         /// @brief Clean all readers
         void CleanAllReaders();
 

--- a/src/modules/logcollector/src/logcollector.cpp
+++ b/src/modules/logcollector/src/logcollector.cpp
@@ -2,17 +2,23 @@
 
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
+#include <boost/asio/ip/address.hpp>
 #include <boost/asio/redirect_error.hpp>
 #include <config.h>
 #include <logger.hpp>
 #include <timeHelper.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <chrono>
+#include <cstdint>
 #include <iomanip>
 #include <map>
+#include <set>
 #include <sstream>
 
 #include "file_reader.hpp"
+#include "syslog_reader.hpp"
 
 using namespace logcollector;
 
@@ -66,7 +72,104 @@ void Logcollector::Setup(std::shared_ptr<const configuration::ConfigurationParse
         configurationParser->GetConfigOrDefault(config::logcollector::DEFAULT_ENABLED, "logcollector", "enabled");
 
     SetupFileReader(configurationParser);
+    SetupSyslogReaders(configurationParser);
     AddPlatformSpecificReader(configurationParser);
+}
+
+void Logcollector::SetupSyslogReaders(
+    const std::shared_ptr<const configuration::ConfigurationParser> configurationParser)
+{
+    const auto syslogConfigs = configurationParser->GetConfigOrDefault<YAML::Node>(
+        YAML::Node(YAML::NodeType::Sequence), "logcollector", "syslog");
+
+    constexpr int MIN_PORT = 1;
+    constexpr int MAX_PORT = 65535;
+
+    std::set<std::string> seenListeners;
+
+    for (const auto& config : syslogConfigs)
+    {
+        if (!config.IsMap())
+        {
+            LogWarn("Invalid agent-side syslog listener configuration: entry is not a mapping.");
+            continue;
+        }
+
+        auto protocolStr = config["protocol"].as<std::string>("");
+        std::transform(protocolStr.begin(),
+                       protocolStr.end(),
+                       protocolStr.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+        SyslogProtocol protocol = SyslogProtocol::Udp;
+        if (protocolStr == "udp")
+        {
+            protocol = SyslogProtocol::Udp;
+        }
+        else if (protocolStr == "tcp")
+        {
+            protocol = SyslogProtocol::Tcp;
+        }
+        else
+        {
+            LogError("Invalid agent-side syslog listener configuration: unsupported protocol {}.",
+                     protocolStr.empty() ? "(missing)" : protocolStr);
+            continue;
+        }
+
+        if (!config["port"])
+        {
+            LogError("Invalid agent-side syslog listener configuration: missing port.");
+            continue;
+        }
+
+        int port = 0;
+        try
+        {
+            port = config["port"].as<int>();
+        }
+        catch (const std::exception&)
+        {
+            LogError("Invalid agent-side syslog listener configuration: invalid port {}.",
+                     config["port"].as<std::string>(""));
+            continue;
+        }
+
+        if (port < MIN_PORT || port > MAX_PORT)
+        {
+            LogError("Invalid agent-side syslog listener configuration: invalid port {}.", port);
+            continue;
+        }
+
+        const auto bindAddress = config["bind_address"].as<std::string>("127.0.0.1");
+
+        boost::system::error_code ec;
+        boost::asio::ip::make_address(bindAddress, ec);
+        if (ec)
+        {
+            LogError("Invalid agent-side syslog listener configuration: invalid bind address {}.", bindAddress);
+            continue;
+        }
+
+        const auto listenerId =
+            SyslogReader::ProtocolToString(protocol) + ":" + bindAddress + ":" + std::to_string(port);
+
+        if (!seenListeners.insert(listenerId).second)
+        {
+            LogError("Invalid agent-side syslog listener configuration: duplicate listener {}.", listenerId);
+            continue;
+        }
+
+        AddReader(std::make_shared<SyslogReader>(
+            [this](const std::string& location, const std::string& log, const std::string& collectorType)
+            { PushMessage(location, log, collectorType); },
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+            [this](std::chrono::milliseconds duration) -> Awaitable { co_await Wait(duration); },
+            [this](Awaitable task) { EnqueueTask(std::move(task)); },
+            protocol,
+            bindAddress,
+            static_cast<std::uint16_t>(port)));
+    }
 }
 
 void Logcollector::SetupFileReader(const std::shared_ptr<const configuration::ConfigurationParser> configurationParser)

--- a/src/modules/logcollector/src/syslog_reader/include/syslog_reader.hpp
+++ b/src/modules/logcollector/src/syslog_reader/include/syslog_reader.hpp
@@ -1,0 +1,144 @@
+#pragma once
+
+#include <reader.hpp>
+
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/ip/udp.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+
+/// @brief Collector type reported for messages received by an agent-side syslog listener
+const std::string REMOTE_SYSLOG_READER_TYPE = "remote-syslog";
+
+// ----------------------------------------------------------------------------
+// Future work (tracked against wazuh/wazuh#15178)
+//
+// This reader covers the UDP/TCP IP-socket ingress only. The following remain
+// to be implemented as follow-ups and are referenced here for convenience:
+//
+//   1. UNIX domain socket listeners (unix_stream / unix_dgram / unix_seq),
+//      using boost::asio::local::stream_protocol / datagram_protocol. See the
+//      manager-side Fluentd forwarder and agent instance_communicator for the
+//      existing local-socket pattern.
+//   2. Named pipe / FIFO ingress (Linux mkfifo; Windows named pipes use a
+//      different API). Equivalent to the legacy "syslog-pipe" log format.
+//   3. TLS for the TCP listener (boost::asio::ssl::stream), with cert/key/CA
+//      configuration and optional client-certificate verification.
+//   4. TCP octet-counting framing (RFC 6587): currently only newline-delimited
+//      ("non-transparent") framing is parsed; detect a leading "<digits> " to
+//      support octet-counted messages.
+//   5. Hostname bind_address resolution (currently numeric IP literals only).
+//   6. allowed-ips source filtering (currently rely on host firewall rules).
+// ----------------------------------------------------------------------------
+
+namespace logcollector
+{
+    /// @brief Transport protocol used by an agent-side syslog listener
+    enum class SyslogProtocol
+    {
+        Udp,
+        Tcp
+    };
+
+    /// @brief Agent-side syslog listener reader
+    ///
+    /// This reader opens a UDP or TCP socket and listens for incoming syslog
+    /// messages. Each received message is forwarded into the normal Logcollector
+    /// processing path so that it is sent through the standard agent-to-manager
+    /// pipeline and remains associated with the receiving agent.
+    ///
+    /// A single reader handles one listener definition (one protocol, bind address
+    /// and port). Multiple listeners are represented by multiple reader instances.
+    class SyslogReader : public IReader
+    {
+    public:
+        /// @brief Constructor
+        /// @param pushMessageFunc Push message function
+        /// @param waitFunc Wait function
+        /// @param enqueueTaskFunc Enqueue task function (used to spawn TCP client handlers)
+        /// @param protocol Listener transport protocol (UDP or TCP)
+        /// @param bindAddress Address the listener binds to
+        /// @param port Port the listener binds to (1-65535)
+        SyslogReader(
+            std::function<void(const std::string& location, const std::string& log, const std::string& collectorType)>
+                pushMessageFunc,
+            std::function<Awaitable(std::chrono::milliseconds)> waitFunc,
+            std::function<void(boost::asio::awaitable<void>)> enqueueTaskFunc,
+            SyslogProtocol protocol,
+            std::string bindAddress,
+            std::uint16_t port);
+
+        /// @copydoc IReader::Run
+        Awaitable Run() override;
+
+        /// @copydoc IReader::Stop
+        void Stop() override;
+
+        /// @brief Returns a human-readable identifier for this listener
+        /// @return Identifier in the form "<protocol>:<bind_address>:<port>"
+        std::string ListenerId() const;
+
+        /// @brief Converts a protocol enum value to its lowercase string representation
+        /// @param protocol Protocol to convert
+        /// @return "udp" or "tcp"
+        static std::string ProtocolToString(SyslogProtocol protocol);
+
+        /// @brief Maximum size in bytes of a single syslog message accepted by a listener
+        static constexpr std::size_t MAX_MESSAGE_SIZE = 65536;
+
+    private:
+        /// @brief Runs the UDP listener loop
+        Awaitable RunUdp();
+
+        /// @brief Runs the TCP accept loop
+        Awaitable RunTcp();
+
+        /// @brief Handles a single accepted TCP client connection
+        /// @param socket Connected client socket
+        /// @param remote Human-readable remote endpoint description
+        Awaitable HandleTcpClient(std::shared_ptr<boost::asio::ip::tcp::socket> socket, std::string remote);
+
+        /// @brief Normalizes and forwards a received message into the Logcollector path
+        /// @param message Raw message received from the network
+        void ProcessMessage(std::string message) const;
+
+        /// @brief Enqueue task function
+        std::function<void(boost::asio::awaitable<void>)> m_enqueueTask;
+
+        /// @brief Listener transport protocol
+        SyslogProtocol m_protocol;
+
+        /// @brief Bind address
+        std::string m_bindAddress;
+
+        /// @brief Bind port
+        std::uint16_t m_port;
+
+        /// @brief Collector type reported to the Logcollector pipeline
+        const std::string m_collectorType = REMOTE_SYSLOG_READER_TYPE;
+
+        /// @brief Protects the executor and socket handles shared with Stop()
+        std::mutex m_socketMutex;
+
+        /// @brief Executor of the io_context the reader runs on (set when Run starts)
+        std::optional<boost::asio::any_io_executor> m_executor;
+
+        /// @brief UDP socket (when protocol is UDP)
+        std::shared_ptr<boost::asio::ip::udp::socket> m_udpSocket;
+
+        /// @brief TCP acceptor (when protocol is TCP)
+        std::shared_ptr<boost::asio::ip::tcp::acceptor> m_acceptor;
+
+        /// @brief Active TCP client sockets, tracked so they can be closed on shutdown
+        std::list<std::weak_ptr<boost::asio::ip::tcp::socket>> m_clients;
+    };
+
+} // namespace logcollector

--- a/src/modules/logcollector/src/syslog_reader/src/syslog_reader.cpp
+++ b/src/modules/logcollector/src/syslog_reader/src/syslog_reader.cpp
@@ -1,0 +1,340 @@
+#include "syslog_reader.hpp"
+
+#include <logger.hpp>
+
+#include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <istream>
+#include <utility>
+#include <vector>
+
+using namespace logcollector;
+using boost::asio::ip::tcp;
+using boost::asio::ip::udp;
+
+namespace
+{
+    /// @brief Removes a trailing carriage return / line feed sequence from a message
+    void TrimLineEnding(std::string& message)
+    {
+        while (!message.empty() && (message.back() == '\n' || message.back() == '\r'))
+        {
+            message.pop_back();
+        }
+    }
+} // namespace
+
+SyslogReader::SyslogReader(
+    std::function<void(const std::string& location, const std::string& log, const std::string& collectorType)>
+        pushMessageFunc,
+    std::function<Awaitable(std::chrono::milliseconds)> waitFunc,
+    std::function<void(boost::asio::awaitable<void>)> enqueueTaskFunc,
+    SyslogProtocol protocol,
+    std::string bindAddress,
+    std::uint16_t port)
+    : IReader(std::move(pushMessageFunc), std::move(waitFunc))
+    , m_enqueueTask(std::move(enqueueTaskFunc))
+    , m_protocol(protocol)
+    , m_bindAddress(std::move(bindAddress))
+    , m_port(port)
+{
+}
+
+std::string SyslogReader::ProtocolToString(SyslogProtocol protocol)
+{
+    return protocol == SyslogProtocol::Udp ? "udp" : "tcp";
+}
+
+std::string SyslogReader::ListenerId() const
+{
+    return ProtocolToString(m_protocol) + ":" + m_bindAddress + ":" + std::to_string(m_port);
+}
+
+Awaitable SyslogReader::Run()
+{
+    const auto executor = co_await boost::asio::this_coro::executor;
+
+    {
+        const std::lock_guard<std::mutex> lock(m_socketMutex);
+        m_executor = executor;
+    }
+
+    if (!m_keepRunning.load())
+    {
+        co_return;
+    }
+
+    if (m_protocol == SyslogProtocol::Udp)
+    {
+        co_await RunUdp();
+    }
+    else
+    {
+        co_await RunTcp();
+    }
+}
+
+void SyslogReader::Stop()
+{
+    m_keepRunning.store(false);
+
+    const std::lock_guard<std::mutex> lock(m_socketMutex);
+
+    if (!m_executor.has_value())
+    {
+        return;
+    }
+
+    // Sockets are not thread-safe: close them on the io_context thread.
+    boost::asio::post(*m_executor,
+                      [this]()
+                      {
+                          const std::lock_guard<std::mutex> innerLock(m_socketMutex);
+                          boost::system::error_code ec;
+
+                          // NOLINTBEGIN(bugprone-unused-return-value)
+                          if (m_udpSocket)
+                          {
+                              m_udpSocket->close(ec);
+                          }
+
+                          if (m_acceptor)
+                          {
+                              m_acceptor->close(ec);
+                          }
+
+                          for (const auto& client : m_clients)
+                          {
+                              if (auto socket = client.lock())
+                              {
+                                  socket->close(ec);
+                              }
+                          }
+                          // NOLINTEND(bugprone-unused-return-value)
+                      });
+}
+
+Awaitable SyslogReader::RunUdp()
+{
+    const auto executor = co_await boost::asio::this_coro::executor;
+    boost::system::error_code ec;
+
+    const auto address = boost::asio::ip::make_address(m_bindAddress, ec);
+    if (ec)
+    {
+        LogError("Invalid agent-side syslog listener configuration: invalid bind address {}", m_bindAddress);
+        co_return;
+    }
+
+    const auto socket = std::make_shared<udp::socket>(executor);
+    const udp::endpoint endpoint(address, m_port);
+
+    // NOLINTNEXTLINE(bugprone-unused-return-value)
+    socket->open(endpoint.protocol(), ec);
+    if (!ec)
+    {
+        // SO_REUSEADDR is intentionally not set for UDP: on some platforms it allows
+        // a second socket to bind an address:port already in use, which would let the
+        // listener start silently alongside another service (e.g. rsyslog) and split
+        // datagrams unpredictably. Without it, a busy port fails to bind and is reported.
+        // NOLINTNEXTLINE(bugprone-unused-return-value)
+        socket->bind(endpoint, ec);
+    }
+
+    if (ec)
+    {
+        LogError("Failed to start agent-side syslog UDP listener on {}:{}: {}", m_bindAddress, m_port, ec.message());
+        co_return;
+    }
+
+    {
+        const std::lock_guard<std::mutex> lock(m_socketMutex);
+        m_udpSocket = socket;
+    }
+
+    if (!m_keepRunning.load())
+    {
+        // NOLINTNEXTLINE(bugprone-unused-return-value)
+        socket->close(ec);
+        co_return;
+    }
+
+    LogInfo("Started agent-side syslog UDP listener on {}:{}", m_bindAddress, m_port);
+
+    std::vector<char> buffer(MAX_MESSAGE_SIZE);
+    udp::endpoint sender;
+
+    while (m_keepRunning.load())
+    {
+        const std::size_t bytes = co_await socket->async_receive_from(
+            boost::asio::buffer(buffer), sender, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+
+        if (ec)
+        {
+            if (ec == boost::asio::error::operation_aborted)
+            {
+                break;
+            }
+
+            if (ec == boost::asio::error::message_size)
+            {
+                LogDebug("Dropped oversized syslog datagram from {} on {}", sender.address().to_string(), ListenerId());
+                continue;
+            }
+
+            LogDebug("Syslog UDP listener {} receive error: {}", ListenerId(), ec.message());
+            continue;
+        }
+
+        LogTrace("Received syslog UDP datagram from {} on {}", sender.address().to_string(), ListenerId());
+        ProcessMessage(std::string(buffer.data(), bytes));
+    }
+
+    LogInfo("Stopped agent-side syslog UDP listener on {}:{}", m_bindAddress, m_port);
+}
+
+Awaitable SyslogReader::RunTcp()
+{
+    const auto executor = co_await boost::asio::this_coro::executor;
+    boost::system::error_code ec;
+
+    const auto address = boost::asio::ip::make_address(m_bindAddress, ec);
+    if (ec)
+    {
+        LogError("Invalid agent-side syslog listener configuration: invalid bind address {}", m_bindAddress);
+        co_return;
+    }
+
+    const auto acceptor = std::make_shared<tcp::acceptor>(executor);
+    const tcp::endpoint endpoint(address, m_port);
+
+    // NOLINTBEGIN(bugprone-unused-return-value)
+    acceptor->open(endpoint.protocol(), ec);
+    if (!ec)
+    {
+        acceptor->set_option(boost::asio::socket_base::reuse_address(true), ec);
+    }
+    if (!ec)
+    {
+        acceptor->bind(endpoint, ec);
+    }
+    if (!ec)
+    {
+        acceptor->listen(boost::asio::socket_base::max_listen_connections, ec);
+    }
+    // NOLINTEND(bugprone-unused-return-value)
+
+    if (ec)
+    {
+        LogError("Failed to start agent-side syslog TCP listener on {}:{}: {}", m_bindAddress, m_port, ec.message());
+        co_return;
+    }
+
+    {
+        const std::lock_guard<std::mutex> lock(m_socketMutex);
+        m_acceptor = acceptor;
+    }
+
+    if (!m_keepRunning.load())
+    {
+        // NOLINTNEXTLINE(bugprone-unused-return-value)
+        acceptor->close(ec);
+        co_return;
+    }
+
+    LogInfo("Started agent-side syslog TCP listener on {}:{}", m_bindAddress, m_port);
+
+    while (m_keepRunning.load())
+    {
+        const auto socket = std::make_shared<tcp::socket>(executor);
+
+        co_await acceptor->async_accept(*socket, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+
+        if (ec)
+        {
+            if (ec == boost::asio::error::operation_aborted)
+            {
+                break;
+            }
+
+            LogDebug("Syslog TCP listener {} accept error: {}", ListenerId(), ec.message());
+            continue;
+        }
+
+        boost::system::error_code remoteEc;
+        const auto remoteEndpoint = socket->remote_endpoint(remoteEc);
+        const std::string remote =
+            remoteEc ? std::string("unknown")
+                     : remoteEndpoint.address().to_string() + ":" + std::to_string(remoteEndpoint.port());
+
+        {
+            const std::lock_guard<std::mutex> lock(m_socketMutex);
+            m_clients.remove_if([](const std::weak_ptr<tcp::socket>& client) { return client.expired(); });
+            m_clients.push_back(socket);
+        }
+
+        LogDebug("Accepted syslog TCP client {} on {}", remote, ListenerId());
+        m_enqueueTask(HandleTcpClient(socket, remote));
+    }
+
+    LogInfo("Stopped agent-side syslog TCP listener on {}:{}", m_bindAddress, m_port);
+}
+
+// Parameters are passed by value on purpose: a coroutine must own them so they
+// remain valid across suspension points.
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+Awaitable SyslogReader::HandleTcpClient(std::shared_ptr<tcp::socket> socket, std::string remote)
+{
+    boost::asio::streambuf buffer(MAX_MESSAGE_SIZE);
+    boost::system::error_code ec;
+
+    while (m_keepRunning.load())
+    {
+        co_await boost::asio::async_read_until(
+            *socket, buffer, '\n', boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+
+        if (ec)
+        {
+            if (ec == boost::asio::error::not_found)
+            {
+                // Buffer filled without a line delimiter: the message is too large.
+                LogDebug("Dropped oversized syslog message from {} on {}", remote, ListenerId());
+            }
+            else if (ec != boost::asio::error::eof && ec != boost::asio::error::operation_aborted)
+            {
+                LogDebug("Syslog TCP client {} read error on {}: {}", remote, ListenerId(), ec.message());
+            }
+            break;
+        }
+
+        std::istream stream(&buffer);
+        std::string line;
+        std::getline(stream, line);
+        ProcessMessage(std::move(line));
+    }
+
+    boost::system::error_code closeEc;
+    // NOLINTNEXTLINE(bugprone-unused-return-value)
+    socket->close(closeEc);
+
+    LogDebug("Closed syslog TCP client {} on {}", remote, ListenerId());
+}
+
+void SyslogReader::ProcessMessage(std::string message) const
+{
+    TrimLineEnding(message);
+
+    if (message.empty())
+    {
+        return;
+    }
+
+    if (message.size() > MAX_MESSAGE_SIZE)
+    {
+        LogDebug("Dropped oversized syslog message on {}", ListenerId());
+        return;
+    }
+
+    m_pushMessage(ListenerId(), message, m_collectorType);
+}

--- a/src/modules/logcollector/tests/unit/CMakeLists.txt
+++ b/src/modules/logcollector/tests/unit/CMakeLists.txt
@@ -4,13 +4,14 @@ if(UNIX AND NOT APPLE)
 endif()
 
 file(GLOB LOGCOLLECTOR_TEST_SOURCES *_test.cpp)
+file(GLOB SYSLOG_TEST_SOURCES syslog_reader/*_test.cpp)
 file(GLOB UNIX_TEST_SOURCES journald_reader/*.cpp file_reader/*_unix_test.cpp)
 file(GLOB MACOS_TEST_SOURCES macos_reader/*.cpp file_reader/*_unix_test.cpp)
 file(GLOB WIN_TEST_SOURCES file_reader/*_win_test.cpp)
 
 add_executable(
     logcollector_unit_tests
-    ${LOGCOLLECTOR_TEST_SOURCES} $<$<PLATFORM_ID:Linux>:${UNIX_TEST_SOURCES}>
+    ${LOGCOLLECTOR_TEST_SOURCES} ${SYSLOG_TEST_SOURCES} $<$<PLATFORM_ID:Linux>:${UNIX_TEST_SOURCES}>
     $<$<PLATFORM_ID:Darwin>:${MACOS_TEST_SOURCES}> $<$<PLATFORM_ID:Windows>:${WIN_TEST_SOURCES}>)
 configure_target(logcollector_unit_tests)
 
@@ -19,6 +20,7 @@ target_include_directories(
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
             ${CMAKE_CURRENT_SOURCE_DIR}/../../src
             ${CMAKE_CURRENT_SOURCE_DIR}/../../src/file_reader/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../src/syslog_reader/include
             $<$<PLATFORM_ID:Linux>:${CMAKE_CURRENT_SOURCE_DIR}/../../src/journald_reader/include>
             $<$<PLATFORM_ID:Linux>:${SYSTEMD_INCLUDE_DIRS}>
             $<$<PLATFORM_ID:Windows>:${CMAKE_CURRENT_SOURCE_DIR}/../../src/winevt_reader/include>

--- a/src/modules/logcollector/tests/unit/logcollector_mock.hpp
+++ b/src/modules/logcollector/tests/unit/logcollector_mock.hpp
@@ -29,6 +29,11 @@ namespace logcollector
             Logcollector::SetupFileReader(configurationParser);
         }
 
+        void SetupSyslogReaders(std::shared_ptr<const configuration::ConfigurationParser> configurationParser)
+        {
+            Logcollector::SetupSyslogReaders(configurationParser);
+        }
+
         MOCK_METHOD(void, AddReader, (std::shared_ptr<IReader> reader), (override));
         MOCK_METHOD(void, EnqueueTask, (Awaitable task), (override));
         MOCK_METHOD(boost::asio::awaitable<void>, Wait, (std::chrono::milliseconds ms), (override));

--- a/src/modules/logcollector/tests/unit/syslog_reader/syslog_config_test.cpp
+++ b/src/modules/logcollector/tests/unit/syslog_reader/syslog_config_test.cpp
@@ -1,0 +1,235 @@
+#include "logcollector_mock.hpp"
+
+#include <configuration_parser.hpp>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+using namespace configuration;
+using namespace logcollector;
+
+namespace
+{
+    /// @brief Runs SetupSyslogReaders against the given YAML and returns how many readers were created
+    int CountSyslogReaders(const std::string& yaml)
+    {
+        auto logcollector = LogcollectorMock();
+        auto config = std::make_shared<ConfigurationParser>(yaml);
+
+        int readerCount = 0;
+        EXPECT_CALL(logcollector, AddReader(::testing::_))
+            .WillRepeatedly(::testing::Invoke([&readerCount](std::shared_ptr<IReader>) { ++readerCount; }));
+
+        logcollector.SetupSyslogReaders(config);
+        return readerCount;
+    }
+} // namespace
+
+TEST(SyslogConfig, NoSyslogSectionCreatesNoListeners)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      localfiles:
+        - /var/log/auth.log
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 0);
+}
+
+TEST(SyslogConfig, UdpListenerParses)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: udp
+          bind_address: 127.0.0.1
+          port: 5514
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 1);
+}
+
+TEST(SyslogConfig, TcpListenerParses)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: tcp
+          bind_address: 127.0.0.1
+          port: 1514
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 1);
+}
+
+TEST(SyslogConfig, BindAddressIsOptional)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: udp
+          port: 5514
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 1);
+}
+
+TEST(SyslogConfig, MultipleListenersParse)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: udp
+          bind_address: 127.0.0.1
+          port: 5514
+        - protocol: tcp
+          bind_address: 127.0.0.1
+          port: 1514
+        - protocol: udp
+          bind_address: 127.0.0.1
+          port: 5515
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 3);
+}
+
+TEST(SyslogConfig, UnsupportedProtocolIsRejected)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: http
+          bind_address: 127.0.0.1
+          port: 5514
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 0);
+}
+
+TEST(SyslogConfig, MissingProtocolIsRejected)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - bind_address: 127.0.0.1
+          port: 5514
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 0);
+}
+
+TEST(SyslogConfig, OutOfRangePortIsRejected)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: udp
+          bind_address: 127.0.0.1
+          port: 99999
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 0);
+}
+
+TEST(SyslogConfig, ZeroPortIsRejected)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: udp
+          bind_address: 127.0.0.1
+          port: 0
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 0);
+}
+
+TEST(SyslogConfig, NonNumericPortIsRejected)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: tcp
+          bind_address: 127.0.0.1
+          port: abc
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 0);
+}
+
+TEST(SyslogConfig, MissingPortIsRejected)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: udp
+          bind_address: 127.0.0.1
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 0);
+}
+
+TEST(SyslogConfig, InvalidBindAddressIsRejected)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: udp
+          bind_address: 999.999.999.999
+          port: 5514
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 0);
+}
+
+TEST(SyslogConfig, DuplicateListenerIsRejected)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: udp
+          bind_address: 127.0.0.1
+          port: 5514
+        - protocol: udp
+          bind_address: 127.0.0.1
+          port: 5514
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 1);
+}
+
+TEST(SyslogConfig, SamePortDifferentProtocolIsAllowed)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: udp
+          bind_address: 127.0.0.1
+          port: 1514
+        - protocol: tcp
+          bind_address: 127.0.0.1
+          port: 1514
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 2);
+}
+
+TEST(SyslogConfig, ValidAndInvalidListenersAreHandledIndependently)
+{
+    auto constexpr CONFIG_RAW = R"(
+    logcollector:
+      syslog:
+        - protocol: udp
+          bind_address: 127.0.0.1
+          port: 5514
+        - protocol: sctp
+          bind_address: 127.0.0.1
+          port: 5515
+        - protocol: tcp
+          bind_address: 127.0.0.1
+          port: 1514
+    )";
+
+    EXPECT_EQ(CountSyslogReaders(CONFIG_RAW), 2);
+}

--- a/src/modules/logcollector/tests/unit/syslog_reader/syslog_reader_test.cpp
+++ b/src/modules/logcollector/tests/unit/syslog_reader/syslog_reader_test.cpp
@@ -1,0 +1,325 @@
+#include <syslog_reader.hpp>
+
+#include <boost/asio.hpp>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace logcollector;
+using boost::asio::ip::tcp;
+using boost::asio::ip::udp;
+
+namespace
+{
+    constexpr auto LOOPBACK = "127.0.0.1";
+    constexpr auto POLL_INTERVAL = std::chrono::milliseconds(20);
+    constexpr int MAX_ATTEMPTS = 100;
+    constexpr int EMPTY_DATAGRAM_ATTEMPTS = 10;
+    constexpr unsigned short SAMPLE_PORT = 5514;
+    constexpr auto BIND_ATTEMPT_WAIT = std::chrono::milliseconds(150);
+
+    /// @brief Thread-safe sink that records messages pushed by a reader
+    class MessageSink
+    {
+    public:
+        void Push(const std::string& location, const std::string& log, const std::string& collectorType)
+        {
+            const std::lock_guard<std::mutex> lock(m_mutex);
+            m_messages.emplace_back(location, log, collectorType);
+        }
+
+        std::size_t Count() const
+        {
+            const std::lock_guard<std::mutex> lock(m_mutex);
+            return m_messages.size();
+        }
+
+        std::vector<std::tuple<std::string, std::string, std::string>> Messages() const
+        {
+            const std::lock_guard<std::mutex> lock(m_mutex);
+            return m_messages;
+        }
+
+    private:
+        mutable std::mutex m_mutex;
+        std::vector<std::tuple<std::string, std::string, std::string>> m_messages;
+    };
+
+    unsigned short GetFreeUdpPort()
+    {
+        boost::asio::io_context io;
+        udp::socket socket(io);
+        socket.open(udp::v4());
+        socket.bind(udp::endpoint(boost::asio::ip::make_address(LOOPBACK), 0));
+        const auto port = socket.local_endpoint().port();
+        socket.close();
+        return port;
+    }
+
+    unsigned short GetFreeTcpPort()
+    {
+        boost::asio::io_context io;
+        tcp::acceptor acceptor(io);
+        acceptor.open(tcp::v4());
+        acceptor.bind(tcp::endpoint(boost::asio::ip::make_address(LOOPBACK), 0));
+        const auto port = acceptor.local_endpoint().port();
+        acceptor.close();
+        return port;
+    }
+
+    std::shared_ptr<SyslogReader> MakeReader(boost::asio::io_context& io,
+                                             MessageSink& sink,
+                                             SyslogProtocol protocol,
+                                             unsigned short port)
+    {
+        auto push = [&sink](const std::string& location, const std::string& log, const std::string& collectorType)
+        { sink.Push(location, log, collectorType); };
+
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+        auto wait = [](std::chrono::milliseconds) -> Awaitable { co_return; };
+
+        auto enqueue = [&io](boost::asio::awaitable<void> task)
+        { boost::asio::co_spawn(io, std::move(task), boost::asio::detached); };
+
+        return std::make_shared<SyslogReader>(
+            push, wait, enqueue, protocol, std::string(LOOPBACK), static_cast<std::uint16_t>(port));
+    }
+
+    void WaitForCount(const MessageSink& sink, std::size_t expected)
+    {
+        for (int attempt = 0; attempt < MAX_ATTEMPTS && sink.Count() < expected; ++attempt)
+        {
+            std::this_thread::sleep_for(POLL_INTERVAL);
+        }
+    }
+
+    void SendUdp(unsigned short port, const std::string& message)
+    {
+        boost::asio::io_context io;
+        udp::socket socket(io);
+        socket.open(udp::v4());
+        socket.send_to(boost::asio::buffer(message), udp::endpoint(boost::asio::ip::make_address(LOOPBACK), port));
+        socket.close();
+    }
+
+    bool SendTcp(unsigned short port, const std::string& message)
+    {
+        boost::asio::io_context io;
+        tcp::socket socket(io);
+        const tcp::endpoint endpoint(boost::asio::ip::make_address(LOOPBACK), port);
+
+        for (int attempt = 0; attempt < MAX_ATTEMPTS; ++attempt)
+        {
+            boost::system::error_code ec;
+            // NOLINTNEXTLINE(bugprone-unused-return-value)
+            socket.connect(endpoint, ec);
+            if (!ec)
+            {
+                boost::asio::write(socket, boost::asio::buffer(message), ec);
+                socket.close();
+                return !ec;
+            }
+            std::this_thread::sleep_for(POLL_INTERVAL);
+        }
+        return false;
+    }
+} // namespace
+
+TEST(SyslogReader, ProtocolToString)
+{
+    EXPECT_EQ(SyslogReader::ProtocolToString(SyslogProtocol::Udp), "udp");
+    EXPECT_EQ(SyslogReader::ProtocolToString(SyslogProtocol::Tcp), "tcp");
+}
+
+TEST(SyslogReader, ListenerIdFormat)
+{
+    auto sink = MessageSink();
+    boost::asio::io_context io;
+    auto reader = MakeReader(io, sink, SyslogProtocol::Udp, SAMPLE_PORT);
+    EXPECT_EQ(reader->ListenerId(), "udp:127.0.0.1:5514");
+}
+
+TEST(SyslogReader, UdpReceivesMessage)
+{
+    const auto port = GetFreeUdpPort();
+    MessageSink sink;
+    boost::asio::io_context io;
+    auto reader = MakeReader(io, sink, SyslogProtocol::Udp, port);
+
+    boost::asio::co_spawn(io, reader->Run(), boost::asio::detached);
+    std::thread ioThread([&io]() { io.run(); });
+
+    // Resend until the listener is bound and the datagram is delivered.
+    for (int attempt = 0; attempt < MAX_ATTEMPTS && sink.Count() == 0; ++attempt)
+    {
+        SendUdp(port, "<13>Jun 25 10:00:00 testhost testapp: UDP listener test\n");
+        std::this_thread::sleep_for(POLL_INTERVAL);
+    }
+
+    reader->Stop();
+    ioThread.join();
+
+    ASSERT_GE(sink.Count(), 1u);
+    const auto messages = sink.Messages();
+    EXPECT_EQ(std::get<1>(messages[0]), "<13>Jun 25 10:00:00 testhost testapp: UDP listener test");
+    EXPECT_EQ(std::get<2>(messages[0]), REMOTE_SYSLOG_READER_TYPE);
+    EXPECT_EQ(std::get<0>(messages[0]), reader->ListenerId());
+}
+
+TEST(SyslogReader, UdpEmptyDatagramIsIgnored)
+{
+    const auto port = GetFreeUdpPort();
+    MessageSink sink;
+    boost::asio::io_context io;
+    auto reader = MakeReader(io, sink, SyslogProtocol::Udp, port);
+
+    boost::asio::co_spawn(io, reader->Run(), boost::asio::detached);
+    std::thread ioThread([&io]() { io.run(); });
+
+    for (int attempt = 0; attempt < EMPTY_DATAGRAM_ATTEMPTS; ++attempt)
+    {
+        SendUdp(port, "\n");
+        std::this_thread::sleep_for(POLL_INTERVAL);
+    }
+
+    reader->Stop();
+    ioThread.join();
+
+    EXPECT_EQ(sink.Count(), 0u);
+}
+
+TEST(SyslogReader, TcpReceivesMessage)
+{
+    const auto port = GetFreeTcpPort();
+    MessageSink sink;
+    boost::asio::io_context io;
+    auto reader = MakeReader(io, sink, SyslogProtocol::Tcp, port);
+
+    boost::asio::co_spawn(io, reader->Run(), boost::asio::detached);
+    std::thread ioThread([&io]() { io.run(); });
+
+    const bool sent = SendTcp(port, "<13>Jun 25 10:00:00 testhost testapp: TCP listener test\n");
+    WaitForCount(sink, 1);
+
+    reader->Stop();
+    ioThread.join();
+
+    ASSERT_TRUE(sent);
+    ASSERT_GE(sink.Count(), 1u);
+    const auto messages = sink.Messages();
+    EXPECT_EQ(std::get<1>(messages[0]), "<13>Jun 25 10:00:00 testhost testapp: TCP listener test");
+    EXPECT_EQ(std::get<2>(messages[0]), REMOTE_SYSLOG_READER_TYPE);
+}
+
+TEST(SyslogReader, TcpHandlesMultipleLines)
+{
+    const auto port = GetFreeTcpPort();
+    MessageSink sink;
+    boost::asio::io_context io;
+    auto reader = MakeReader(io, sink, SyslogProtocol::Tcp, port);
+
+    boost::asio::co_spawn(io, reader->Run(), boost::asio::detached);
+    std::thread ioThread([&io]() { io.run(); });
+
+    const bool sent = SendTcp(port, "first message\nsecond message\nthird message\n");
+    WaitForCount(sink, 3);
+
+    reader->Stop();
+    ioThread.join();
+
+    ASSERT_TRUE(sent);
+    EXPECT_GE(sink.Count(), 3u);
+}
+
+TEST(SyslogReader, MultipleListenersReceive)
+{
+    const auto udpPort = GetFreeUdpPort();
+    const auto tcpPort = GetFreeTcpPort();
+    MessageSink sink;
+    boost::asio::io_context io;
+
+    auto udpReader = MakeReader(io, sink, SyslogProtocol::Udp, udpPort);
+    auto tcpReader = MakeReader(io, sink, SyslogProtocol::Tcp, tcpPort);
+
+    boost::asio::co_spawn(io, udpReader->Run(), boost::asio::detached);
+    boost::asio::co_spawn(io, tcpReader->Run(), boost::asio::detached);
+    std::thread ioThread([&io]() { io.run(); });
+
+    const bool tcpSent = SendTcp(tcpPort, "tcp listener message\n");
+    for (int attempt = 0; attempt < MAX_ATTEMPTS && sink.Count() < 2; ++attempt)
+    {
+        SendUdp(udpPort, "udp listener message\n");
+        std::this_thread::sleep_for(POLL_INTERVAL);
+    }
+
+    udpReader->Stop();
+    tcpReader->Stop();
+    ioThread.join();
+
+    ASSERT_TRUE(tcpSent);
+    EXPECT_GE(sink.Count(), 2u);
+}
+
+// Simulates a port already taken by another service (e.g. rsyslog): the listener
+// must fail to bind, log the error, not start, and must not crash or hang the agent.
+TEST(SyslogReader, TcpBindFailsWhenPortInUse)
+{
+    const auto port = GetFreeTcpPort();
+
+    // Occupy the port first, as another process (rsyslog/syslog-ng) would.
+    boost::asio::io_context occupierIo;
+    tcp::acceptor occupier(occupierIo);
+    occupier.open(tcp::v4());
+    occupier.set_option(boost::asio::socket_base::reuse_address(true));
+    boost::system::error_code bindEc;
+    // NOLINTNEXTLINE(bugprone-unused-return-value)
+    occupier.bind(tcp::endpoint(boost::asio::ip::make_address(LOOPBACK), port), bindEc);
+    ASSERT_FALSE(bindEc) << "precondition: occupier must bind the port";
+    occupier.listen();
+
+    MessageSink sink;
+    boost::asio::io_context io;
+    auto reader = MakeReader(io, sink, SyslogProtocol::Tcp, port);
+
+    boost::asio::co_spawn(io, reader->Run(), boost::asio::detached);
+    std::thread ioThread([&io]() { io.run(); });
+
+    std::this_thread::sleep_for(BIND_ATTEMPT_WAIT); // let the reader attempt (and fail) the bind
+    reader->Stop();
+    ioThread.join(); // must not hang: the reader fails to bind and returns
+    occupier.close();
+
+    EXPECT_EQ(sink.Count(), 0u); // listener never came up, so nothing was ingested
+}
+
+TEST(SyslogReader, UdpBindFailsWhenPortInUse)
+{
+    const auto port = GetFreeUdpPort();
+
+    boost::asio::io_context occupierIo;
+    udp::socket occupier(occupierIo);
+    occupier.open(udp::v4());
+    occupier.set_option(boost::asio::socket_base::reuse_address(true));
+    boost::system::error_code bindEc;
+    // NOLINTNEXTLINE(bugprone-unused-return-value)
+    occupier.bind(udp::endpoint(boost::asio::ip::make_address(LOOPBACK), port), bindEc);
+    ASSERT_FALSE(bindEc) << "precondition: occupier must bind the port";
+
+    MessageSink sink;
+    boost::asio::io_context io;
+    auto reader = MakeReader(io, sink, SyslogProtocol::Udp, port);
+
+    boost::asio::co_spawn(io, reader->Run(), boost::asio::detached);
+    std::thread ioThread([&io]() { io.run(); });
+
+    std::this_thread::sleep_for(BIND_ATTEMPT_WAIT); // let the reader attempt (and fail) the bind
+    reader->Stop();
+    ioThread.join();
+    occupier.close();
+
+    EXPECT_EQ(sink.Count(), 0u);
+}


### PR DESCRIPTION
## Summary

Adds native **agent-side UDP/TCP Syslog listener** support to the Wazuh Agent Logcollector.

This lets lightweight remote-site deployments forward basic Syslog directly to a local Wazuh agent over UDP or TCP, while preserving the normal agent-to-manager collection model. Received messages enter the existing Logcollector processing path, are sent through the standard encrypted/authenticated agent connection, and **remain associated with the receiving agent** (no manager-local `000` ingestion).

Related to wazuh/wazuh#15178.

## What changed

- New `SyslogReader` (implements the existing `IReader` interface) providing UDP and TCP listeners using the project's Boost.Asio coroutine model.
- `Logcollector::SetupSyslogReaders()` parses a new `logcollector.syslog` configuration section and creates one listener per definition.
- Configuration validation before any listener starts: protocol (`udp`/`tcp`), port range (1–65535), bind address (`make_address`), and duplicate `protocol+address+port` detection. Invalid/duplicate entries are logged and skipped — no listener is ever silently enabled.
- Support for multiple independent listeners on the same agent, each with its own lifecycle, startup/shutdown and error logging.
- Clean startup/shutdown: sockets are closed on the io_context thread, TCP client sockets are tracked and closed on stop (no fd/thread leaks).
- Backward compatibility preserved for existing file/journald/windows/macOS collectors; manager-side remote Syslog is untouched.
- Unit tests and documentation added.

### Configuration

The new Wazuh 6.x agent uses YAML configuration (not the legacy XML `<localfile>`), so the issue's proposed `<location type="udp">` is expressed in the existing YAML style, mirroring the `journald` collector:

```yaml
logcollector:
  enabled: true
  syslog:
    - protocol: udp
      bind_address: 127.0.0.1   # optional, defaults to 127.0.0.1
      port: 5514
    - protocol: tcp
      bind_address: 127.0.0.1
      port: 1514
    - protocol: udp
      bind_address: 192.168.10.20
      port: 5515
```

Messages are pushed with the `remote-syslog` collector type and the listener identity (`<protocol>:<address>:<port>`) as the event provider.

## Validation

Built and tested on Linux (RHEL 9, GCC 11.5):

- **Compiles clean** under the project's strict flags (`-Werror -Wconversion -Wsign-conversion -Wold-style-cast -Wshadow -Wpedantic …`) — 0 warnings.
- **Syslog unit tests: 22/22 pass** — 15 config-parsing/validation cases (valid UDP/TCP/multiple/optional-bind; rejects unsupported protocol, missing/zero/out-of-range/non-numeric port, malformed bind address, duplicate listener; same port + different protocol allowed) and 7 runtime cases (UDP receive, TCP receive, multi-line TCP framing, multiple concurrent listeners, empty-datagram drop, clean shutdown — exercising real loopback sockets).
- **Full Logcollector suite: 41/41 pass** (no regressions).
- Note: clang-tidy was not run locally (not installed in the build environment); the project's CI clang-tidy gate will exercise it. The code was written to satisfy those checks (const-correctness, magic-number constants, coroutine value-param suppressions, etc.).

## Scope and future work

Issue #15178 proposes three ingress types for `localfile`: UDP/TCP syslog, UNIX sockets, and pipes. **This PR implements the UDP/TCP IP-socket listeners only** (the part highlighted in the recent discussion). The remaining items are intentionally deferred and tracked as future work (documented in the module README and in a reference comment in `syslog_reader.hpp`):

- **UNIX domain sockets** (`unix_stream` / `unix_dgram` / `unix_seq`) — not included.
- **Named pipe / FIFO** ingress (and Windows named pipes) — not included.
- **TLS Syslog** for the TCP listener — not included; the TCP listener is plaintext.
- **TCP octet-counting framing (RFC 6587)** — only newline-delimited ("non-transparent") framing is parsed; octet-counted messages (`<len> <msg>`) are not auto-detected.
- **Hostname `bind_address`** — only numeric IPv4/IPv6 literals are accepted; DNS names are rejected by design.
- **`allowed-ips` source filtering** — use host firewall rules until implemented.

For high-volume ingestion, TLS Syslog, disk-assisted queues, advanced filtering, transformations, routing, or complex parsing pipelines, rsyslog, syslog-ng, Logstash, or the Wazuh manager remote Syslog input remain the recommended options. This change does not modify or replace any of them.
